### PR TITLE
Fix the incremental update loop being broken

### DIFF
--- a/src/main/java/com/knowledgepixels/query/LocalNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/LocalNanopubLoader.java
@@ -69,7 +69,7 @@ public class LocalNanopubLoader {
                 MultiNanopubRdfHandler.process(RDFFormat.TRIG, loadNanopubsFile, new NanopubHandler() {
                     @Override
                     public void handleNanopub(Nanopub np) {
-                        NanopubLoader.load(np);
+                        NanopubLoader.load(np, -1);
                     }
                 });
             } catch (IOException | MalformedNanopubException ex) {

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -48,7 +48,9 @@ public class MainVerticle extends AbstractVerticle {
 	@Override
 	public void start(Promise<Void> startPromise) throws Exception {
 		HttpClient httpClient = vertx.createHttpClient(
-				new HttpClientOptions().setConnectTimeout(1000).setIdleTimeoutUnit(TimeUnit.SECONDS).setIdleTimeout(60).setReadIdleTimeout(60).setWriteIdleTimeout(60),
+				new HttpClientOptions()
+					.setConnectTimeout(1000).setIdleTimeoutUnit(TimeUnit.SECONDS)
+					.setIdleTimeout(60).setReadIdleTimeout(60).setWriteIdleTimeout(60),
 				new PoolOptions().setHttp1MaxSize(200).setHttp2MaxSize(200)
 			);
 
@@ -323,7 +325,7 @@ public class MainVerticle extends AbstractVerticle {
 					final String dataString = payload.toString();
 					try {
 						Nanopub np = new NanopubImpl(dataString, RDFFormat.TRIG);
-						NanopubLoader.load(np);
+						NanopubLoader.load(np, -1);
 					} catch (MalformedNanopubException ex) {
 						req.response().setStatusCode(HttpStatus.SC_BAD_REQUEST)
 							.setStatusMessage(Arrays.toString(ex.getStackTrace()))


### PR DESCRIPTION
`JellyNanopubLoader.loadUpdates` was not supposed to throw any exceptions, as that would stop the scheduled executor, and in turn prevent it from scheduling the `loadUpdates` task again. I forgot that it is possible that an exception may be thrown inside the `finally {}` block there if the StatusController fails to communicate with RDF4J. I've added a try/catch here to mitigate it.

I've also plugged some more holes in logic around restoring the service after a hard restart.

Because I've noticed some inconsistencies in load counters that caused repeated loads of a single nanopub, I've added some logging to track situations like this, it will be easier to debug it later if it happens again.