### PR TITLE
Use LMDB as the SAIL implementation

### DIFF
--- a/scripts/autofetch.sh
+++ b/scripts/autofetch.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cd /app/load
+cd ../load
 
 echo "Autofetch init"
 

--- a/src/main/java/com/knowledgepixels/query/LocalNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/LocalNanopubLoader.java
@@ -53,11 +53,16 @@ public class LocalNanopubLoader {
         if (!autofetchNanopubsFile.exists()) {
             System.err.println("No local autofetch nanopub URI file found.");
         } else {
+            long loaded = 0L;
             try (BufferedReader reader = new BufferedReader(new FileReader(autofetchNanopubsFile))) {
                 String line = reader.readLine();
                 while (line != null) {
                     NanopubLoader.load(line);
                     line = reader.readLine();
+                    loaded++;
+                    if (loaded % 50 == 0) {
+                        System.err.println("Loaded " + loaded + " nanopubs...");
+                    }
                 }
             } catch (IOException ex) {
                 ex.printStackTrace();

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -146,7 +146,9 @@ public class TripleStore {
 //					+ "        ]\n"
 //					+ "    ].";
 
-			String indexTypes = "spoc,posc,ospc,cspo,cpos,cosp";
+			// We can use at most 5 indexes in LMDB without hacks.
+			// We use one index for graphs, which should be more than enough (graphs are small).
+			String indexTypes = "spoc,posc,ospc,cspo";
 			if (repoName.startsWith("meta") || repoName.startsWith("text")) {
 				indexTypes = "spoc,posc,ospc";
 			}
@@ -156,18 +158,18 @@ public class TripleStore {
 					+ "@prefix sr: <http://www.openrdf.org/config/repository/sail#>.\n"
 					+ "@prefix sail: <http://www.openrdf.org/config/sail#>.\n"
 					+ "@prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.\n"
-					+ "@prefix ns: <http://www.openrdf.org/config/sail/native#>.\n"
+					+ "@prefix lmdb: <http://rdf4j.org/config/sail/lmdb#>.\n"
 					+ "@prefix sb: <http://www.openrdf.org/config/sail/base#>.\n"
 					+ "\n"
 					+ "[] a rep:Repository ;\n"
 					+ "    rep:repositoryID \"" + repoName + "\" ;\n"
-					+ "    rdfs:label \"" + repoName + " native store\" ;\n"
+					+ "    rdfs:label \"" + repoName + " LMDB store\" ;\n"
 					+ "    rep:repositoryImpl [\n"
 					+ "        rep:repositoryType \"openrdf:SailRepository\" ;\n"
 					+ "        sr:sailImpl [\n"
-					+ "            sail:sailType \"openrdf:NativeStore\" ;\n"
+					+ "            sail:sailType \"rdf4j:LmdbStore\" ;\n"
 					+ "            sail:iterationCacheSyncThreshold \"10000\";\n"
-					+ "            ns:tripleIndexes \"" + indexTypes + "\" ;\n"
+					+ "            lmdb:tripleIndexes \"" + indexTypes + "\" ;\n"
 					+ "            sb:defaultQueryEvaluationMode \"STANDARD\"\n"
 					+ "        ]\n"
 					+ "    ].\n";
@@ -178,7 +180,7 @@ public class TripleStore {
 					+ "@prefix sr: <http://www.openrdf.org/config/repository/sail#>.\n"
 					+ "@prefix sail: <http://www.openrdf.org/config/sail#>.\n"
 					+ "@prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.\n"
-					+ "@prefix ns: <http://www.openrdf.org/config/sail/native#>.\n"
+					+ "@prefix lmdb: <http://rdf4j.org/config/sail/lmdb#>.\n"
 					+ "@prefix sb: <http://www.openrdf.org/config/sail/base#>.\n"
 					+ "\n"
 					+ "[] a rep:Repository ;\n"
@@ -190,9 +192,9 @@ public class TripleStore {
 					+ "            sail:sailType \"openrdf:LuceneSail\" ;\n"
 					+ "            sail-luc:indexDir \"index/\" ;\n"
 					+ "            sail:delegate ["
-					+ "              sail:sailType \"openrdf:NativeStore\" ;\n"
+					+ "              sail:sailType \"rdf4j:LmdbStore\" ;\n"
 					+ "              sail:iterationCacheSyncThreshold \"10000\";\n"
-					+ "              ns:tripleIndexes \"" + indexTypes + "\" ;\n"
+					+ "              lmdb:tripleIndexes \"" + indexTypes + "\" ;\n"
 					+ "              sb:defaultQueryEvaluationMode \"STANDARD\"\n"
 					+ "            ]\n"
 					+ "        ]\n"


### PR DESCRIPTION
Issue: #17 

This changes the SAIL repository implementation from NativeStore to LmdbStore, which has a much smaller memory overhead.


I managed to load the entire Registry with LmdbStore and Jelly, with no restarts:

```
Initial load: loaded batch up to counter 60466
Initial load complete.
```

The loading speed was around 9–10 nanopubs per second.

Heap size is 487 MB. SailRepository instances take up 463 MB of that. With 1567 repos, this works out to ~302 kB of heap overhead per repo instance. Most of this is this cache I mentioned previously. I could probably go in and do some optimizations to reduce this overhead by a sizeable degree, but even without it, we are well within acceptable values.

I had to reduce the number of used indexes. From what I understand, LmdbStore by default only allows 5 indexes to be used per store. I could modify this limit if needed, but honestly, I'm not sure if it's really needed. I've added one index starting with the graph name, which should be enough, because each graph is very small. We can also later profile this and see if any changes are needed.

I've also made 2 small changes to local nanopub loading. Autofetch script now assumes it's running locally, not in Docker, because we've removed it from the Compose stack. Local loader will now report on loading progress (loaded nanopub count).