### PR TITLE
Fix the incremental loader getting stuck on last nanopub

### DIFF
--- a/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
@@ -178,7 +178,7 @@ public class JellyNanopubLoader {
                 }
             });
             // Make sure to save the last committed counter at the end of the batch
-            if (lastCommittedCounter > lastSavedCounter.get()) {
+            if (lastCommittedCounter >= lastSavedCounter.get()) {
                 saveCommittedCounter(type);
             }
         } catch (IOException e) {


### PR DESCRIPTION
Closes #40

I can't reproduce the original issue, but it's likely an edge case where the counter is not getting saved to the DB for some reason. To mitigate that, I changed the code to also save the counter if the loader thinks it's up to date anyway, just to be sure.