### PR TITLE
feat: preview unpublished nanopub queries via URL parameter

### DIFF
--- a/src/main/java/com/knowledgepixels/query/GrlcSpec.java
+++ b/src/main/java/com/knowledgepixels/query/GrlcSpec.java
@@ -14,7 +14,10 @@ import org.eclipse.rdf4j.query.algebra.helpers.AbstractSimpleQueryModelVisitor;
 import org.eclipse.rdf4j.query.parser.ParsedGraphQuery;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
+import org.nanopub.NanopubImpl;
 import org.nanopub.SimpleCreatorPattern;
 import org.nanopub.extra.server.GetNanopub;
 import org.eclipse.rdf4j.query.QueryLanguage;
@@ -25,6 +28,8 @@ import org.nanopub.vocabulary.NPX;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.*;
 
 //TODO merge this class with GrlcQuery of Nanodash and move to a library like nanopub-java
@@ -103,8 +108,18 @@ public class GrlcSpec {
         queryPart = requestUrl.replaceFirst("^(.*/)(RA[A-Za-z0-9\\-_]{43}/)(.*)?$", "$3");
         queryPart = queryPart.replaceFirst(".rq$", "");
 
-        // TODO Get the nanopub from the local store:
-        np = GetNanopub.get(artifactCode);
+        String nanopubParam = parameters.get("_nanopub_trig");
+        if (nanopubParam != null && !nanopubParam.isEmpty()) {
+            try {
+                byte[] trig = Base64.getUrlDecoder().decode(nanopubParam);
+                np = new NanopubImpl(new ByteArrayInputStream(trig), RDFFormat.TRIG);
+            } catch (MalformedNanopubException | IOException | IllegalArgumentException ex) {
+                throw new InvalidGrlcSpecException("Failed to parse nanopub from 'nanopub' parameter", ex);
+            }
+        } else {
+            np = GetNanopub.get(artifactCode);
+        }
+        // TODO rename "api-version" to "_api_version" for consistency
         if (parameters.get("api-version") != null && parameters.get("api-version").equals("latest")) {
             String latestUri = getLatestVersionIdLocally(np.getUri().stringValue());
             if (!latestUri.equals(np.getUri().stringValue())) {

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -57,7 +57,9 @@ public class MainVerticle extends AbstractVerticle {
                 new PoolOptions().setHttp1MaxSize(200).setHttp2MaxSize(200)
         );
 
-        HttpServer proxyServer = vertx.createHttpServer();
+        HttpServer proxyServer = vertx.createHttpServer(
+                new HttpServerOptions().setMaxInitialLineLength(65536)
+        );
         Router proxyRouter = Router.router(vertx);
         proxyRouter.route().handler(CorsHandler.create().addRelativeOrigin(".*"));
 

--- a/src/main/resources/com/knowledgepixels/query/swagger/swagger-initializer.js
+++ b/src/main/resources/com/knowledgepixels/query/swagger/swagger-initializer.js
@@ -4,15 +4,26 @@ window.onload = function() {
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   var params = new URLSearchParams(window.location.search);
   var specUrl = params.get('url') || "https://petstore.swagger.io/v2/swagger.json";
-  var apiVersion = params.get('api-version');
+  var apiVersion = params.get('api-version'); // TODO rename to '_api_version' for consistency
   if (apiVersion && specUrl.indexOf('api-version=') === -1) {
     specUrl += (specUrl.indexOf('?') !== -1 ? '&' : '?') + 'api-version=' + encodeURIComponent(apiVersion);
+  }
+  var nanopub = params.get('_nanopub_trig');
+  if (nanopub && specUrl.indexOf('_nanopub_trig=') === -1) {
+    specUrl += (specUrl.indexOf('?') !== -1 ? '&' : '?') + '_nanopub_trig=' + encodeURIComponent(nanopub);
   }
 
   window.ui = SwaggerUIBundle({
     url: specUrl,
     dom_id: '#swagger-ui',
     deepLinking: true,
+    requestInterceptor: function(req) {
+      if (nanopub) {
+        var separator = req.url.indexOf('?') !== -1 ? '&' : '?';
+        req.url += separator + '_nanopub_trig=' + encodeURIComponent(nanopub);
+      }
+      return req;
+    },
     presets: [
       SwaggerUIBundle.presets.apis,
       SwaggerUIStandalonePreset


### PR DESCRIPTION
## Summary

Closes #60

- Add `_nanopub_trig` query parameter that accepts a base64url-encoded signed TriG nanopub, allowing users to preview and execute query templates through the OpenAPI UI without publishing first
- Increase Vert.x `maxInitialLineLength` to 64KB to support long URLs with inline nanopubs
- Forward the parameter to both the spec fetch and API execute requests via Swagger UI's `requestInterceptor`

## Usage

```bash
# Base64url-encode a signed nanopub
NP_B64=$(base64 -w0 signed.trig | tr '+/' '-_' | tr -d '=')

# Open in browser
http://localhost:9393/openapi/?url=spec/<artifact-code>/<query-name>&_nanopub_trig=$NP_B64
```

## Test plan

- [ ] Verify existing published nanopub queries still work unchanged
- [ ] Preview an unpublished signed nanopub via `_nanopub_trig` parameter in the OpenAPI UI
- [ ] Execute the previewed query and confirm results are returned
- [ ] Confirm `_nanopub_trig` does not appear as a visible API parameter in Swagger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)