### PR TITLE
Batch 3 reads in loadNanopubToRepo into 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <release>11</release>
+          <release>21</release>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This replaces three separate sp?g SPARQL queries with a single one, to reduce back-and-forth communication between the Query application and the RDF4J Server, improving performance.

It does work. In my 5-minute profiling test, the CPU time spent on fetching these values went down from 2720 ms to 1150 ms, and these operations now take up 10% of time in loadNanopubToRepo, instead of 38%.

Part of #27 