### PR TITLE
Tune and document DB isolation levels

### DIFF
--- a/src/main/java/com/knowledgepixels/query/StatusController.java
+++ b/src/main/java/com/knowledgepixels/query/StatusController.java
@@ -52,6 +52,7 @@ public class StatusController {
             }
             state = State.LAUNCHING;
             adminRepoConn = TripleStore.get().getAdminRepoConnection();
+            // Serializable, as the service state needs to be strictly consistent
             adminRepoConn.begin(IsolationLevels.SERIALIZABLE);
             // Fetch the state from the DB
             try (var statements = adminRepoConn.getStatements(
@@ -168,6 +169,7 @@ public class StatusController {
     private void updateState(State newState, long loadCounter) {
         synchronized (this) {
             try {
+                // Serializable, as the service state needs to be strictly consistent
                 adminRepoConn.begin(IsolationLevels.SERIALIZABLE);
                 adminRepoConn.remove(
                         TripleStore.THIS_REPO_ID,

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -289,6 +289,7 @@ public class TripleStore {
 		if (!repoName.equals("empty")) {
 			RepositoryConnection conn = getRepoConnection(repoName);
 			try (conn) {
+				// Full isolation, just in case.
 				conn.begin(IsolationLevels.SERIALIZABLE);
 				conn.add(THIS_REPO_ID, HAS_REPO_INIT_ID, vf.createLiteral(repoInitId), NanopubLoader.ADMIN_GRAPH);
 				conn.add(THIS_REPO_ID, HAS_NANOPUB_COUNT, vf.createLiteral(0l), NanopubLoader.ADMIN_GRAPH);


### PR DESCRIPTION
I went through all uses of transactions in Query and validated whether the used isolation level was appropriate. I also had a refresher of Kleppmann's "Designing Data-Intensive Applications" beforehand :)

For a few transaction patterns, we can actually reduce the isolation level safely. Unfortunately, the most performance-sensitive transaction of all is in the `loadNanopubToRepo` method, and it must remain SERIALIZABLE. This is because in that transaction we increment a load counter and incrementally update the nanopub hash. If we used weaker isolation, this transaction would be susceptible to write skew, and we'd get broken hash chains (e.g., one nanopub is missing in the hash). This is quite honestly a rather rare case in DB usage, and I don't see a way around it.

In other places, I reduced the isolation level if possible. The loader and query service still work afterwards. I did not see any appreciable performance boost (not with all the other overhead that is present around the transaction), but maybe it will lead to fewer deadlocks in the future.

Oh, and I've also simplified a bit the code for inserting statements. Splitting the statements in batches should not have any effect, as RDF4J should do fine with processing large blobs of statements. Anyway, the inserts must happen in the same transaction, so such batching won't help anything.