### PR TITLE
refactor: spaces foundation — vocab + drop per-space repos (#62)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -61,7 +61,6 @@ public class NanopubLoader {
     private Statement pubkeyStatement, pubkeyStatementX;
     private List<String> notes = new ArrayList<>();
     private boolean aborted = false;
-    private Set<String> detectedSpaceRefs = Collections.emptySet();
     private static final Logger log = LoggerFactory.getLogger(NanopubLoader.class);
 
 
@@ -237,7 +236,9 @@ public class NanopubLoader {
             // @ADMIN-TRIPLE-TABLE@ NANOPUB, npx:hasNanopubType, NANOPUB_TYPE, npa:graph, meta, type of NANOPUB
             literalFilter += " _type_" + Utils.createHash(typeIri);
         }
-        detectedSpaceRefs = detectAndRegisterSpaces(np);
+        // Side-effecting call: populates SpaceRegistry as gen:Space-typed nanopubs flow through.
+        // Consumers of the registry (extraction, materialization) land in later steps of #62.
+        detectAndRegisterSpaces(np);
         String label = NanopubUtils.getLabel(np);
         if (label != null) {
             metaStatements.add(vf.createStatement(np.getUri(), RDFS.LABEL, vf.createLiteral(label), NPA.GRAPH));
@@ -343,9 +344,6 @@ public class NanopubLoader {
                 if (!typeIri.stringValue().matches("https?://.*")) continue;
                 runTask.accept(() -> loadNanopubToRepo(np.getUri(), allStatements, "type_" + Utils.createHash(typeIri)));
                 //			loadNanopubToRepo(np.getUri(), textStatements, "text-type_" + Utils.createHash(typeIri));
-            }
-            for (String spaceRef : detectedSpaceRefs) {
-                runTask.accept(() -> loadNanopubToRepo(np.getUri(), allStatements, "space_" + spaceRef));
             }
             //		for (IRI creatorIri : SimpleCreatorPattern.getCreators(np)) {
             //			// Exclude locally minted IRIs:
@@ -455,29 +453,17 @@ public class NanopubLoader {
                 if (repoStatus.isLoaded) {
                     log.info("Already loaded: {}", npId);
                 } else {
-                    // Space repos can have nanopubs removed (via invalidation/unloading), so a
-                    // cumulative XOR checksum and count would drift after the first removal.
-                    // Mirror the last30d approach: skip checksum/count maintenance for these
-                    // repos. HAS_LOAD_NUMBER is still added as a presence marker so the
-                    // isLoaded check above remains effective on re-runs.
-                    boolean trackChecksum = !repoName.startsWith("space_");
-                    if (trackChecksum) {
-                        String newChecksum = NanopubUtils.updateXorChecksum(npId, repoStatus.checksum);
-                        conn.remove(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, null, NPA.GRAPH);
-                        conn.remove(NPA.THIS_REPO, NPA.HAS_NANOPUB_CHECKSUM, null, NPA.GRAPH);
-                        conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, vf.createLiteral(repoStatus.count + 1), NPA.GRAPH);
-                        // @ADMIN-TRIPLE-TABLE@ REPO, npa:hasNanopubCount, NANOPUB_COUNT, npa:graph, admin, number of nanopubs loaded
-                        conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_CHECKSUM, vf.createLiteral(newChecksum), NPA.GRAPH);
-                        // @ADMIN-TRIPLE-TABLE@ REPO, npa:hasNanopubChecksum, NANOPUB_CHECKSUM, npa:graph, admin, checksum of all loaded nanopubs (order-independent XOR checksum on trusty URIs in Base64 notation)
-                        conn.add(npId, NPA.HAS_LOAD_NUMBER, vf.createLiteral(repoStatus.count), NPA.GRAPH);
-                        // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadNumber, LOAD_NUMBER, npa:graph, admin, the sequential number at which this NANOPUB was loaded
-                        conn.add(npId, NPA.HAS_LOAD_CHECKSUM, vf.createLiteral(newChecksum), NPA.GRAPH);
-                        // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadChecksum, LOAD_CHECKSUM, npa:graph, admin, the checksum of all loaded nanopubs after loading the given NANOPUB
-                    } else {
-                        // Presence marker only — the numeric value is not meaningful for
-                        // repos that skip checksum/count tracking.
-                        conn.add(npId, NPA.HAS_LOAD_NUMBER, vf.createLiteral(0L), NPA.GRAPH);
-                    }
+                    String newChecksum = NanopubUtils.updateXorChecksum(npId, repoStatus.checksum);
+                    conn.remove(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, null, NPA.GRAPH);
+                    conn.remove(NPA.THIS_REPO, NPA.HAS_NANOPUB_CHECKSUM, null, NPA.GRAPH);
+                    conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, vf.createLiteral(repoStatus.count + 1), NPA.GRAPH);
+                    // @ADMIN-TRIPLE-TABLE@ REPO, npa:hasNanopubCount, NANOPUB_COUNT, npa:graph, admin, number of nanopubs loaded
+                    conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_CHECKSUM, vf.createLiteral(newChecksum), NPA.GRAPH);
+                    // @ADMIN-TRIPLE-TABLE@ REPO, npa:hasNanopubChecksum, NANOPUB_CHECKSUM, npa:graph, admin, checksum of all loaded nanopubs (order-independent XOR checksum on trusty URIs in Base64 notation)
+                    conn.add(npId, NPA.HAS_LOAD_NUMBER, vf.createLiteral(repoStatus.count), NPA.GRAPH);
+                    // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadNumber, LOAD_NUMBER, npa:graph, admin, the sequential number at which this NANOPUB was loaded
+                    conn.add(npId, NPA.HAS_LOAD_CHECKSUM, vf.createLiteral(newChecksum), NPA.GRAPH);
+                    // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadChecksum, LOAD_CHECKSUM, npa:graph, admin, the checksum of all loaded nanopubs after loading the given NANOPUB
                     conn.add(npId, NPA.HAS_LOAD_TIMESTAMP, vf.createLiteral(new Date()), NPA.GRAPH);
                     // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadTimestamp, LOAD_TIMESTAMP, npa:graph, admin, the time point at which this NANOPUB was loaded
                     conn.add(statements);
