### PR TITLE
Add configurable proxy host

### DIFF
--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -4,6 +4,8 @@ services:
       - JPDA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
       - NANOPUB_QUERY_URL=https://query.your.domain.com/
       - REGISTRY_FIXED_URL=http://your.nanopub.registry.com/
+      - RDF4J_PROXY_HOST="rdf4j"
+      - RDF4J_PROXY_PORT=8080
     ports:
       - 5005:5005
     entrypoint: 'java -jar -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 nanopub-query.jar'

--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -4,7 +4,7 @@ services:
       - JPDA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
       - NANOPUB_QUERY_URL=https://query.your.domain.com/
       - REGISTRY_FIXED_URL=http://your.nanopub.registry.com/
-      - RDF4J_PROXY_HOST="rdf4j"
+      - RDF4J_PROXY_HOST=rdf4j
       - RDF4J_PROXY_PORT=8080
     ports:
       - 5005:5005

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ENDPOINT_TYPE=rdf4j
       - ENDPOINT_BASE=http://rdf4j:8080/rdf4j-server/
       - REGISTRY_FIXED_URL=https://registry.knowledgepixels.com/
+      - RDF4J_PROXY_HOST=rdf4j
 #     - INIT_WAIT_SECONDS=120   # Only used by the local nanopub loader
 #     - NANOPUB_QUERY_URL=https://query.knowledgepixels.com/
     logging:

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -68,12 +68,13 @@ public class MainVerticle extends AbstractVerticle {
 		final var metricsRegistry = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
 		final var collector = new MetricsCollector(metricsRegistry);
 		metricsRouter.route("/metrics").handler(PrometheusScrapingHandler.create(metricsRegistry));
-
 		// ----------
 		// This part is only used if the redirection is not done through Nginx.
 		// See nginx.conf and this bug report: https://github.com/eclipse-rdf4j/rdf4j/discussions/5120
 		HttpProxy rdf4jProxy = HttpProxy.reverseProxy(httpClient);
-		rdf4jProxy.origin(8080, "rdf4j");
+		String proxy = Utils.getEnvString("RDF4J_PROXY_HOST", "rdf4j");
+		int proxyPort = Utils.getEnvInt("RDF4J_PROXY_PORT", 8080);
+		rdf4jProxy.origin(proxyPort, proxy);
 
 		rdf4jProxy.addInterceptor(new ProxyInterceptor() {
 


### PR DESCRIPTION
Currently, RDF4J proxy hostname and port are hardcoded inside `MainVerticle.java`. However, this causes problems when combined with situations in which more advanced network setup is needed. As such, this PR adds two environmental variables to make this configurable, `RDF4J_PROXY_HOST` and `RDF4J_PROXY_PORT`.
