### PR TITLE
Ensure all resources are closed during loading

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./load:/app/load
     environment:
       - ENDPOINT_TYPE=rdf4j
-      - ENDPOINT_BASE=http://rdf4j:8080/rdf4j-server/repositories/
+      - ENDPOINT_BASE=http://rdf4j:8080/rdf4j-server/
       - REGISTRY_FIXED_URL=https://registry.knowledgepixels.com/
 #     - INIT_WAIT_SECONDS=120   # Only used by the local nanopub loader
 #     - NANOPUB_QUERY_URL=https://query.knowledgepixels.com/

--- a/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
@@ -9,7 +9,6 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.eclipse.rdf4j.query.algebra.Str;
 import org.nanopub.NanopubUtils;
 import org.nanopub.jelly.NanopubStream;
 
@@ -136,6 +135,12 @@ public class JellyNanopubLoader {
             });
         } catch (IOException e) {
             throw new RuntimeException("I/O error while reading the response Jelly stream.", e);
+        } finally {
+            try {
+                response.close();
+            } catch (IOException e) {
+                System.err.println("Failed to close the Jelly stream response.");
+            }
         }
         System.err.println("Initial load: loaded batch up to counter " + lastCommittedCounter);
     }
@@ -179,8 +184,8 @@ public class JellyNanopubLoader {
         var request = new HttpHead(registryUrl);
         var response = metadataClient.execute(request);
         int status = response.getStatusLine().getStatusCode();
+        EntityUtils.consumeQuietly(response.getEntity());
         if (status < 200 || status >= 300) {
-            EntityUtils.consumeQuietly(response.getEntity());
             throw new RuntimeException("Registry load counter HTTP status is not 2xx: " +
                     status + ".");
         }

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -74,13 +74,13 @@ public class TripleStore {
 		getRepository("empty");  // Make sure empty repo exists
 	}
 
-	private CloseableHttpClient httpclient = HttpClients.createDefault();
+	private final CloseableHttpClient httpclient = HttpClients.createDefault();
 
 	private Repository getRepository(String name) {
 		if (!repositories.containsKey(name)) {
 			Repository repository = null;
 			if (endpointType == null || endpointType.equals("rdf4j")) {
-				HTTPRepository hr = new HTTPRepository(endpointBase + name);
+				HTTPRepository hr = new HTTPRepository(endpointBase + "repositories/" + name);
 				hr.setHttpClient(httpclient);
 				repository = hr;
 //			} else if (endpointType.equals("virtuoso")) {
@@ -204,7 +204,7 @@ public class TripleStore {
 			}
 
 			HttpUriRequest createRepoRequest = RequestBuilder.put()
-					.setUri("http://rdf4j:8080/rdf4j-server/repositories/" + repoName)
+					.setUri(endpointBase + "repositories/" + repoName)
 					.addHeader("Content-Type", "text/turtle")
 					.setEntity(new StringEntity(createRepoQueryString))
 					.build();
@@ -243,7 +243,7 @@ public class TripleStore {
 		Map<String,Boolean> repositoryNames = null;
 		try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
 			HttpResponse resp = httpclient.execute(RequestBuilder.get()
-					.setUri("http://rdf4j:8080/rdf4j-server/repositories")
+					.setUri(endpointBase + "/repositories")
 					.addHeader("Content-Type", "text/csv")
 					.build());
 			BufferedReader reader = new BufferedReader(new InputStreamReader(resp.getEntity().getContent()));


### PR DESCRIPTION
Follow-up from the issue reported here: https://github.com/knowledgepixels/nanopub-query/pull/15#issuecomment-2743416727

I checked the code, and we weren't closing `TupleQueryResult` instances, which we should. There were also a few other small cases where things weren't closed, so I fixed them as well.

I did some profiling, and the system first allocates a bunch of threads over a minute or so (up to ~1500 threads). Heap usage reaches up to ~300MB here. I'm pretty sure that's because at this initial stage we are skipping most nanopubs (just parsing and discarding), which does result in a higher heap pressure.

![image](https://github.com/user-attachments/assets/0195dd5c-ecb3-47b7-82d9-70f91c53f2fe)

When we get to the actual loading, the thread count stabilizes and heap usage oscillates between 30 and 60 MB, which is due to the lower pressure.

While profiling I found that the biggest performance hogs are dealing with network sockets (opening/closing, write/read), and thread management. Unfortunately, every instance of `RepositoryConnection` creates a new `HttpClient`, takes a thread from an RDF4J thread pool, and also creates an additional auxiliary thread. That's a lot of overhead, and we do it a few times per loaded nanopub. I'm not sure if it's worth reworking the `TripleStore` for this, or we should just internalize the store like I suggested in the previous PR, which would allow us to streamline this even more.

I've also fixed how Query uses the `ENDPOINT_BASE` env var, which did require a small change in `docker-compose.yml`. Without this, I wasn't able to point Query to a different endpoint, which was needed for a profiling deployment.