@@ -714,8 +700,10 @@ public class NanopubLoader {
      *
      * @param np the nanopub to inspect
      * @return the set of space refs registered from this nanopub (possibly empty);
-     *         the caller uses this to load the nanopub into the corresponding
-     *         {@code space_<spaceRef>} repositories
+     *         currently used by tests to assert detection behavior. Production
+     *         callers invoke this for its side effect on {@link SpaceRegistry};
+     *         downstream consumers (extraction, materialization) follow in later
+     *         steps of #62.
      */
     static Set<String> detectAndRegisterSpaces(Nanopub np) {
         boolean isSpaceTyped = false;

--- a/src/main/java/com/knowledgepixels/query/SpaceRegistry.java
+++ b/src/main/java/com/knowledgepixels/query/SpaceRegistry.java
@@ -13,12 +13,13 @@ import org.slf4j.LoggerFactory;
 /**
  * In-memory registry of known spaces. A <b>space ref</b> uniquely identifies a space
  * as the concatenation of its root nanopub's artifact code and the hash of its Space
- * IRI: {@code <rootNanopubId>_<SPACEIRIHASH>}. The space ref is used directly as the
- * suffix of the {@code space_<spaceRef>} RDF4J repository name.
+ * IRI: {@code <rootNanopubId>_<SPACEIRIHASH>}. Each space gets its own named graph
+ * {@code npas:<spaceRef>} in the shared {@code spaces} repo (see
+ * {@link com.knowledgepixels.query.vocabulary.NPAS}).
  *
  * <p>This skeleton only tracks what is needed to recognize space refs during nanopub
- * detection. Initial admin sets, role properties, and admin-repo persistence will be
- * added in later steps when they have a consumer. See
+ * detection. Role-property tracking, per-source-nanopub reverse index, and admin-repo
+ * persistence are added in later steps when they have a consumer. See
  * {@code doc/plan-space-repositories.md} for the full roadmap.
  */
 public class SpaceRegistry {

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -363,11 +363,6 @@ public class TripleStore {
                     conn.add(NPA.THIS_REPO, NPA.HAS_COVERAGE_ITEM, Utils.getObjectForHash(h), NPA.GRAPH);
                     conn.add(NPA.THIS_REPO, NPA.HAS_COVERAGE_HASH, vf.createLiteral(h), NPA.GRAPH);
                     conn.add(NPA.THIS_REPO, NPA.HAS_COVERAGE_FILTER, vf.createLiteral("_" + repoName), NPA.GRAPH);
-                } else if (repoName.startsWith("space_")) {
-                    // The space ref is the literal suffix of the repo name; no hash lookup needed.
-                    String spaceRef = repoName.substring("space_".length());
-                    conn.add(NPA.THIS_REPO, NPA.HAS_COVERAGE_ITEM, vf.createLiteral(spaceRef), NPA.GRAPH);
-                    conn.add(NPA.THIS_REPO, NPA.HAS_COVERAGE_FILTER, vf.createLiteral("_" + repoName), NPA.GRAPH);
                 }
                 conn.commit();
             }

--- a/src/main/java/com/knowledgepixels/query/vocabulary/NPAS.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/NPAS.java
@@ -1,0 +1,35 @@
+package com.knowledgepixels.query.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
+import org.nanopub.vocabulary.VocabUtils;
+
+/**
+ * Namespace declaration for per-space graph IRIs in the {@code spaces} repo.
+ *
+ * <p>Each space has its own named graph in the {@code spaces} repo, identified
+ * by {@code npas:<spaceRef>}, expanded from
+ * {@code http://purl.org/nanopub/admin/space/}. The space ref has the form
+ * {@code <rootNanopubId>_<SPACEIRIHASH>}; see
+ * {@link com.knowledgepixels.query.SpaceRegistry} for construction.
+ */
+public class NPAS {
+
+    public static final String NAMESPACE = "http://purl.org/nanopub/admin/space/";
+    public static final String PREFIX = "npas";
+    public static final Namespace NS = VocabUtils.createNamespace(PREFIX, NAMESPACE);
+
+    private NPAS() {
+    }
+
+    /**
+     * Mints the named-graph IRI for the given space ref.
+     *
+     * @param spaceRef the space ref of the form {@code <rootNanopubId>_<SPACEIRIHASH>}
+     * @return the IRI {@code npas:<spaceRef>}
+     */
+    public static IRI forSpaceRef(String spaceRef) {
+        return VocabUtils.createIRI(NAMESPACE, spaceRef);
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpaceAuthority.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpaceAuthority.java
@@ -1,0 +1,66 @@
+package com.knowledgepixels.query.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.nanopub.vocabulary.NPA;
+import org.nanopub.vocabulary.VocabUtils;
+
+/**
+ * IRIs in the {@code npa:} namespace used to materialize space-authority data
+ * into a space's graph in the {@code spaces} repo.
+ *
+ * <p>The shape is one {@link #ROLE_ASSIGNMENT} per
+ * {@code (agent, role, space)} tuple, linking via {@link #HAS_EVIDENCE} to one
+ * or more {@link #ROLE_ASSIGNMENT_EVIDENCE} objects, each carrying an
+ * {@link #EVIDENCE_KIND} ({@link #AUTHORITY_EVIDENCE} or {@link #SELF_EVIDENCE}),
+ * a {@link #VIA_NANOPUB} provenance pointer, and the {@link #VIA_PUBLISHER_AGENT}
+ * resolved at materialization time so consumers don't need to join the trust
+ * repo. Validated view displays use {@link #VALIDATED_VIEW_DISPLAY}.
+ *
+ * <p>See {@code doc/plan-space-repositories.md} for the full design.
+ */
+public class SpaceAuthority {
+
+    /** RDF type for an admin/maintainer/role assignment for a given (agent, role, space) tuple. */
+    public static final IRI ROLE_ASSIGNMENT = createIRI("RoleAssignment");
+
+    /** RDF type for an evidence record attached to a role assignment via {@link #HAS_EVIDENCE}. */
+    public static final IRI ROLE_ASSIGNMENT_EVIDENCE = createIRI("RoleAssignmentEvidence");
+
+    /** RDF type for a view-display nanopub whose publisher passes the view-display policy. */
+    public static final IRI VALIDATED_VIEW_DISPLAY = createIRI("ValidatedViewDisplay");
+
+    /** Links a {@link #ROLE_ASSIGNMENT} (or other authority record) to the space ref it applies to. */
+    public static final IRI FOR_SPACE = createIRI("forSpace");
+
+    /** Links a {@link #ROLE_ASSIGNMENT} to its role IRI (e.g. {@code gen:AdminRole}). */
+    public static final IRI ROLE = createIRI("role");
+
+    /** Links a {@link #ROLE_ASSIGNMENT} to the assigned-member agent IRI. */
+    public static final IRI AGENT = createIRI("agent");
+
+    /** Links a {@link #ROLE_ASSIGNMENT} to one of its {@link #ROLE_ASSIGNMENT_EVIDENCE} pieces. */
+    public static final IRI HAS_EVIDENCE = createIRI("hasEvidence");
+
+    /** Tags an evidence object with {@link #AUTHORITY_EVIDENCE} or {@link #SELF_EVIDENCE}. */
+    public static final IRI EVIDENCE_KIND = createIRI("evidenceKind");
+
+    /** Provenance pointer from an evidence object to the source nanopub URI. */
+    public static final IRI VIA_NANOPUB = createIRI("viaNanopub");
+
+    /** Resolved publisher agent for the source nanopub, computed against the trust state at materialization time. */
+    public static final IRI VIA_PUBLISHER_AGENT = createIRI("viaPublisherAgent");
+
+    /** Evidence-kind individual: the source nanopub's publisher resolves to an agent in the appropriate authority closure. */
+    public static final IRI AUTHORITY_EVIDENCE = createIRI("authorityEvidence");
+
+    /** Evidence-kind individual: the source nanopub's publisher resolves to the assigned-member agent. */
+    public static final IRI SELF_EVIDENCE = createIRI("selfEvidence");
+
+    private SpaceAuthority() {
+    }
+
+    private static IRI createIRI(String localName) {
+        return VocabUtils.createIRI(NPA.NAMESPACE, localName);
+    }
+
+}


### PR DESCRIPTION
## Summary

Pre-work for the next step of #62 (Space repositories). Aligns the codebase with the recently-revised plan (single `spaces` repo + named graph per space) so the upcoming extraction + materialization PRs have a clean foundation.

- New `vocabulary/NPAS.java` for per-space graph IRIs (`npas:<spaceRef>`, expanding `http://purl.org/nanopub/admin/space/`).
- New `vocabulary/SpaceAuthority.java` collecting the `npa:` predicates that authority materialization will emit (`RoleAssignment`, `RoleAssignmentEvidence`, `ValidatedViewDisplay`, plus the predicates and evidence-kind individuals).
- Drops the now-stale per-space repo machinery from #64: `TripleStore.initNewRepo` `space_` branch, `NanopubLoader` `space_<spaceRef>` loading loop and checksum-skip. `SpaceRegistry.detectAndRegisterSpaces` stays as a side-effecting call so the registry continues to pick up known spaces.

No functional change to consumers — there are no consumers of the removed `space_*` repos yet. After this lands, `gen:Space`-typed nanopubs still register in `SpaceRegistry`, but no per-space repo is created.

See `doc/plan-space-repositories.md` for the full design.

## Test plan

- [x] `mvn test` — 154/154 pass locally
- [x] CI green