### PR TITLE
Fix api-version=latest hanging for OpenAPI links

### DIFF
--- a/src/main/java/com/knowledgepixels/query/GrlcSpec.java
+++ b/src/main/java/com/knowledgepixels/query/GrlcSpec.java
@@ -17,7 +17,11 @@ import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
 import org.nanopub.Nanopub;
 import org.nanopub.SimpleCreatorPattern;
 import org.nanopub.extra.server.GetNanopub;
-import org.nanopub.extra.services.QueryAccess;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.nanopub.vocabulary.NPA;
+import org.nanopub.vocabulary.NPX;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,8 +106,10 @@ public class GrlcSpec {
         // TODO Get the nanopub from the local store:
         np = GetNanopub.get(artifactCode);
         if (parameters.get("api-version") != null && parameters.get("api-version").equals("latest")) {
-            // TODO Get the latest version from the local store:
-            np = GetNanopub.get(QueryAccess.getLatestVersionId(np.getUri().stringValue()));
+            String latestUri = getLatestVersionIdLocally(np.getUri().stringValue());
+            if (!latestUri.equals(np.getUri().stringValue())) {
+                np = GetNanopub.get(TrustyUriUtils.getArtifactCode(latestUri));
+            }
             artifactCode = TrustyUriUtils.getArtifactCode(np.getUri().stringValue());
         }
         for (Statement st : np.getAssertion()) {
@@ -421,6 +427,50 @@ public class GrlcSpec {
      */
     public static String serializeLiteral(String literalString) {
         return "\"" + escapeLiteral(literalString) + "\"";
+    }
+
+    /**
+     * Resolves the latest version of a nanopub by following the supersedes chain in the local store.
+     * Uses a single SPARQL query with a property path to find the latest non-invalidated version
+     * signed by the same key. If no result is found locally, or if the local store is unavailable,
+     * returns the original URI.
+     *
+     * @param nanopubUri the URI of the nanopub to resolve
+     * @return the URI of the latest version
+     */
+    static String getLatestVersionIdLocally(String nanopubUri) {
+        logger.info("Resolving latest version locally for: {}", nanopubUri);
+        try {
+            RepositoryConnection conn = TripleStore.get().getRepoConnection("meta");
+            try (conn) {
+                String query =
+                    "SELECT ?latest ?date WHERE { " +
+                    "GRAPH <" + NPA.GRAPH + "> { " +
+                        "<" + nanopubUri + "> <" + NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY + "> ?pubkey . " +
+                        "?latest <" + NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY + "> ?pubkey . " +
+                        "FILTER NOT EXISTS { ?npx <" + NPX.INVALIDATES + "> ?latest ; " +
+                            "<" + NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY + "> ?pubkey . } " +
+                        "?latest <" + DCTERMS.CREATED + "> ?date . " +
+                    "} " +
+                    "GRAPH <" + NPA.NETWORK_GRAPH + "> { " +
+                        "?latest (<" + NPX.SUPERSEDES + ">)* <" + nanopubUri + "> . " +
+                    "} " +
+                    "} ORDER BY DESC(?date) LIMIT 1";
+                TupleQueryResult r = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate();
+                try (r) {
+                    if (r.hasNext()) {
+                        String latestUri = r.next().getBinding("latest").getValue().stringValue();
+                        logger.info("Resolved latest version: {}", latestUri);
+                        return latestUri;
+                    }
+                }
+                logger.info("No latest version found locally for: {}", nanopubUri);
+                return nanopubUri;
+            }
+        } catch (Exception ex) {
+            logger.warn("Could not resolve latest version locally, using original version: {}", ex.getMessage());
+            return nanopubUri;
+        }
     }
 
 }

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -297,25 +297,33 @@ public class MainVerticle extends AbstractVerticle {
 
         // TODO This is no longer needed and can be removed at some point:
         proxyRouter.route(HttpMethod.GET, "/grlc-spec/*").handler(req -> {
-            try {
+            vertx.<String>executeBlocking(() -> {
                 GrlcSpec gsp = new GrlcSpec(req.normalizedPath(), req.queryParams());
-                req.response().putHeader("content-type", "text/yaml").end(gsp.getSpec());
-            } catch (InvalidGrlcSpecException ex) {
-                req.response().setStatusCode(400).end(ex.getMessage());
-            } catch (Exception ex) {
-                req.response().setStatusCode(500).end("Unexpected error: " + ex.getMessage());
-            }
+                return gsp.getSpec();
+            }, false).onSuccess(spec -> {
+                req.response().putHeader("content-type", "text/yaml").end(spec);
+            }).onFailure(ex -> {
+                if (ex instanceof InvalidGrlcSpecException) {
+                    req.response().setStatusCode(400).end(ex.getMessage());
+                } else {
+                    req.response().setStatusCode(500).end("Unexpected error: " + ex.getMessage());
+                }
+            });
         });
 
         proxyRouter.route(HttpMethod.GET, "/openapi/spec/*").handler(req -> {
-            try {
+            vertx.<String>executeBlocking(() -> {
                 OpenApiSpecPage osp = new OpenApiSpecPage(req.normalizedPath(), req.queryParams());
-                req.response().putHeader("content-type", "text/yaml").end(osp.getSpec());
-            } catch (InvalidGrlcSpecException ex) {
-                req.response().setStatusCode(400).end("Invlid grlc API definition: " + ex.getMessage());
-            } catch (Exception ex) {
-                req.response().setStatusCode(500).end("Unexpected error: " + ex.getMessage());
-            }
+                return osp.getSpec();
+            }, false).onSuccess(spec -> {
+                req.response().putHeader("content-type", "text/yaml").end(spec);
+            }).onFailure(ex -> {
+                if (ex instanceof InvalidGrlcSpecException) {
+                    req.response().setStatusCode(400).end("Invalid grlc API definition: " + ex.getMessage());
+                } else {
+                    req.response().setStatusCode(500).end("Unexpected error: " + ex.getMessage());
+                }
+            });
         });
 
         proxyRouter.route("/openapi/*").handler(StaticHandler.create("com/knowledgepixels/query/swagger"));

--- a/src/main/resources/com/knowledgepixels/query/swagger/swagger-initializer.js
+++ b/src/main/resources/com/knowledgepixels/query/swagger/swagger-initializer.js
@@ -2,9 +2,15 @@ window.onload = function() {
   //<editor-fold desc="Changeable Configuration Block">
 
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
+  var params = new URLSearchParams(window.location.search);
+  var specUrl = params.get('url') || "https://petstore.swagger.io/v2/swagger.json";
+  var apiVersion = params.get('api-version');
+  if (apiVersion && specUrl.indexOf('api-version=') === -1) {
+    specUrl += (specUrl.indexOf('?') !== -1 ? '&' : '?') + 'api-version=' + encodeURIComponent(apiVersion);
+  }
+
   window.ui = SwaggerUIBundle({
-    url: "https://petstore.swagger.io/v2/swagger.json",
-    queryConfigEnabled: true,
+    url: specUrl,
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
## Summary
- Replace external `QueryAccess.getLatestVersionId()` network call with a local SPARQL query on the meta repository that follows the `npx:supersedes` chain, checking signature validity and invalidation status
- Move `/grlc-spec/*` and `/openapi/spec/*` handlers to `vertx.executeBlocking()` to keep remaining I/O (e.g. `GetNanopub.get()`) off the Vert.x event loop
- Fix Swagger UI initializer to forward `api-version` from the page URL to the spec fetch URL, so both `&api-version=latest` and `%3Fapi-version=latest` URL formats work

## Test plan
- [x] All 86 existing tests pass
- [ ] Verify with `http://localhost:9393/openapi/?url=spec/<artifact-code>/query%3Fapi-version=latest` that the latest version is resolved
- [ ] Verify with `http://localhost:9393/openapi/?url=spec/<artifact-code>/query&api-version=latest` that the latest version is also resolved
- [ ] Check logs for "Resolving latest version locally" / "Resolved latest version" messages

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)