### PR TITLE
feat: mirror registry trust state into the trust repo (#65)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
@@ -39,7 +39,8 @@ public class JellyNanopubLoader {
      * Registry metadata returned by a HEAD request.
      */
     record RegistryMetadata(long loadCounter, Long setupId, String coverageTypes,
-                            String coverageAgents, String testInstance, String nanopubCount) {}
+                            String coverageAgents, String testInstance, String nanopubCount,
+                            String trustStateHash) {}
 
     /**
      * The interval in milliseconds at which the updates loader should poll for new nanopubs.
@@ -72,6 +73,7 @@ public class JellyNanopubLoader {
     public static void loadInitial(long afterCounter) {
         RegistryMetadata metadata = fetchRegistryMetadata();
         updateForwardingMetadata(metadata);
+        TrustStateLoader.maybeUpdate(metadata.trustStateHash());
         long targetCounter = metadata.loadCounter();
         log.info("Fetched Registry load counter: {}", targetCounter);
         // Store setupId on initial load
@@ -108,6 +110,7 @@ public class JellyNanopubLoader {
             lastCommittedCounter = status.loadCounter;
             RegistryMetadata metadata = fetchRegistryMetadata();
             updateForwardingMetadata(metadata);
+            TrustStateLoader.maybeUpdate(metadata.trustStateHash());
             long targetCounter = metadata.loadCounter();
             Long currentSetupId = metadata.setupId();
 
@@ -380,8 +383,11 @@ public class JellyNanopubLoader {
             String coverageAgents = getHeaderValue(response, "Nanopub-Registry-Coverage-Agents");
             String testInstance = getHeaderValue(response, "Nanopub-Registry-Test-Instance");
             String nanopubCount = getHeaderValue(response, "Nanopub-Registry-Nanopub-Count");
+            // Optional — older registries (without trust calculation) won't set this header.
+            String trustStateHash = getHeaderValue(response, "Nanopub-Registry-Trust-State-Hash");
 
-            return new RegistryMetadata(loadCounter, setupId, coverageTypes, coverageAgents, testInstance, nanopubCount);
+            return new RegistryMetadata(loadCounter, setupId, coverageTypes, coverageAgents,
+                    testInstance, nanopubCount, trustStateHash);
         }
     }
 

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -485,6 +485,11 @@ public class MainVerticle extends AbstractVerticle {
                 Runtime.getRuntime().exit(1);
             }
 
+            // Seed the TrustStateRegistry from any persisted pointer before the
+            // periodic poll begins, so the first tick doesn't re-materialize state
+            // we already have.
+            TrustStateLoader.bootstrap();
+
             // Start periodic nanopub loading
             log.info("Starting periodic nanopub loading...");
             var executor = Executors.newSingleThreadScheduledExecutor();

--- a/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
@@ -1,5 +1,14 @@
 package com.knowledgepixels.query;
 
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,21 +22,24 @@ import org.slf4j.LoggerFactory;
  * envelope, materialize the snapshot into a named graph, swap the current
  * pointer, and prune beyond retention — all in one serializable transaction.
  *
- * <p>This file currently only contains the {@link #maybeUpdate(String)} entry
- * point as a stub that logs the detected hash. Fetch and materialization land
- * in subsequent steps. See {@code doc/plan-trust-state-repos.md}.
+ * <p>Currently implements detection (via {@link #maybeUpdate(String)}) plus
+ * snapshot fetch and envelope parsing. Materialization (Step 4+) is logged
+ * but not yet performed. See {@code doc/plan-trust-state-repos.md}.
  */
 public class TrustStateLoader {
 
     private static final Logger log = LoggerFactory.getLogger(TrustStateLoader.class);
+
+    private static final CloseableHttpClient httpClient =
+            HttpClientBuilder.create().setDefaultRequestConfig(Utils.getHttpRequestConfig()).build();
 
     private TrustStateLoader() {
     }  // no instances
 
     /**
      * Called when registry-poll metadata is fetched. Compares the hash to the
-     * locally-tracked one and, if different, will (eventually) materialize the
-     * new snapshot. Currently logs the change and returns.
+     * locally-tracked one and, if different, fetches and parses the snapshot.
+     * (Materialization happens in subsequent steps.)
      *
      * <p>Safe to call with a null/empty hash (older registries don't expose
      * trust state) — silently no-op in that case.
@@ -40,9 +52,61 @@ public class TrustStateLoader {
         if (newTrustStateHash == null || newTrustStateHash.isEmpty()) return;
         String current = TrustStateRegistry.get().getCurrentHash().orElse(null);
         if (newTrustStateHash.equals(current)) return;
-        // TODO step 3+: fetch /trust-state/<hash>.json, parse envelope, materialize, swap pointer, prune.
-        log.info("Trust state hash change detected: {} -> {} (materialization not yet implemented)",
+
+        log.info("Trust state hash change detected: {} -> {}",
                 current == null ? "(none)" : current, newTrustStateHash);
+
+        Optional<TrustStateSnapshot> snapshotOpt = fetchSnapshot(newTrustStateHash);
+        if (snapshotOpt.isEmpty()) return;
+        TrustStateSnapshot snapshot = snapshotOpt.get();
+
+        // Integrity check: the registry's URL hash must match what's in the body.
+        if (!newTrustStateHash.equals(snapshot.trustStateHash())) {
+            log.warn("Trust state envelope hash mismatch: URL was {}, body says {}",
+                    newTrustStateHash, snapshot.trustStateHash());
+            return;
+        }
+
+        // TODO step 4+: materialize snapshot into the trust repo, swap pointer, prune.
+        log.info("Fetched trust state snapshot {} (counter={}, createdAt={}, accounts={})",
+                snapshot.trustStateHash(), snapshot.trustStateCounter(),
+                snapshot.createdAt(), snapshot.accounts().size());
+    }
+
+    /**
+     * Fetches and parses the snapshot for the given trust state hash from the
+     * registry. Returns {@link Optional#empty()} on 404 (the registry has
+     * pruned this hash) or on any I/O / parse error (logged at INFO).
+     *
+     * @param trustStateHash the hash to fetch
+     * @return the parsed snapshot, or empty if unavailable
+     */
+    static Optional<TrustStateSnapshot> fetchSnapshot(String trustStateHash) {
+        String url = JellyNanopubLoader.registryUrl
+                + "trust-state/" + URLEncoder.encode(trustStateHash, StandardCharsets.UTF_8) + ".json";
+        try (var response = httpClient.execute(new HttpGet(url))) {
+            int status = response.getStatusLine().getStatusCode();
+            if (status == 404) {
+                log.info("Trust state snapshot {} returned 404 (pruned by registry); skipping",
+                        trustStateHash);
+                EntityUtils.consumeQuietly(response.getEntity());
+                return Optional.empty();
+            }
+            if (status < 200 || status >= 300) {
+                log.info("Trust state snapshot {} returned HTTP {} ({}); skipping",
+                        trustStateHash, status, response.getStatusLine().getReasonPhrase());
+                EntityUtils.consumeQuietly(response.getEntity());
+                return Optional.empty();
+            }
+            String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            return Optional.of(TrustStateSnapshot.parse(body));
+        } catch (IOException ex) {
+            log.info("Failed to fetch trust state snapshot {}: {}", trustStateHash, ex.toString());
+            return Optional.empty();
+        } catch (IllegalArgumentException ex) {
+            log.info("Failed to parse trust state snapshot {}: {}", trustStateHash, ex.toString());
+            return Optional.empty();
+        }
     }
 
 }

--- a/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
@@ -9,8 +9,20 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.nanopub.vocabulary.NPA;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.hash.Hashing;
+import com.knowledgepixels.query.vocabulary.NPAA;
+import com.knowledgepixels.query.vocabulary.NPAT;
 
 /**
  * Materializes a registry trust state into the local {@code trust} repository
@@ -19,16 +31,36 @@ import org.slf4j.LoggerFactory;
  * <p>Detection happens in {@link JellyNanopubLoader} (which polls the registry
  * every ~2 s anyway and reads {@code Nanopub-Registry-Trust-State-Hash}). This
  * class does the rest: fetch {@code /trust-state/<hash>.json}, parse the
- * envelope, materialize the snapshot into a named graph, swap the current
- * pointer, and prune beyond retention — all in one serializable transaction.
+ * envelope, materialize the snapshot into a named graph, and swap the current
+ * pointer — all in one serializable transaction.
  *
- * <p>Currently implements detection (via {@link #maybeUpdate(String)}) plus
- * snapshot fetch and envelope parsing. Materialization (Step 4+) is logged
- * but not yet performed. See {@code doc/plan-trust-state-repos.md}.
+ * <p>See {@code doc/plan-trust-state-repos.md} for the full design.
  */
 public class TrustStateLoader {
 
     private static final Logger log = LoggerFactory.getLogger(TrustStateLoader.class);
+
+    /** Local name of the repository that holds all mirrored trust states. */
+    static final String TRUST_REPO = "trust";
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    // Local extensions to the upstream NPA vocabulary (terms used only on the
+    // consumer side). Defined here rather than in a vocab class because they're
+    // strictly internal to the trust-state mirroring code.
+    private static final IRI NPA_TRUST_STATE = vf.createIRI(NPA.NAMESPACE, "TrustState");
+    private static final IRI NPA_ACCOUNT_STATE = vf.createIRI(NPA.NAMESPACE, "AccountState");
+    private static final IRI NPA_HAS_TRUST_STATE_HASH = vf.createIRI(NPA.NAMESPACE, "hasTrustStateHash");
+    private static final IRI NPA_HAS_TRUST_STATE_COUNTER = vf.createIRI(NPA.NAMESPACE, "hasTrustStateCounter");
+    private static final IRI NPA_HAS_CREATED_AT = vf.createIRI(NPA.NAMESPACE, "hasCreatedAt");
+    private static final IRI NPA_HAS_CURRENT_TRUST_STATE = vf.createIRI(NPA.NAMESPACE, "hasCurrentTrustState");
+    private static final IRI NPA_AGENT = vf.createIRI(NPA.NAMESPACE, "agent");
+    private static final IRI NPA_PUBKEY = vf.createIRI(NPA.NAMESPACE, "pubkey");
+    private static final IRI NPA_TRUST_STATUS = vf.createIRI(NPA.NAMESPACE, "trustStatus");
+    private static final IRI NPA_DEPTH = vf.createIRI(NPA.NAMESPACE, "depth");
+    private static final IRI NPA_PATH_COUNT = vf.createIRI(NPA.NAMESPACE, "pathCount");
+    private static final IRI NPA_RATIO = vf.createIRI(NPA.NAMESPACE, "ratio");
+    private static final IRI NPA_QUOTA = vf.createIRI(NPA.NAMESPACE, "quota");
 
     private static final CloseableHttpClient httpClient =
             HttpClientBuilder.create().setDefaultRequestConfig(Utils.getHttpRequestConfig()).build();
@@ -38,8 +70,8 @@ public class TrustStateLoader {
 
     /**
      * Called when registry-poll metadata is fetched. Compares the hash to the
-     * locally-tracked one and, if different, fetches and parses the snapshot.
-     * (Materialization happens in subsequent steps.)
+     * locally-tracked one and, if different, fetches the snapshot and
+     * materializes it into the {@code trust} repo.
      *
      * <p>Safe to call with a null/empty hash (older registries don't expose
      * trust state) — silently no-op in that case.
@@ -60,17 +92,23 @@ public class TrustStateLoader {
         if (snapshotOpt.isEmpty()) return;
         TrustStateSnapshot snapshot = snapshotOpt.get();
 
-        // Integrity check: the registry's URL hash must match what's in the body.
+        // Integrity check: the URL hash must match what's in the body.
         if (!newTrustStateHash.equals(snapshot.trustStateHash())) {
             log.warn("Trust state envelope hash mismatch: URL was {}, body says {}",
                     newTrustStateHash, snapshot.trustStateHash());
             return;
         }
 
-        // TODO step 4+: materialize snapshot into the trust repo, swap pointer, prune.
-        log.info("Fetched trust state snapshot {} (counter={}, createdAt={}, accounts={})",
-                snapshot.trustStateHash(), snapshot.trustStateCounter(),
-                snapshot.createdAt(), snapshot.accounts().size());
+        try {
+            materialize(snapshot);
+            TrustStateRegistry.get().setCurrentHash(snapshot.trustStateHash());
+            log.info("Materialized trust state {} (counter={}, accounts={})",
+                    snapshot.trustStateHash(), snapshot.trustStateCounter(),
+                    snapshot.accounts().size());
+        } catch (Exception ex) {
+            log.warn("Failed to materialize trust state {}: {}",
+                    snapshot.trustStateHash(), ex.toString(), ex);
+        }
     }
 
     /**
@@ -107,6 +145,73 @@ public class TrustStateLoader {
             log.info("Failed to parse trust state snapshot {}: {}", trustStateHash, ex.toString());
             return Optional.empty();
         }
+    }
+
+    /**
+     * Writes the snapshot's account-state triples into the trust state's named
+     * graph, writes cross-state metadata into {@code npa:graph}, and swaps the
+     * current-state pointer — all in one serializable transaction. Idempotent
+     * on the same hash (re-running just rewrites the same triples).
+     *
+     * @param snapshot the snapshot to materialize
+     */
+    static void materialize(TrustStateSnapshot snapshot) {
+        IRI trustStateIri = NPAT.forHash(snapshot.trustStateHash());
+
+        try (RepositoryConnection conn =
+                     TripleStore.get().getRepoConnection(TRUST_REPO)) {
+            conn.begin(IsolationLevels.SERIALIZABLE);
+
+            // 1. Account-state triples in the trust state's named graph
+            for (TrustStateSnapshot.AccountEntry a : snapshot.accounts()) {
+                IRI accountStateIri =
+                        NPAA.forHash(accountStateHash(snapshot.trustStateHash(), a));
+                conn.add(accountStateIri, RDF.TYPE, NPA_ACCOUNT_STATE, trustStateIri);
+                conn.add(accountStateIri, NPA_AGENT,
+                        vf.createIRI(a.agent()), trustStateIri);
+                conn.add(accountStateIri, NPA_PUBKEY,
+                        vf.createLiteral(a.pubkey()), trustStateIri);
+                conn.add(accountStateIri, NPA_TRUST_STATUS,
+                        vf.createIRI(NPA.NAMESPACE, a.status()), trustStateIri);
+                conn.add(accountStateIri, NPA_DEPTH,
+                        vf.createLiteral(a.depth()), trustStateIri);
+                conn.add(accountStateIri, NPA_PATH_COUNT,
+                        vf.createLiteral(a.pathCount()), trustStateIri);
+                conn.add(accountStateIri, NPA_RATIO,
+                        vf.createLiteral(a.ratio()), trustStateIri);
+                conn.add(accountStateIri, NPA_QUOTA,
+                        vf.createLiteral(a.quota()), trustStateIri);
+            }
+
+            // 2. Cross-state metadata in npa:graph
+            conn.add(trustStateIri, RDF.TYPE, NPA_TRUST_STATE, NPA.GRAPH);
+            conn.add(trustStateIri, NPA_HAS_TRUST_STATE_HASH,
+                    vf.createLiteral(snapshot.trustStateHash()), NPA.GRAPH);
+            conn.add(trustStateIri, NPA_HAS_TRUST_STATE_COUNTER,
+                    vf.createLiteral(snapshot.trustStateCounter()), NPA.GRAPH);
+            conn.add(trustStateIri, NPA_HAS_CREATED_AT,
+                    vf.createLiteral(snapshot.createdAt().toString(), XSD.DATETIME),
+                    NPA.GRAPH);
+
+            // 3. Atomic pointer swap
+            conn.remove(NPA.THIS_REPO, NPA_HAS_CURRENT_TRUST_STATE, null, NPA.GRAPH);
+            conn.add(NPA.THIS_REPO, NPA_HAS_CURRENT_TRUST_STATE, trustStateIri, NPA.GRAPH);
+
+            // 4. (Step 5) Retention pruning will go here.
+
+            conn.commit();
+        }
+    }
+
+    /**
+     * Computes the account-state hash for a single entry within a snapshot.
+     * SHA-256 over {@code trustStateHash + "|" + pubkey + "|" + agent}; the
+     * trustStateHash is part of the input so the same {@code (pubkey, agent)}
+     * pair in two snapshots produces two different account-state IRIs.
+     */
+    static String accountStateHash(String trustStateHash, TrustStateSnapshot.AccountEntry a) {
+        String composite = trustStateHash + "|" + a.pubkey() + "|" + a.agent();
+        return Hashing.sha256().hashString(composite, StandardCharsets.UTF_8).toString();
     }
 
 }

--- a/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
@@ -3,6 +3,8 @@ package com.knowledgepixels.query;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.http.client.methods.HttpGet;
@@ -15,6 +17,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.nanopub.vocabulary.NPA;
 import org.slf4j.Logger;
@@ -42,6 +46,9 @@ public class TrustStateLoader {
 
     /** Local name of the repository that holds all mirrored trust states. */
     static final String TRUST_REPO = "trust";
+
+    /** Default number of historical trust states retained locally. Matches the registry's own snapshot retention. */
+    static final int DEFAULT_LOCAL_RETENTION = 100;
 
     private static final ValueFactory vf = SimpleValueFactory.getInstance();
 
@@ -197,10 +204,61 @@ public class TrustStateLoader {
             conn.remove(NPA.THIS_REPO, NPA_HAS_CURRENT_TRUST_STATE, null, NPA.GRAPH);
             conn.add(NPA.THIS_REPO, NPA_HAS_CURRENT_TRUST_STATE, trustStateIri, NPA.GRAPH);
 
-            // 4. (Step 5) Retention pruning will go here.
+            // 4. Prune any historical trust states beyond the retention window
+            int pruned = pruneOldStates(conn);
+            if (pruned > 0) {
+                log.info("Pruned {} trust state(s) beyond retention", pruned);
+            }
 
             conn.commit();
         }
+    }
+
+    /**
+     * Removes trust states beyond the retention window: their named-graph
+     * contents are dropped and their metadata triples in {@code npa:graph}
+     * are removed. Must be called inside an open transaction on the
+     * {@code trust} repo. Returns the number of states pruned.
+     */
+    private static int pruneOldStates(RepositoryConnection conn) {
+        int retention = effectiveRetention();
+        // ORDER BY DESC counter, then OFFSET retention → those beyond the keep window.
+        String query = String.format("""
+                PREFIX npa: <%s>
+                SELECT ?s WHERE {
+                  GRAPH <%s> {
+                    ?s a <%s> ; <%s> ?c .
+                  }
+                } ORDER BY DESC(?c) OFFSET %d
+                """,
+                NPA.NAMESPACE, NPA.GRAPH, NPA_TRUST_STATE, NPA_HAS_TRUST_STATE_COUNTER, retention);
+
+        List<IRI> toPrune = new ArrayList<>();
+        try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
+            while (result.hasNext()) {
+                toPrune.add((IRI) result.next().getValue("s"));
+            }
+        }
+        for (IRI old : toPrune) {
+            conn.clear(old);                          // drop the named graph's triples
+            conn.remove(old, null, null, NPA.GRAPH);  // drop its metadata in npa:graph
+        }
+        return toPrune.size();
+    }
+
+    /**
+     * Reads {@code TRUST_STATE_LOCAL_RETENTION} from the environment, falling
+     * back to {@link #DEFAULT_LOCAL_RETENTION}. Values below 1 are coerced
+     * back to the default with a warning (the plan rejects retention=0).
+     */
+    static int effectiveRetention() {
+        int n = Utils.getEnvInt("TRUST_STATE_LOCAL_RETENTION", DEFAULT_LOCAL_RETENTION);
+        if (n < 1) {
+            log.warn("TRUST_STATE_LOCAL_RETENTION={} is invalid (must be >= 1); using default {}",
+                    n, DEFAULT_LOCAL_RETENTION);
+            return DEFAULT_LOCAL_RETENTION;
+        }
+        return n;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
@@ -216,7 +216,10 @@ public class TrustStateLoader {
                      TripleStore.get().getRepoConnection(TRUST_REPO)) {
             conn.begin(IsolationLevels.SERIALIZABLE);
 
-            // 1. Account-state triples in the trust state's named graph
+            // 1. Account-state triples in the trust state's named graph.
+            // depth / pathCount / ratio / quota may be null (e.g. for status=skipped
+            // accounts, which were rejected by trust calculation and so don't carry
+            // these stats). Only emit a triple when the field is present.
             for (TrustStateSnapshot.AccountEntry a : snapshot.accounts()) {
                 IRI accountStateIri =
                         NPAA.forHash(accountStateHash(snapshot.trustStateHash(), a));
@@ -227,14 +230,22 @@ public class TrustStateLoader {
                         vf.createLiteral(a.pubkey()), trustStateIri);
                 conn.add(accountStateIri, NPA_TRUST_STATUS,
                         vf.createIRI(NPA.NAMESPACE, a.status()), trustStateIri);
-                conn.add(accountStateIri, NPA_DEPTH,
-                        vf.createLiteral(a.depth()), trustStateIri);
-                conn.add(accountStateIri, NPA_PATH_COUNT,
-                        vf.createLiteral(a.pathCount()), trustStateIri);
-                conn.add(accountStateIri, NPA_RATIO,
-                        vf.createLiteral(a.ratio()), trustStateIri);
-                conn.add(accountStateIri, NPA_QUOTA,
-                        vf.createLiteral(a.quota()), trustStateIri);
+                if (a.depth() != null) {
+                    conn.add(accountStateIri, NPA_DEPTH,
+                            vf.createLiteral(a.depth()), trustStateIri);
+                }
+                if (a.pathCount() != null) {
+                    conn.add(accountStateIri, NPA_PATH_COUNT,
+                            vf.createLiteral(a.pathCount()), trustStateIri);
+                }
+                if (a.ratio() != null) {
+                    conn.add(accountStateIri, NPA_RATIO,
+                            vf.createLiteral(a.ratio()), trustStateIri);
+                }
+                if (a.quota() != null) {
+                    conn.add(accountStateIri, NPA_QUOTA,
+                            vf.createLiteral(a.quota()), trustStateIri);
+                }
             }
 
             // 2. Cross-state metadata in npa:graph

--- a/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
@@ -1,0 +1,48 @@
+package com.knowledgepixels.query;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Materializes a registry trust state into the local {@code trust} repository
+ * when a hash change is detected.
+ *
+ * <p>Detection happens in {@link JellyNanopubLoader} (which polls the registry
+ * every ~2 s anyway and reads {@code Nanopub-Registry-Trust-State-Hash}). This
+ * class does the rest: fetch {@code /trust-state/<hash>.json}, parse the
+ * envelope, materialize the snapshot into a named graph, swap the current
+ * pointer, and prune beyond retention — all in one serializable transaction.
+ *
+ * <p>This file currently only contains the {@link #maybeUpdate(String)} entry
+ * point as a stub that logs the detected hash. Fetch and materialization land
+ * in subsequent steps. See {@code doc/plan-trust-state-repos.md}.
+ */
+public class TrustStateLoader {
+
+    private static final Logger log = LoggerFactory.getLogger(TrustStateLoader.class);
+
+    private TrustStateLoader() {
+    }  // no instances
+
+    /**
+     * Called when registry-poll metadata is fetched. Compares the hash to the
+     * locally-tracked one and, if different, will (eventually) materialize the
+     * new snapshot. Currently logs the change and returns.
+     *
+     * <p>Safe to call with a null/empty hash (older registries don't expose
+     * trust state) — silently no-op in that case.
+     *
+     * @param newTrustStateHash the {@code trustStateHash} reported by the
+     *                          registry, or null if the registry doesn't
+     *                          expose one
+     */
+    public static void maybeUpdate(String newTrustStateHash) {
+        if (newTrustStateHash == null || newTrustStateHash.isEmpty()) return;
+        String current = TrustStateRegistry.get().getCurrentHash().orElse(null);
+        if (newTrustStateHash.equals(current)) return;
+        // TODO step 3+: fetch /trust-state/<hash>.json, parse envelope, materialize, swap pointer, prune.
+        log.info("Trust state hash change detected: {} -> {} (materialization not yet implemented)",
+                current == null ? "(none)" : current, newTrustStateHash);
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
@@ -76,6 +76,53 @@ public class TrustStateLoader {
     }  // no instances
 
     /**
+     * Seeds {@link TrustStateRegistry} from the current-state pointer persisted
+     * in the {@code trust} repo. Intended to run once on startup, before the
+     * periodic poll begins — so if the pointer already matches the registry's
+     * advertised hash, the first poll is a no-op rather than a redundant
+     * re-materialization.
+     *
+     * <p>Safe to call on a fresh deployment (the trust repo may not even exist
+     * yet — auto-created, found empty, seeded nothing). Any failure is logged
+     * at INFO; bootstrap falls through and the first poll materializes from
+     * scratch.
+     */
+    public static void bootstrap() {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(TRUST_REPO)) {
+            String query = String.format("""
+                    SELECT ?s WHERE {
+                      GRAPH <%s> {
+                        <%s> <%s> ?s .
+                      }
+                    } LIMIT 1
+                    """,
+                    NPA.GRAPH, NPA.THIS_REPO, NPA_HAS_CURRENT_TRUST_STATE);
+            try (TupleQueryResult result =
+                         conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
+                if (!result.hasNext()) {
+                    log.info("Trust state bootstrap: no current-state pointer yet");
+                    return;
+                }
+                IRI ptr = (IRI) result.next().getValue("s");
+                String iri = ptr.stringValue();
+                if (!iri.startsWith(NPAT.NAMESPACE)) {
+                    log.warn("Trust state bootstrap: unexpected pointer IRI {}", iri);
+                    return;
+                }
+                String hash = iri.substring(NPAT.NAMESPACE.length());
+                if (hash.isEmpty()) {
+                    log.warn("Trust state bootstrap: pointer IRI has empty hash suffix");
+                    return;
+                }
+                TrustStateRegistry.get().setCurrentHash(hash);
+                log.info("Trust state bootstrap: seeded current hash {}", hash);
+            }
+        } catch (Exception ex) {
+            log.info("Trust state bootstrap: failed to read pointer: {}", ex.toString());
+        }
+    }
+
+    /**
      * Called when registry-poll metadata is fetched. Compares the hash to the
      * locally-tracked one and, if different, fetches the snapshot and
      * materializes it into the {@code trust} repo.

--- a/src/main/java/com/knowledgepixels/query/TrustStateRegistry.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateRegistry.java
@@ -1,0 +1,68 @@
+package com.knowledgepixels.query;
+
+import java.util.Optional;
+
+/**
+ * In-memory tracker for the currently-known trust state hash.
+ *
+ * <p>This is the small bit of mutable state shared between the polling code
+ * (which detects when the registry advertises a new {@code trustStateHash})
+ * and the materialization code (which writes the corresponding snapshot into
+ * the {@code trust} repository's named graph).
+ *
+ * <p>Authoritative state lives in the {@code trust} RDF4J repository
+ * ({@code npa:thisRepo npa:hasCurrentTrustState …}); this class is a
+ * convenience cache so the polling code can do an O(1) equality check on
+ * each tick without hitting RDF4J. The cache is updated only after a
+ * successful materialization commits.
+ *
+ * <p>See {@code doc/plan-trust-state-repos.md} for the full design.
+ */
+public class TrustStateRegistry {
+
+    private static TrustStateRegistry instance;
+
+    /**
+     * Returns the singleton instance.
+     *
+     * @return the singleton instance
+     */
+    public static TrustStateRegistry get() {
+        if (instance == null) {
+            instance = new TrustStateRegistry();
+        }
+        return instance;
+    }
+
+    private String currentHash;
+
+    private TrustStateRegistry() {
+    }
+
+    /**
+     * Returns the trust state hash that nanopub-query currently considers
+     * "loaded", or empty if no trust state has been materialized yet.
+     *
+     * @return the current trust state hash, or {@link Optional#empty()} if none
+     */
+    public synchronized Optional<String> getCurrentHash() {
+        return Optional.ofNullable(currentHash);
+    }
+
+    /**
+     * Records that the given trust state hash is now the current one. Should
+     * only be called after the corresponding snapshot has been successfully
+     * materialized and the pointer triple in the {@code trust} repo has been
+     * committed.
+     *
+     * @param hash the trust state hash that is now current; must be non-null and non-empty
+     * @throws IllegalArgumentException if the hash is null or empty
+     */
+    public synchronized void setCurrentHash(String hash) {
+        if (hash == null || hash.isEmpty()) {
+            throw new IllegalArgumentException("Trust state hash must be non-null and non-empty");
+        }
+        this.currentHash = hash;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/TrustStateSnapshot.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateSnapshot.java
@@ -38,23 +38,27 @@ public record TrustStateSnapshot(
      * exposes; consumers (e.g. authority queries) decide which {@code status}
      * values count as "approved".
      *
+     * <p>{@code pathCount}, {@code ratio}, and {@code quota} can be {@code null}
+     * for accounts with {@code status == "skipped"} (trust calculation rejected
+     * them, so those stats aren't meaningful). Boxed types preserve that.
+     *
      * @param pubkey hex-encoded public key
      * @param agent agent IRI (typically an ORCID, but any IRI is allowed)
      * @param status one of the registry's {@code EntryStatus} values
      *               (e.g. {@code "loaded"}, {@code "toLoad"}, {@code "skipped"})
      * @param depth steps from the trust seed
-     * @param pathCount number of independent trust paths
-     * @param ratio aggregated trust score
-     * @param quota allocated upload quota
+     * @param pathCount number of independent trust paths, or {@code null} for skipped accounts
+     * @param ratio aggregated trust score, or {@code null} for skipped accounts
+     * @param quota allocated upload quota, or {@code null} for skipped accounts
      */
     public record AccountEntry(
             String pubkey,
             String agent,
             String status,
-            int depth,
-            int pathCount,
-            double ratio,
-            long quota
+            Integer depth,
+            Integer pathCount,
+            Double ratio,
+            Long quota
     ) {}
 
     /**
@@ -106,7 +110,7 @@ public record TrustStateSnapshot(
                     a.getInteger("depth"),
                     a.getInteger("pathCount"),
                     a.getDouble("ratio"),
-                    unwrapLong(a, "quota")
+                    unwrapLongNullable(a, "quota")
             ));
         }
 
@@ -123,14 +127,26 @@ public record TrustStateSnapshot(
     }
 
     /**
-     * Reads a long-typed field, transparently handling MongoDB extended JSON
-     * ({@code {"$numberLong": "..."}}) as well as plain numeric / string forms.
+     * Reads a required long-typed field, transparently handling MongoDB
+     * extended JSON ({@code {"$numberLong": "..."}}) as well as plain numeric
+     * or string forms. Throws if the field is missing or null.
      */
     private static long unwrapLong(JsonObject obj, String key) {
-        Object v = obj.getValue(key);
+        Long v = unwrapLongNullable(obj, key);
         if (v == null) {
             throw new IllegalArgumentException("Trust state envelope is missing required field: " + key);
         }
+        return v;
+    }
+
+    /**
+     * Reads an optional long-typed field, returning {@code null} if the field
+     * is absent or its value is JSON {@code null}. Same extended-JSON handling
+     * as {@link #unwrapLong(JsonObject, String)}.
+     */
+    private static Long unwrapLongNullable(JsonObject obj, String key) {
+        Object v = obj.getValue(key);
+        if (v == null) return null;
         if (v instanceof Number n) return n.longValue();
         if (v instanceof JsonObject j) {
             String s = j.getString("$numberLong");

--- a/src/main/java/com/knowledgepixels/query/TrustStateSnapshot.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateSnapshot.java
@@ -1,0 +1,143 @@
+package com.knowledgepixels.query;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Parsed envelope of a {@code /trust-state/<hash>.json} response from the
+ * registry. Immutable; produced by {@link #parse(String)}.
+ *
+ * <p>The {@code trustStateCounter} field arrives as MongoDB extended JSON
+ * (e.g. {@code {"$numberLong": "1"}}) when the registry's serializer chooses
+ * to wrap a long. The parser handles either wrapped or plain numeric form.
+ *
+ * <p>The {@code createdAt} field uses Java's {@code ZonedDateTime.toString()}
+ * shape — ISO-8601 plus an optional {@code [Etc/UTC]} zone bracket — which
+ * {@link ZonedDateTime#parse(CharSequence)} reads natively.
+ *
+ * @param trustStateHash the hash advertised by the registry for this snapshot
+ * @param trustStateCounter monotonic counter; matches the registry's value
+ * @param createdAt when the registry committed this snapshot
+ * @param accounts one entry per non-{@code "$"} account in the trust graph
+ */
+public record TrustStateSnapshot(
+        String trustStateHash,
+        long trustStateCounter,
+        Instant createdAt,
+        List<AccountEntry> accounts
+) {
+
+    /**
+     * One account in a trust state snapshot. Mirrors the fields the registry
+     * exposes; consumers (e.g. authority queries) decide which {@code status}
+     * values count as "approved".
+     *
+     * @param pubkey hex-encoded public key
+     * @param agent agent IRI (typically an ORCID, but any IRI is allowed)
+     * @param status one of the registry's {@code EntryStatus} values
+     *               (e.g. {@code "loaded"}, {@code "toLoad"}, {@code "skipped"})
+     * @param depth steps from the trust seed
+     * @param pathCount number of independent trust paths
+     * @param ratio aggregated trust score
+     * @param quota allocated upload quota
+     */
+    public record AccountEntry(
+            String pubkey,
+            String agent,
+            String status,
+            int depth,
+            int pathCount,
+            double ratio,
+            long quota
+    ) {}
+
+    /**
+     * Parses a {@code /trust-state/<hash>.json} envelope from its JSON
+     * serialization. Throws {@link IllegalArgumentException} if the JSON is
+     * malformed or missing required fields.
+     *
+     * @param json the response body as a string
+     * @return the parsed snapshot
+     * @throws IllegalArgumentException if parsing fails
+     */
+    public static TrustStateSnapshot parse(String json) {
+        JsonObject obj;
+        try {
+            obj = new JsonObject(json);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Trust state envelope is not valid JSON", ex);
+        }
+
+        String hash = requireString(obj, "trustStateHash");
+        long counter = unwrapLong(obj, "trustStateCounter");
+
+        String rawCreatedAt = requireString(obj, "createdAt");
+        Instant createdAt;
+        try {
+            createdAt = ZonedDateTime.parse(rawCreatedAt).toInstant();
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(
+                    "Cannot parse createdAt as ZonedDateTime: " + rawCreatedAt, ex);
+        }
+
+        JsonArray accountsArray = obj.getJsonArray("accounts");
+        if (accountsArray == null) {
+            throw new IllegalArgumentException("Trust state envelope is missing 'accounts' array");
+        }
+        List<AccountEntry> accounts = new ArrayList<>(accountsArray.size());
+        for (int i = 0; i < accountsArray.size(); i++) {
+            JsonObject a;
+            try {
+                a = accountsArray.getJsonObject(i);
+            } catch (ClassCastException ex) {
+                throw new IllegalArgumentException(
+                        "Trust state account entry " + i + " is not a JSON object", ex);
+            }
+            accounts.add(new AccountEntry(
+                    requireString(a, "pubkey"),
+                    requireString(a, "agent"),
+                    requireString(a, "status"),
+                    a.getInteger("depth"),
+                    a.getInteger("pathCount"),
+                    a.getDouble("ratio"),
+                    unwrapLong(a, "quota")
+            ));
+        }
+
+        return new TrustStateSnapshot(hash, counter, createdAt,
+                Collections.unmodifiableList(accounts));
+    }
+
+    private static String requireString(JsonObject obj, String key) {
+        String s = obj.getString(key);
+        if (s == null) {
+            throw new IllegalArgumentException("Trust state envelope is missing required field: " + key);
+        }
+        return s;
+    }
+
+    /**
+     * Reads a long-typed field, transparently handling MongoDB extended JSON
+     * ({@code {"$numberLong": "..."}}) as well as plain numeric / string forms.
+     */
+    private static long unwrapLong(JsonObject obj, String key) {
+        Object v = obj.getValue(key);
+        if (v == null) {
+            throw new IllegalArgumentException("Trust state envelope is missing required field: " + key);
+        }
+        if (v instanceof Number n) return n.longValue();
+        if (v instanceof JsonObject j) {
+            String s = j.getString("$numberLong");
+            if (s != null) return Long.parseLong(s);
+        }
+        if (v instanceof String s) return Long.parseLong(s);
+        throw new IllegalArgumentException("Cannot unwrap " + key + " as long: " + v);
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/vocabulary/NPAA.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/NPAA.java
@@ -1,0 +1,36 @@
+package com.knowledgepixels.query.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
+import org.nanopub.vocabulary.VocabUtils;
+
+/**
+ * Namespace declaration for account-state IRIs used in nanopub-query.
+ *
+ * <p>Each account entry in a mirrored trust state is identified by
+ * {@code npaa:<accountStateHash>}, expanded from
+ * {@code http://purl.org/nanopub/admin/accountstate/}. The hash is
+ * {@code SHA-256(trustStateHash + "|" + pubkey + "|" + agent)}, so the IRI
+ * is stable within a snapshot and different across snapshots.
+ */
+public class NPAA {
+
+    public static final String NAMESPACE = "http://purl.org/nanopub/admin/accountstate/";
+    public static final String PREFIX = "npaa";
+    public static final Namespace NS = VocabUtils.createNamespace(PREFIX, NAMESPACE);
+
+    private NPAA() {
+    }
+
+    /**
+     * Mints the account-state IRI for the given hash.
+     *
+     * @param accountStateHash SHA-256 hex of the composite
+     *                         {@code trustStateHash + "|" + pubkey + "|" + agent}
+     * @return the IRI {@code npaa:<accountStateHash>}
+     */
+    public static IRI forHash(String accountStateHash) {
+        return VocabUtils.createIRI(NAMESPACE, accountStateHash);
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/vocabulary/NPAT.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/NPAT.java
@@ -1,0 +1,33 @@
+package com.knowledgepixels.query.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
+import org.nanopub.vocabulary.VocabUtils;
+
+/**
+ * Namespace declaration for trust-state IRIs used in nanopub-query.
+ *
+ * <p>Each mirrored trust state is identified (and its named graph named) by
+ * {@code npat:<trustStateHash>}, expanded from
+ * {@code http://purl.org/nanopub/admin/truststate/}.
+ */
+public class NPAT {
+
+    public static final String NAMESPACE = "http://purl.org/nanopub/admin/truststate/";
+    public static final String PREFIX = "npat";
+    public static final Namespace NS = VocabUtils.createNamespace(PREFIX, NAMESPACE);
+
+    private NPAT() {
+    }
+
+    /**
+     * Mints the trust-state IRI for the given hash.
+     *
+     * @param trustStateHash 64-hex-char hash advertised by the registry
+     * @return the IRI {@code npat:<trustStateHash>}
+     */
+    public static IRI forHash(String trustStateHash) {
+        return VocabUtils.createIRI(NAMESPACE, trustStateHash);
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/query/JellyNanopubLoaderTest.java
+++ b/src/test/java/com/knowledgepixels/query/JellyNanopubLoaderTest.java
@@ -12,7 +12,7 @@ class JellyNanopubLoaderTest {
     @Test
     void loadInitialWithAfterGreater() {
         try (MockedStatic<JellyNanopubLoader> mockedJellyLoader = mockStatic(JellyNanopubLoader.class, CALLS_REAL_METHODS)) {
-            mockedJellyLoader.when(JellyNanopubLoader::fetchRegistryMetadata).thenReturn(new RegistryMetadata(5L, null, null, null, null, null));
+            mockedJellyLoader.when(JellyNanopubLoader::fetchRegistryMetadata).thenReturn(new RegistryMetadata(5L, null, null, null, null, null, null));
             JellyNanopubLoader.loadInitial(10L);
             mockedJellyLoader.verify(() -> JellyNanopubLoader.loadBatch(anyLong(), any(LoadingType.class)), never());
         }
@@ -22,7 +22,7 @@ class JellyNanopubLoaderTest {
     @Test
     void loadInitialWithException() {
         try (MockedStatic<JellyNanopubLoader> mockedJellyLoader = mockStatic(JellyNanopubLoader.class, CALLS_REAL_METHODS)) {
-            mockedJellyLoader.when(JellyNanopubLoader::fetchRegistryMetadata).thenReturn(new RegistryMetadata(10L, null, null, null, null, null));
+            mockedJellyLoader.when(JellyNanopubLoader::fetchRegistryMetadata).thenReturn(new RegistryMetadata(10L, null, null, null, null, null, null));
             // if loadBatch is mocked then the lastCommittedCounter is never increased therefore there is an infinite loop
             mockedJellyLoader.when(() -> JellyNanopubLoader.loadBatch(anyLong(), any(LoadingType.class))).thenThrow(new RuntimeException("This is just an example exception"));
 

--- a/src/test/java/com/knowledgepixels/query/TrustStateLoaderTest.java
+++ b/src/test/java/com/knowledgepixels/query/TrustStateLoaderTest.java
@@ -49,4 +49,48 @@ class TrustStateLoaderTest {
         assertEquals("abc123", TrustStateRegistry.get().getCurrentHash().orElseThrow());
     }
 
+    @Test
+    void accountStateHash_isDeterministicOverSameInputs() {
+        TrustStateSnapshot.AccountEntry a = new TrustStateSnapshot.AccountEntry(
+                "pk1", "https://orcid.org/0000-0001-5118-256X", "loaded",
+                1, 1, 0.008, 100000);
+        String h1 = TrustStateLoader.accountStateHash("trustA", a);
+        String h2 = TrustStateLoader.accountStateHash("trustA", a);
+        assertEquals(h1, h2);
+        // Known SHA-256 hex length
+        assertEquals(64, h1.length());
+    }
+
+    @Test
+    void accountStateHash_differsAcrossTrustStates() {
+        // Same (pubkey, agent) under different trust states → different IRIs (by design).
+        TrustStateSnapshot.AccountEntry a = new TrustStateSnapshot.AccountEntry(
+                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000);
+        String h1 = TrustStateLoader.accountStateHash("trustA", a);
+        String h2 = TrustStateLoader.accountStateHash("trustB", a);
+        org.junit.jupiter.api.Assertions.assertNotEquals(h1, h2);
+    }
+
+    @Test
+    void accountStateHash_differsAcrossAgents() {
+        TrustStateSnapshot.AccountEntry a1 = new TrustStateSnapshot.AccountEntry(
+                "pk1", "https://example.org/agentA", "loaded", 1, 1, 0.5, 1000);
+        TrustStateSnapshot.AccountEntry a2 = new TrustStateSnapshot.AccountEntry(
+                "pk1", "https://example.org/agentB", "loaded", 1, 1, 0.5, 1000);
+        org.junit.jupiter.api.Assertions.assertNotEquals(
+                TrustStateLoader.accountStateHash("trustA", a1),
+                TrustStateLoader.accountStateHash("trustA", a2));
+    }
+
+    @Test
+    void accountStateHash_differsAcrossPubkeys() {
+        TrustStateSnapshot.AccountEntry a1 = new TrustStateSnapshot.AccountEntry(
+                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000);
+        TrustStateSnapshot.AccountEntry a2 = new TrustStateSnapshot.AccountEntry(
+                "pk2", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000);
+        org.junit.jupiter.api.Assertions.assertNotEquals(
+                TrustStateLoader.accountStateHash("trustA", a1),
+                TrustStateLoader.accountStateHash("trustA", a2));
+    }
+
 }

--- a/src/test/java/com/knowledgepixels/query/TrustStateLoaderTest.java
+++ b/src/test/java/com/knowledgepixels/query/TrustStateLoaderTest.java
@@ -83,6 +83,12 @@ class TrustStateLoaderTest {
     }
 
     @Test
+    void effectiveRetention_defaultsTo100() {
+        // No env var set → default.
+        assertEquals(100, TrustStateLoader.effectiveRetention());
+    }
+
+    @Test
     void accountStateHash_differsAcrossPubkeys() {
         TrustStateSnapshot.AccountEntry a1 = new TrustStateSnapshot.AccountEntry(
                 "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000);

--- a/src/test/java/com/knowledgepixels/query/TrustStateLoaderTest.java
+++ b/src/test/java/com/knowledgepixels/query/TrustStateLoaderTest.java
@@ -53,7 +53,7 @@ class TrustStateLoaderTest {
     void accountStateHash_isDeterministicOverSameInputs() {
         TrustStateSnapshot.AccountEntry a = new TrustStateSnapshot.AccountEntry(
                 "pk1", "https://orcid.org/0000-0001-5118-256X", "loaded",
-                1, 1, 0.008, 100000);
+                1, 1, 0.008, 100000L);
         String h1 = TrustStateLoader.accountStateHash("trustA", a);
         String h2 = TrustStateLoader.accountStateHash("trustA", a);
         assertEquals(h1, h2);
@@ -65,7 +65,7 @@ class TrustStateLoaderTest {
     void accountStateHash_differsAcrossTrustStates() {
         // Same (pubkey, agent) under different trust states → different IRIs (by design).
         TrustStateSnapshot.AccountEntry a = new TrustStateSnapshot.AccountEntry(
-                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000);
+                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000L);
         String h1 = TrustStateLoader.accountStateHash("trustA", a);
         String h2 = TrustStateLoader.accountStateHash("trustB", a);
         org.junit.jupiter.api.Assertions.assertNotEquals(h1, h2);
@@ -74,9 +74,9 @@ class TrustStateLoaderTest {
     @Test
     void accountStateHash_differsAcrossAgents() {
         TrustStateSnapshot.AccountEntry a1 = new TrustStateSnapshot.AccountEntry(
-                "pk1", "https://example.org/agentA", "loaded", 1, 1, 0.5, 1000);
+                "pk1", "https://example.org/agentA", "loaded", 1, 1, 0.5, 1000L);
         TrustStateSnapshot.AccountEntry a2 = new TrustStateSnapshot.AccountEntry(
-                "pk1", "https://example.org/agentB", "loaded", 1, 1, 0.5, 1000);
+                "pk1", "https://example.org/agentB", "loaded", 1, 1, 0.5, 1000L);
         org.junit.jupiter.api.Assertions.assertNotEquals(
                 TrustStateLoader.accountStateHash("trustA", a1),
                 TrustStateLoader.accountStateHash("trustA", a2));
@@ -91,9 +91,9 @@ class TrustStateLoaderTest {
     @Test
     void accountStateHash_differsAcrossPubkeys() {
         TrustStateSnapshot.AccountEntry a1 = new TrustStateSnapshot.AccountEntry(
-                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000);
+                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000L);
         TrustStateSnapshot.AccountEntry a2 = new TrustStateSnapshot.AccountEntry(
-                "pk2", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000);
+                "pk2", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000L);
         org.junit.jupiter.api.Assertions.assertNotEquals(
                 TrustStateLoader.accountStateHash("trustA", a1),
                 TrustStateLoader.accountStateHash("trustA", a2));

--- a/src/test/java/com/knowledgepixels/query/TrustStateLoaderTest.java
+++ b/src/test/java/com/knowledgepixels/query/TrustStateLoaderTest.java
@@ -1,0 +1,52 @@
+package com.knowledgepixels.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TrustStateLoaderTest {
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException, IllegalAccessException {
+        // Reset the registry singleton between tests so the "current hash"
+        // doesn't leak across test cases.
+        Field instance = TrustStateRegistry.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+    }
+
+    @Test
+    void maybeUpdate_isNoOpForNullHash() {
+        // Should not throw, should not change registry state.
+        TrustStateLoader.maybeUpdate(null);
+        assertFalse(TrustStateRegistry.get().getCurrentHash().isPresent());
+    }
+
+    @Test
+    void maybeUpdate_isNoOpForEmptyHash() {
+        TrustStateLoader.maybeUpdate("");
+        assertFalse(TrustStateRegistry.get().getCurrentHash().isPresent());
+    }
+
+    @Test
+    void maybeUpdate_doesNotChangeRegistryState_inStubVersion() {
+        // The stub only logs — it doesn't actually materialize anything,
+        // so the registry's currentHash stays empty even after detection.
+        TrustStateLoader.maybeUpdate("abc123");
+        assertFalse(TrustStateRegistry.get().getCurrentHash().isPresent());
+    }
+
+    @Test
+    void maybeUpdate_isNoOpWhenHashEqualsCurrent() {
+        // Pre-seed the registry as if a previous materialization had set this.
+        TrustStateRegistry.get().setCurrentHash("abc123");
+        // Same hash → no-op (no exception, no change).
+        TrustStateLoader.maybeUpdate("abc123");
+        assertEquals("abc123", TrustStateRegistry.get().getCurrentHash().orElseThrow());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/query/TrustStateRegistryTest.java
+++ b/src/test/java/com/knowledgepixels/query/TrustStateRegistryTest.java
@@ -1,0 +1,62 @@
+package com.knowledgepixels.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TrustStateRegistryTest {
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException, IllegalAccessException {
+        // Reset the singleton so each test starts fresh.
+        Field instance = TrustStateRegistry.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+    }
+
+    @Test
+    void getCurrentHash_isEmptyBeforeAnythingIsSet() {
+        assertFalse(TrustStateRegistry.get().getCurrentHash().isPresent());
+    }
+
+    @Test
+    void setCurrentHash_isReflectedByGetCurrentHash() {
+        TrustStateRegistry.get().setCurrentHash("abc123");
+        assertTrue(TrustStateRegistry.get().getCurrentHash().isPresent());
+        assertEquals("abc123", TrustStateRegistry.get().getCurrentHash().get());
+    }
+
+    @Test
+    void setCurrentHash_overwritesPreviousValue() {
+        TrustStateRegistry.get().setCurrentHash("first");
+        TrustStateRegistry.get().setCurrentHash("second");
+        assertEquals("second", TrustStateRegistry.get().getCurrentHash().get());
+    }
+
+    @Test
+    void setCurrentHash_rejectsNull() {
+        assertThrows(IllegalArgumentException.class,
+                () -> TrustStateRegistry.get().setCurrentHash(null));
+    }
+
+    @Test
+    void setCurrentHash_rejectsEmpty() {
+        assertThrows(IllegalArgumentException.class,
+                () -> TrustStateRegistry.get().setCurrentHash(""));
+    }
+
+    @Test
+    void getReturnsSameInstanceAcrossCalls() {
+        TrustStateRegistry first = TrustStateRegistry.get();
+        TrustStateRegistry second = TrustStateRegistry.get();
+        assertSame(first, second);
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/query/TrustStateSnapshotTest.java
+++ b/src/test/java/com/knowledgepixels/query/TrustStateSnapshotTest.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.query;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -143,6 +144,39 @@ class TrustStateSnapshotTest {
                 "\"pubkey\": \"edf7482308e4e59fc3f658fbd1fe2a2a9a538de3adce2ec7ad6c5f804461d310\",",
                 "");
         assertThrows(IllegalArgumentException.class, () -> TrustStateSnapshot.parse(json));
+    }
+
+    @Test
+    void parse_acceptsSkippedAccountWithNullStats() {
+        // Accounts rejected by trust calculation (status=skipped) have null
+        // pathCount / ratio / quota. The parser must accept this and pass
+        // the nulls through so materialization can choose to skip those
+        // triples rather than inventing zero values.
+        String json = """
+                {
+                  "trustStateHash": "abc",
+                  "trustStateCounter": {"$numberLong": "1"},
+                  "createdAt": "2026-04-15T14:16:16Z[Etc/UTC]",
+                  "accounts": [
+                    {
+                      "pubkey": "a5c5aa...",
+                      "agent": "https://orcid.org/0000-0001-8327-0142",
+                      "status": "skipped",
+                      "depth": 2,
+                      "pathCount": null,
+                      "ratio": null,
+                      "quota": null
+                    }
+                  ]
+                }
+                """;
+        TrustStateSnapshot s = TrustStateSnapshot.parse(json);
+        TrustStateSnapshot.AccountEntry a = s.accounts().get(0);
+        assertEquals("skipped", a.status());
+        assertEquals(2, a.depth());
+        assertNull(a.pathCount());
+        assertNull(a.ratio());
+        assertNull(a.quota());
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/query/TrustStateSnapshotTest.java
+++ b/src/test/java/com/knowledgepixels/query/TrustStateSnapshotTest.java
@@ -1,0 +1,158 @@
+package com.knowledgepixels.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class TrustStateSnapshotTest {
+
+    /** Mirrors the live registry response shape: trustStateCounter is BSON-wrapped, plain
+     *  ZonedDateTime.toString() format for createdAt (with [Etc/UTC] zone bracket),
+     *  and a couple of representative account entries. */
+    private static final String FIXTURE = """
+            {
+              "trustStateHash": "abc123",
+              "trustStateCounter": {"$numberLong": "18"},
+              "createdAt": "2026-04-15T14:16:16.112094241Z[Etc/UTC]",
+              "accounts": [
+                {
+                  "pubkey": "edf7482308e4e59fc3f658fbd1fe2a2a9a538de3adce2ec7ad6c5f804461d310",
+                  "agent": "https://orcid.org/0000-0001-5118-256X",
+                  "status": "toLoad",
+                  "depth": 1,
+                  "pathCount": 1,
+                  "ratio": 0.008181818181818182,
+                  "quota": 100000
+                },
+                {
+                  "pubkey": "1162349fdeaf431e71ab55898cb2a425b971d466150c2aa5b3c1beb498045a37",
+                  "agent": "https://orcid.org/0000-0002-1267-0234",
+                  "status": "loaded",
+                  "depth": 2,
+                  "pathCount": 3,
+                  "ratio": 0.0024,
+                  "quota": 24000
+                }
+              ]
+            }
+            """;
+
+    @Test
+    void parse_extractsEnvelopeFields() {
+        TrustStateSnapshot s = TrustStateSnapshot.parse(FIXTURE);
+        assertEquals("abc123", s.trustStateHash());
+        assertEquals(18L, s.trustStateCounter());
+        // Reproduce the exact instant: 2026-04-15T14:16:16.112094241Z
+        assertEquals(Instant.parse("2026-04-15T14:16:16.112094241Z"), s.createdAt());
+        assertEquals(2, s.accounts().size());
+    }
+
+    @Test
+    void parse_unwrapsBsonNumberLongCounter() {
+        // The {"$numberLong": "18"} wrap is what MongoDB extended JSON looks like.
+        TrustStateSnapshot s = TrustStateSnapshot.parse(FIXTURE);
+        assertEquals(18L, s.trustStateCounter());
+    }
+
+    @Test
+    void parse_acceptsPlainNumericCounter() {
+        // If MongoDB serializes the long as plain JSON (smaller values, future change), still works.
+        String json = FIXTURE.replace("{\"$numberLong\": \"18\"}", "18");
+        TrustStateSnapshot s = TrustStateSnapshot.parse(json);
+        assertEquals(18L, s.trustStateCounter());
+    }
+
+    @Test
+    void parse_extractsAccountEntryFields() {
+        TrustStateSnapshot s = TrustStateSnapshot.parse(FIXTURE);
+        TrustStateSnapshot.AccountEntry first = s.accounts().get(0);
+        assertEquals("edf7482308e4e59fc3f658fbd1fe2a2a9a538de3adce2ec7ad6c5f804461d310", first.pubkey());
+        assertEquals("https://orcid.org/0000-0001-5118-256X", first.agent());
+        assertEquals("toLoad", first.status());
+        assertEquals(1, first.depth());
+        assertEquals(1, first.pathCount());
+        assertEquals(0.008181818181818182, first.ratio(), 1e-15);
+        assertEquals(100000L, first.quota());
+
+        TrustStateSnapshot.AccountEntry second = s.accounts().get(1);
+        assertEquals("loaded", second.status());
+        assertEquals(2, second.depth());
+        assertEquals(3, second.pathCount());
+        assertEquals(24000L, second.quota());
+    }
+
+    @Test
+    void parse_returnsUnmodifiableAccountList() {
+        TrustStateSnapshot s = TrustStateSnapshot.parse(FIXTURE);
+        assertThrows(UnsupportedOperationException.class,
+                () -> s.accounts().add(new TrustStateSnapshot.AccountEntry(
+                        "x", "y", "z", 0, 0, 0.0, 0L)));
+    }
+
+    @Test
+    void parse_emptyAccountsArrayIsValid() {
+        String json = """
+                {
+                  "trustStateHash": "abc",
+                  "trustStateCounter": {"$numberLong": "1"},
+                  "createdAt": "2026-04-15T14:16:16Z[Etc/UTC]",
+                  "accounts": []
+                }""";
+        TrustStateSnapshot s = TrustStateSnapshot.parse(json);
+        assertTrue(s.accounts().isEmpty());
+    }
+
+    @Test
+    void parse_throwsOnMalformedJson() {
+        assertThrows(IllegalArgumentException.class,
+                () -> TrustStateSnapshot.parse("{not-valid"));
+    }
+
+    @Test
+    void parse_throwsOnMissingTrustStateHash() {
+        String json = FIXTURE.replace("\"trustStateHash\": \"abc123\",", "");
+        assertThrows(IllegalArgumentException.class, () -> TrustStateSnapshot.parse(json));
+    }
+
+    @Test
+    void parse_throwsOnMissingAccountsArray() {
+        String json = """
+                {
+                  "trustStateHash": "abc",
+                  "trustStateCounter": {"$numberLong": "1"},
+                  "createdAt": "2026-04-15T14:16:16Z[Etc/UTC]"
+                }""";
+        assertThrows(IllegalArgumentException.class, () -> TrustStateSnapshot.parse(json));
+    }
+
+    @Test
+    void parse_throwsOnUnparseableTimestamp() {
+        String json = FIXTURE.replace(
+                "\"createdAt\": \"2026-04-15T14:16:16.112094241Z[Etc/UTC]\"",
+                "\"createdAt\": \"not-a-date\"");
+        assertThrows(IllegalArgumentException.class, () -> TrustStateSnapshot.parse(json));
+    }
+
+    @Test
+    void parse_throwsOnMissingAccountField() {
+        String json = FIXTURE.replace(
+                "\"pubkey\": \"edf7482308e4e59fc3f658fbd1fe2a2a9a538de3adce2ec7ad6c5f804461d310\",",
+                "");
+        assertThrows(IllegalArgumentException.class, () -> TrustStateSnapshot.parse(json));
+    }
+
+    @Test
+    void parse_acceptsCreatedAtWithoutZoneBracket() {
+        // Plain ISO-8601 with offset is also accepted by ZonedDateTime.parse.
+        String json = FIXTURE.replace(
+                "\"createdAt\": \"2026-04-15T14:16:16.112094241Z[Etc/UTC]\"",
+                "\"createdAt\": \"2026-04-15T14:16:16.112094241Z\"");
+        TrustStateSnapshot s = TrustStateSnapshot.parse(json);
+        assertEquals(Instant.parse("2026-04-15T14:16:16.112094241Z"), s.createdAt());
+    }
+
+}


### PR DESCRIPTION
## Summary

Implements [#65](https://github.com/knowledgepixels/nanopub-query/issues/65) — mirrors the registry's trust state into a single `trust` RDF4J repository. Each mirrored state lives in its own named graph keyed by `trustStateHash`, with a current-state pointer in `npa:graph`. Detection piggybacks on the existing 2-second `loadUpdates` poll. Materialization, pointer swap, and retention pruning all happen in one serializable transaction. Up to 100 historical states are retained (matching the registry's own retention).

See [`doc/plan-trust-state-repos.md`](https://github.com/knowledgepixels/nanopub-query/blob/main/doc/plan-trust-state-repos.md) for the full design.

Depends on registry endpoint `/trust-state/<hash>.json` (knowledgepixels/nanopub-registry#107, implemented in knowledgepixels/nanopub-registry#108).

- [x] **Step 1.** `TrustStateRegistry` skeleton + unit tests
- [x] **Step 2.** Extend `RegistryMetadata` with `trustStateHash`; wire hash-change detection into the existing `loadUpdates` poll
- [x] **Step 3.** Snapshot fetch + envelope parsing
- [x] **Step 4.** Materialization into the `trust` repo using the named-graph schema (single transaction including pointer swap)
- [x] **Step 5.** Retention pruning (keep last 100 states, configurable via `TRUST_STATE_LOCAL_RETENTION`)
- [x] **Step 6.** Bootstrap from existing pointer on startup

## Test plan

- [x] Unit tests (135 total; 17 new covering registry singleton, loader no-ops, snapshot parsing, account-state hashing, retention default)
- [ ] End-to-end against `localhost:9292` (a local nanopub-registry with #107/#108 deployed): observe "Materialized trust state <hash>" log within ~2 s of startup; inspect workbench `trust` repo for the named graph and pointer
- [ ] Trigger a registry-side rollover, verify nanopub-query picks up the new hash within ~2 s, adds a new graph, swaps the pointer, prunes any state beyond retention

🤖 Generated with [Claude Code](https://claude.com/claude-code)