### PR TITLE
Use 6 indexes for nanopub repos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,8 @@ services:
         max-file: "3"
 
   rdf4j:
-    image: eclipse/rdf4j-workbench:5.0.3
-#   image: eclipse/rdf4j-workbench:5.0.2
-#   image: nanopub/rdf4j-workbench:5.0.3-SNAPSHOT
+    image: ostrzyciel/rdf4j-workbench-tomcat:5.1.3-SNAPSHOT
+#   image: eclipse/rdf4j-workbench:5.0.3
     restart: unless-stopped
     environment:
       - JAVA_OPTS=-Dorg.eclipse.rdf4j.client.http.connectionTimeout=10000 -Dorg.eclipse.rdf4j.client.http.connectionRequestTimeout=10000 -Dorg.eclipse.rdf4j.client.http.socketTimeout=10000

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -358,7 +358,7 @@ public class NanopubLoader {
 				success = true;
 			} catch (Exception ex) {
 				ex.printStackTrace();
-				conn.rollback();
+				if (conn.isActive()) conn.rollback();
 			}
 			if (!success) {
 				System.err.println("Retrying in 10 second...");
@@ -403,7 +403,7 @@ public class NanopubLoader {
 				success = true;
 			} catch (Exception ex) {
 				ex.printStackTrace();
-				conn.rollback();
+				if (conn.isActive()) conn.rollback();
 			}
 			if (!success) {
 				System.err.println("Retrying in 10 second...");
@@ -459,8 +459,10 @@ public class NanopubLoader {
 				success = true;
 			} catch (Exception ex) {
 				ex.printStackTrace();
-				metaConn.rollback();
-				for (RepositoryConnection c : connections) c.rollback();
+				if (metaConn.isActive()) metaConn.rollback();
+				for (RepositoryConnection c : connections) {
+					if (c.isActive()) c.rollback();
+				}
 			} finally {
 				metaConn.close();
 				for (RepositoryConnection c : connections) c.close();
@@ -505,7 +507,7 @@ public class NanopubLoader {
 				success = true;
 			} catch (Exception ex) {
 				ex.printStackTrace();
-				conn.rollback();
+				if (conn.isActive()) conn.rollback();
 			}
 			if (!success) {
 				System.err.println("Retrying in 10 second...");

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -148,9 +148,7 @@ public class TripleStore {
 //					+ "        ]\n"
 //					+ "    ].";
 
-			// We can use at most 5 indexes in LMDB without hacks.
-			// We use one index for graphs, which should be more than enough (graphs are small).
-			String indexTypes = "spoc,posc,ospc,cspo";
+			String indexTypes = "spoc,posc,ospc,cspo,cpos,cosp";
 			if (repoName.startsWith("meta") || repoName.startsWith("text")) {
 				indexTypes = "spoc,posc,ospc";
 			}


### PR DESCRIPTION
*This must be merged after #21*

This should fix the timeout issues with some complex queries. It currently requires using a build of RDF4J with yet-unmerged changes that allow using 6 (instead of 5) indexes at the same time: https://github.com/eclipse-rdf4j/rdf4j/pull/5280

I've tested this locally, and these are the query times (in seconds) that I obtained with [this query](https://query.knowledgepixels.com/tools/full/yasgui.html#query=prefix+rdfs%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23%3E%0Aprefix+fip%3A+%3Chttps%3A%2F%2Fw3id.org%2Ffair%2Ffip%2Fterms%2F%3E%0Aprefix+dct%3A+%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%0Aprefix+dce%3A+%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%0Aprefix+npa%3A+%3Chttp%3A%2F%2Fpurl.org%2Fnanopub%2Fadmin%2F%3E%0Aprefix+npx%3A+%3Chttp%3A%2F%2Fpurl.org%2Fnanopub%2Fx%2F%3E%0Aprefix+np%3A+%3Chttp%3A%2F%2Fwww.nanopub.org%2Fnschema%23%3E%0A%0Aselect+%3Ffip_index+%3Ffip_title+%3Fdecl_np+where+%7B%0A++graph+npa%3Agraph+%7B%0A++++%3Ffip_index+npx%3AhasNanopubType+npx%3ANanopubIndex+.%0A++++%3Ffip_index+npa%3AhasValidSignatureForPublicKey+%3Fpubkey+.%0A++++filter+not+exists+%7B+%3Findex_np_x+npx%3Ainvalidates+%3Ffip_index+%3B+npa%3AhasValidSignatureForPublicKey+%3Fpubkey+.+%7D%0A++++%3Ffip_index+np%3AhasAssertion+%3Findex_a+.%0A++++%3Ffip_index+rdfs%3Alabel+%3Ffip_title+.%0A++++%3Ffip_index+dct%3Acreated+%3Findex_date+.%0A++++%3Fdecl_np+npa%3AhasValidSignatureForPublicKey+%3Fdecl_pubkey+.%0A++++filter+not+exists+%7B+%3Fdecl_np_x+npx%3Ainvalidates+%3Fdecl_np+%3B+npa%3AhasValidSignatureForPublicKey+%3Fdecl_pubkey+.+%7D%0A++++%3Fdecl_np+npx%3AhasNanopubType+fip%3AFIP-Declaration+.%0A++++%3Fdecl_np+dct%3Acreated+%3Fdate+.%0A++%7D%0A++graph+%3Findex_a+%7B%0A++++%3Ffip_index+npx%3AincludesElement+%3Fdecl_np+.%0A++%7D%0A++filter+not+exists+%7B%0A++++graph+npa%3Agraph+%7B%0A++++++%3Ffip_newer_index+npa%3AhasValidSignatureForPublicKey+%3Fpubkey+.%0A++++++filter+not+exists+%7B+%3Ffip_newer_index_x+npx%3Ainvalidates+%3Ffip_newer_index+%3B+npa%3AhasValidSignatureForPublicKey+%3Fpubkey+.+%7D%0A++++++%3Ffip_newer_index+dct%3Acreated+%3Fnewer_date+.%0A++++++%23+Matching+on+the+title+string+is+an+ugly+hack%3A%0A++++++%3Ffip_newer_index+rdfs%3Alabel+%3Ffip_title+.%0A++++%7D%0A++++filter(%3Fnewer_date+%3E+%3Findex_date).%0A++%7D%0A%7D&contentTypeConstruct=text%2Fturtle&contentTypeSelect=application%2Fsparql-results%2Bjson&endpoint=%2Frepo%2Ffull&requestMethod=POST&tabTitle=Query&headers=%7B%7D&outputFormat=table):

```
12.139
6.478
2.492
2.274
2.28
2.411
```

So, after warm-up, it seems to perform about as well as we'd expect it to.