### PR TITLE
Upgrade Jelly-JVM to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.github.Nanopublication</groupId>
       <artifactId>nanopub-java</artifactId>
-      <version>40a757163ca02beeddc80b66b95eda8b93f19d08</version>
+      <version>e4e430b3b5f09caa1c852e67a15a86bfc7b5a986</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This PR upgrades the version of Nanopubs-Java to the latest. This is the only change neccessary to support Jelly-JVM 3.1.0 in this project.