### PR TITLE
Parallelize NanopubLoader

### DIFF
--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -12,7 +12,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.CookieSpecs;
@@ -52,7 +51,6 @@ public class NanopubLoader {
 	private NanopubLoader() {}  // no instances allowed
 
 	private static HttpClient httpClient;
-	// TODO: configure thread count
 	private static final ThreadPoolExecutor loadingPool =
 			(ThreadPoolExecutor) Executors.newFixedThreadPool(4);
 

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -420,9 +420,7 @@ public class NanopubLoader {
 					// @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadTimestamp, LOAD_TIMESTAMP, npa:graph, admin, the time point at which this NANOPUB was loaded
 					conn.add(statements);
 				}
-				// System.err.println(repoName + " START " + System.nanoTime());
 				conn.commit();
-				// System.err.println(repoName + " -END- " + System.nanoTime());
 				success = true;
 			} catch (Exception ex) {
 				ex.printStackTrace();

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -332,6 +332,7 @@ public class NanopubLoader {
 			);
 		}
 
+		// Wait for all loading tasks to complete before returning
 		for (var task : runningTasks) {
 			try {
 				task.get();

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -7,6 +7,12 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.CookieSpecs;
@@ -46,6 +52,9 @@ public class NanopubLoader {
 	private NanopubLoader() {}  // no instances allowed
 
 	private static HttpClient httpClient;
+	// TODO: configure thread count
+	private static final ThreadPoolExecutor loadingPool =
+			(ThreadPoolExecutor) Executors.newFixedThreadPool(4);
 
 	private static HttpClient getHttpClient() {
 		if (httpClient == null) {
@@ -275,22 +284,33 @@ public class NanopubLoader {
 		textStatements.addAll(metaStatements);
 		textStatements.addAll(invalidatingStatements);
 
+		var runningTasks = new ArrayList<Future<?>>();
+		Consumer<Runnable> runTask = t -> {
+			runningTasks.add(loadingPool.submit(t));
+		};
+
 		if (timestamp != null) {
 			if (new Date().getTime() - timestamp.getTimeInMillis() < THIRTY_DAYS) {
-				loadNanopubToLatest(allStatements);
+				runTask.accept(() -> loadNanopubToLatest(allStatements));
 			}
 		}
 
-		loadNanopubToRepo(np.getUri(), metaStatements, "meta");
-		loadNanopubToRepo(np.getUri(), allStatements, "full");
-		loadNanopubToRepo(np.getUri(), textStatements, "text");
-		loadNanopubToRepo(np.getUri(), allStatements, "pubkey_" + Utils.createHash(el.getPublicKeyString()));
+		runTask.accept(() -> loadNanopubToRepo(np.getUri(), textStatements, "text"));
+		runTask.accept(() -> loadNanopubToRepo(np.getUri(), allStatements, "full"));
+		runTask.accept(() -> loadNanopubToRepo(np.getUri(), metaStatements, "meta"));
+
+		NanopubSignatureElement finalEl = el;
+		runTask.accept(() -> loadNanopubToRepo(
+				np.getUri(), allStatements, "pubkey_" + Utils.createHash(finalEl.getPublicKeyString()))
+		);
 //		loadNanopubToRepo(np.getUri(), textStatements, "text-pubkey_" + Utils.createHash(el.getPublicKeyString()));
 		for (IRI typeIri : NanopubUtils.getTypes(np)) {
 			// Exclude locally minted IRIs:
 			if (typeIri.stringValue().startsWith(np.getUri().stringValue())) continue;
 			if (!typeIri.stringValue().matches("https?://.*")) continue;
-			loadNanopubToRepo(np.getUri(), allStatements, "type_" + Utils.createHash(typeIri));
+			runTask.accept(() ->
+					loadNanopubToRepo(np.getUri(), allStatements, "type_" + Utils.createHash(typeIri))
+			);
 //			loadNanopubToRepo(np.getUri(), textStatements, "text-type_" + Utils.createHash(typeIri));
 		}
 //		for (IRI creatorIri : SimpleCreatorPattern.getCreators(np)) {
@@ -309,7 +329,17 @@ public class NanopubLoader {
 //		}
 
 		for (Statement st : invalidateStatements) {
-			loadInvalidateStatements(np, el.getPublicKeyString(), st, pubkeyStatement, pubkeyStatementX);
+			runTask.accept(() ->
+				loadInvalidateStatements(np, finalEl.getPublicKeyString(), st, pubkeyStatement, pubkeyStatementX)
+			);
+		}
+
+		for (var task : runningTasks) {
+			try {
+				task.get();
+			} catch (ExecutionException | InterruptedException ex) {
+				throw new RuntimeException("Error in nanopub loading thread", ex.getCause());
+			}
 		}
 	}
 
@@ -392,7 +422,9 @@ public class NanopubLoader {
 					// @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadTimestamp, LOAD_TIMESTAMP, npa:graph, admin, the time point at which this NANOPUB was loaded
 					conn.add(statements);
 				}
+				// System.err.println(repoName + " START " + System.nanoTime());
 				conn.commit();
+				// System.err.println(repoName + " -END- " + System.nanoTime());
 				success = true;
 			} catch (Exception ex) {
 				ex.printStackTrace();

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -18,10 +18,8 @@ import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -83,11 +81,7 @@ public class TripleStore {
 		getRepository("empty");  // Make sure empty repo exists
 	}
 
-	private final HttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager();
-	private final CloseableHttpClient httpclient = HttpClients.custom()
-			// .setMaxConnPerRoute(4)
-			// .setMaxConnTotal(100)
-			.build();
+	private final CloseableHttpClient httpclient = HttpClients.createDefault();
 
 	private Repository getRepository(String name) {
 		synchronized (this) {

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -14,10 +14,14 @@ import org.apache.commons.exec.environment.EnvironmentUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -46,7 +50,7 @@ public class TripleStore {
 	public static final IRI HAS_COVERAGE_HASH = vf.createIRI("http://purl.org/nanopub/admin/hasCoverageHash");
 	public static final IRI HAS_COVERAGE_FILTER = vf.createIRI("http://purl.org/nanopub/admin/hasCoverageFilter");
 
-	private Map<String,Repository> repositories = new LinkedHashMap<>();
+	private final Map<String, Repository> repositories = new LinkedHashMap<>();
 
 	private String endpointBase = null;
 	private String endpointType = null;
@@ -79,36 +83,42 @@ public class TripleStore {
 		getRepository("empty");  // Make sure empty repo exists
 	}
 
-	private final CloseableHttpClient httpclient = HttpClients.createDefault();
+	private final HttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager();
+	private final CloseableHttpClient httpclient = HttpClients.custom()
+			// .setMaxConnPerRoute(4)
+			// .setMaxConnTotal(100)
+			.build();
 
 	private Repository getRepository(String name) {
-		while (repositories.size() > 100) {
-			Entry<String,Repository> e = repositories.entrySet().iterator().next();
-			repositories.remove(e.getKey());
-			System.err.println("Shutting down repo: " + e.getKey());
-			e.getValue().shutDown();
-			System.err.println("Shutdown complete");
-		}
-		if (repositories.containsKey(name)) {
-			// Move to the end of the list:
-			Repository repo = repositories.remove(name);
-			repositories.put(name, repo);
-		} else {
-			Repository repository = null;
-			if (endpointType == null || endpointType.equals("rdf4j")) {
-				HTTPRepository hr = new HTTPRepository(endpointBase + "repositories/" + name);
-				hr.setHttpClient(httpclient);
-				repository = hr;
+		synchronized (this) {
+			while (repositories.size() > 100) {
+				Entry<String, Repository> e = repositories.entrySet().iterator().next();
+				repositories.remove(e.getKey());
+				System.err.println("Shutting down repo: " + e.getKey());
+				e.getValue().shutDown();
+				System.err.println("Shutdown complete");
+			}
+			if (repositories.containsKey(name)) {
+				// Move to the end of the list:
+				Repository repo = repositories.remove(name);
+				repositories.put(name, repo);
+			} else {
+				Repository repository = null;
+				if (endpointType == null || endpointType.equals("rdf4j")) {
+					HTTPRepository hr = new HTTPRepository(endpointBase + "repositories/" + name);
+					hr.setHttpClient(httpclient);
+					repository = hr;
 //			} else if (endpointType.equals("virtuoso")) {
 //				repository = new VirtuosoRepository(endpointBase + name, username, password);
-			} else {
-				throw new RuntimeException("Unknown repository type: " + endpointType);
+				} else {
+					throw new RuntimeException("Unknown repository type: " + endpointType);
+				}
+				repositories.put(name, repository);
+				createRepo(name);
+				getRepoConnection(name).close();
 			}
-			repositories.put(name, repository);
-			createRepo(name);
-			getRepoConnection(name).close();
+			return repositories.get(name);
 		}
-		return repositories.get(name);
 	}
 
 	public RepositoryConnection getRepoConnection(String name) {


### PR DESCRIPTION
This introduces a simple thread pool to run the per-repository loading operations in parallel. Because operations on an RDF4J HTTP repo are synchronous, this will allow us to wait on several operations simultaneously, instead of executing them sequentially.

While this does provide a speedup in loading (+10–20%), it's nowhere near as large as I had hoped. The vast majority of time is spent waiting for RDF4J to commit the changes, and it seems that we are already saturating its internal capacity, in some chokepoint. I'm not exactly sure what is the bottleneck, it may be simply disk I/O.

On my system this allows for loading nanopubs at up to ~13 np/s which is already pretty good. I don't think I can make this much faster with the current setup – I'll elaborate in the parent issue (#27).