### PR TITLE
Implement prometheus metrics collection and expose metrics through an endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - 9300:9300
       - 9393:9393
+      - "127.0.0.1:9294:9294" # this port should only be accessible from restricted environment as it is used for the metrics endpoint.
     volumes:
       # For the local nanopub loader (optional).
       # If not used, Query will load the nanopubs from the Registry with Jelly.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     ports:
       - 9300:9300
       - 9393:9393
-      - "127.0.0.1:9294:9294" # this port should only be accessible from restricted environment as it is used for the metrics endpoint.
+      # :9394 is only accessible from localhost as it is used for the /metrics endpoint
+      - "127.0.0.1:9394:9394"
     volumes:
       # For the local nanopub loader (optional).
       # If not used, Query will load the nanopubs from the Registry with Jelly.

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <junit-jupiter.version>5.13.0-M2</junit-jupiter.version>
 
     <main.verticle>com.knowledgepixels.query.MainVerticle</main.verticle>
-    <launcher.class>io.vertx.core.Launcher</launcher.class>
+    <launcher.class>com.knowledgepixels.query.ApplicationLauncher</launcher.class>
   </properties>
 
   <repositories>
@@ -62,6 +62,10 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-micrometer-metrics</artifactId>
     </dependency>
 
     <dependency>
@@ -107,6 +111,11 @@
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-sail-nativerdf</artifactId>
       <version>5.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <version>1.10.13</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/knowledgepixels/query/ApplicationLauncher.java
+++ b/src/main/java/com/knowledgepixels/query/ApplicationLauncher.java
@@ -1,0 +1,24 @@
+package com.knowledgepixels.query;
+
+import io.vertx.core.Launcher;
+import io.vertx.core.VertxOptions;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
+
+public class ApplicationLauncher extends Launcher {
+
+    public static void main(String[] args) {
+        new ApplicationLauncher().dispatch(args);
+    }
+
+    @Override
+    public void beforeStartingVertx(VertxOptions options) {
+        options.setMetricsOptions(
+            // Enable Micrometer metrics
+            new MicrometerMetricsOptions()
+                .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                .setJvmMetricsEnabled(true)
+                .setEnabled(true)
+        );
+    }
+}

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -63,7 +63,7 @@ public class MainVerticle extends AbstractVerticle {
 		// Metrics
 		final var metricsHttpServer = vertx.createHttpServer();
 		final var metricsRouter = Router.router(vertx);
-		metricsHttpServer.requestHandler(metricsRouter).listen(9294);
+		metricsHttpServer.requestHandler(metricsRouter).listen(9394);
 
 		final var metricsRegistry = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
 		final var collector = new MetricsCollector(metricsRegistry);

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -61,9 +61,13 @@ public class MainVerticle extends AbstractVerticle {
 		Router proxyRouter = Router.router(vertx);
 
 		// Metrics
+		final var metricsHttpServer = vertx.createHttpServer();
+		final var metricsRouter = Router.router(vertx);
+		metricsHttpServer.requestHandler(metricsRouter).listen(9294);
+
 		final var metricsRegistry = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
 		final var collector = new MetricsCollector(metricsRegistry);
-		proxyRouter.route("/metrics").handler(PrometheusScrapingHandler.create(metricsRegistry));
+		metricsRouter.route("/metrics").handler(PrometheusScrapingHandler.create(metricsRegistry));
 
 		// ----------
 		// This part is only used if the redirection is not done through Nginx.

--- a/src/main/java/com/knowledgepixels/query/MetricsCollector.java
+++ b/src/main/java/com/knowledgepixels/query/MetricsCollector.java
@@ -1,0 +1,71 @@
+package com.knowledgepixels.query;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class MetricsCollector {
+
+    private final AtomicInteger loadCounter = new AtomicInteger(0);
+    private final AtomicInteger typeRepositoriesCounter = new AtomicInteger(0);
+    private final AtomicInteger pubkeyRepositoriesCounter = new AtomicInteger(0);
+    private final AtomicInteger fullRepositoriesCounter = new AtomicInteger(0);
+
+    private final Map<StatusController.State, AtomicInteger> statusStates = new ConcurrentHashMap<>();
+
+    public MetricsCollector(MeterRegistry meterRegistry) {
+        // Numeric metrics
+        Gauge.builder("registry.load.counter", loadCounter, AtomicInteger::get).register(meterRegistry);
+        Gauge.builder("registry.type.repositories.counter", typeRepositoriesCounter, AtomicInteger::get).register(meterRegistry);
+        Gauge.builder("registry.pubkey.repositories.counter", pubkeyRepositoriesCounter, AtomicInteger::get).register(meterRegistry);
+        Gauge.builder("registry.full.repositories.counter", fullRepositoriesCounter, AtomicInteger::get).register(meterRegistry);
+
+        // Status label metrics
+        for (final var status : StatusController.State.values()) {
+            AtomicInteger stateGauge = new AtomicInteger(0);
+            statusStates.put(status, stateGauge);
+            Gauge.builder("registry.server.status", stateGauge, AtomicInteger::get)
+                .description("Server status (1 if current)")
+                .tag("status", status.name())
+                .register(meterRegistry);
+        }
+    }
+
+    public void updateMetrics() {
+        // Update numeric metrics
+        loadCounter.set((int) StatusController.get().getState().loadCounter);
+        typeRepositoriesCounter.set(
+            (int) Optional
+                .ofNullable(TripleStore.get().getRepositoryNames())
+                .orElse(Set.of())
+                .stream()
+                .filter(repo -> repo.startsWith("type_"))
+                .count()
+        );
+        pubkeyRepositoriesCounter.set(
+            (int) Optional
+                .ofNullable(TripleStore.get().getRepositoryNames())
+                .orElse(Set.of())
+                .stream()
+                .filter(repo -> repo.startsWith("pubkey_"))
+                .count()
+        );
+        fullRepositoriesCounter.set(
+            Optional
+                .ofNullable(TripleStore.get().getRepositoryNames())
+                .orElse(Set.of())
+                .size()
+        );
+
+        // Update status gauge
+        final var currentStatus = StatusController.get().getState().state;
+        for (final var status : StatusController.State.values()) {
+            statusStates.get(status).set(status.equals(currentStatus) ? 1 : 0);
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the collection and exposure of some domain-specific metrics useful for monitoring query's state.
The following metrics are added and collected at an interval of 1 second:
- Extended JVM and system metrics
- Current application state (exposed via `registry_server_status` with 4 labeled gauges)
- Load Counter (exposed via `registry_load_counter`) 
- Type Repositories Count (exposed via `registry_type_repositories_counter`)
- Pubkey Repositories Count (exposed via `registry_pubkey_repositories_counter`)
- Full Repositories Count (exposed via `registry_full_repositories_counter`)

The metrics are exposed and served ready to consume by prometheus through the `/metrics` endpoint:
![image](https://github.com/user-attachments/assets/097ac465-29a5-4dec-a151-7416e9638bd5)

Technical notes:
- The PR replaces standard Vertx `Launcher` with a custom `ApplicationLauncher` extension due to a requirement to configure metrics collection before Vertx is initialized.
- All metrics are collected and managed by `MetricsCollector` class