### PR TITLE
feat: expand SpaceRegistry with role properties, source index, and persistence (#62)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -491,8 +491,11 @@ public class MainVerticle extends AbstractVerticle {
             TrustStateLoader.bootstrap();
 
             // Seed the SpaceRegistry from any persisted (spaceRef, spaceIri) pairs
-            // so previously-known spaces survive a restart.
+            // so previously-known spaces survive a restart, then catch up on any
+            // gen:Space-typed nanopubs that were already loaded before persistence
+            // was wired up (so existing deployments don't need a fresh DB).
             SpacesAdminStore.bootstrap(SpaceRegistry.get());
+            SpacesAdminStore.scanExistingSpaces(SpaceRegistry.get());
 
             // Start periodic nanopub loading
             log.info("Starting periodic nanopub loading...");

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -490,6 +490,10 @@ public class MainVerticle extends AbstractVerticle {
             // we already have.
             TrustStateLoader.bootstrap();
 
+            // Seed the SpaceRegistry from any persisted (spaceRef, spaceIri) pairs
+            // so previously-known spaces survive a restart.
+            SpacesAdminStore.bootstrap(SpaceRegistry.get());
+
             // Start periodic nanopub loading
             log.info("Starting periodic nanopub loading...");
             var executor = Executors.newSingleThreadScheduledExecutor();

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -724,7 +724,11 @@ public class NanopubLoader {
                 log.warn("Ignoring space {}: gen:hasRootDefinition target is not a trusty URI: {}", spaceIri, rootUri);
                 continue;
             }
-            spaceRefs.add(SpaceRegistry.get().registerSpace(rootNanopubId, spaceIri));
+            SpaceRegistry.Registration registration = SpaceRegistry.get().registerSpace(rootNanopubId, spaceIri);
+            spaceRefs.add(registration.spaceRef());
+            if (registration.wasNew()) {
+                SpacesAdminStore.persistSpace(rootNanopubId, spaceIri);
+            }
         }
         return spaceRefs;
     }

--- a/src/main/java/com/knowledgepixels/query/RoleProperty.java
+++ b/src/main/java/com/knowledgepixels/query/RoleProperty.java
@@ -1,0 +1,41 @@
+package com.knowledgepixels.query;
+
+import org.eclipse.rdf4j.model.IRI;
+
+/**
+ * A role property registered for a space. Captures the predicate that
+ * role-assignment nanopubs use, the role type it confers (one of the
+ * {@code gen:*Role} subclasses), and the triple direction the predicate
+ * appears in for valid assignments.
+ *
+ * <p>Direction notes:
+ * <ul>
+ *   <li>{@link Direction#REGULAR} — assignment triple is
+ *       {@code <member> <predicate> <space>}.</li>
+ *   <li>{@link Direction#INVERSE} — assignment triple is
+ *       {@code <space> <predicate> <member>}.</li>
+ * </ul>
+ *
+ * <p>A single role-definition nanopub may register multiple role properties
+ * (some regular, some inverse) for the same role type; each is stored as its
+ * own {@code RoleProperty} record in {@link SpaceRegistry}.
+ *
+ * @param predicate the predicate IRI used in role-assignment triples
+ * @param roleType  the role type IRI ({@code gen:AdminRole},
+ *                  {@code gen:MaintainerRole}, {@code gen:MemberRole}, or
+ *                  {@code gen:ObserverRole})
+ * @param direction whether the predicate appears regular or inverse
+ */
+public record RoleProperty(IRI predicate, IRI roleType, Direction direction) {
+
+    /**
+     * Triple direction for a role-property predicate.
+     */
+    public enum Direction {
+        /** {@code <member> <predicate> <space>}. */
+        REGULAR,
+        /** {@code <space> <predicate> <member>}. */
+        INVERSE
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/SpaceRegistry.java
+++ b/src/main/java/com/knowledgepixels/query/SpaceRegistry.java
@@ -42,9 +42,21 @@ public class SpaceRegistry {
 
     private final Set<String> knownSpaceRefs = new LinkedHashSet<>();
     private final Map<IRI, Set<String>> spaceIriToSpaceRefs = new HashMap<>();
+    private final Map<String, Set<RoleProperty>> roleProperties = new HashMap<>();
+    private final Map<IRI, Set<String>> sourceNanopubsToSpaceRefs = new HashMap<>();
 
     private SpaceRegistry() {
     }
+
+    /**
+     * Result of a {@link #registerSpace(String, IRI)} call: the resolved space ref
+     * and whether the call newly added it to the registry.
+     *
+     * @param spaceRef the space ref of the form {@code <rootNanopubId>_<SPACEIRIHASH>}
+     * @param wasNew   {@code true} if this call added a new space, {@code false} if
+     *                 it was already known
+     */
+    public record Registration(String spaceRef, boolean wasNew) { }
 
     /**
      * Registers a space defined by the given root nanopub and Space IRI. Idempotent:
@@ -54,16 +66,16 @@ public class SpaceRegistry {
      * @param rootNanopubId artifact code (e.g. {@code RA...}) of the root nanopub, as
      *                      resolved by the caller via {@code gen:hasRootDefinition}
      * @param spaceIri      the Space IRI declared in the root nanopub's assertion
-     * @return the space ref, of the form {@code <rootNanopubId>_<SPACEIRIHASH>}
+     * @return the registration result: the space ref and whether it was newly added
      */
-    public String registerSpace(String rootNanopubId, IRI spaceIri) {
+    public Registration registerSpace(String rootNanopubId, IRI spaceIri) {
         String spaceRef = rootNanopubId + "_" + Utils.createHash(spaceIri);
         boolean added = knownSpaceRefs.add(spaceRef);
         spaceIriToSpaceRefs.computeIfAbsent(spaceIri, k -> new LinkedHashSet<>()).add(spaceRef);
         if (added) {
             log.info("Registered space ref: {}", spaceRef);
         }
-        return spaceRef;
+        return new Registration(spaceRef, added);
     }
 
     /**
@@ -109,6 +121,72 @@ public class SpaceRegistry {
      */
     public Set<String> findSpaceRefsBySpaceIri(IRI spaceIri) {
         Set<String> refs = spaceIriToSpaceRefs.get(spaceIri);
+        return refs == null ? Collections.emptySet() : Collections.unmodifiableSet(refs);
+    }
+
+    /**
+     * Registers a role property learned for the given space (typically from a
+     * role-definition nanopub). Idempotent: re-registering the same property is a
+     * no-op.
+     *
+     * @param spaceRef     the space the property belongs to
+     * @param roleProperty the property to register
+     * @return {@code true} if newly added, {@code false} if already known
+     * @throws IllegalArgumentException if the space ref is not registered
+     */
+    public boolean registerRoleProperty(String spaceRef, RoleProperty roleProperty) {
+        if (!knownSpaceRefs.contains(spaceRef)) {
+            throw new IllegalArgumentException("Unknown space ref: " + spaceRef);
+        }
+        return roleProperties.computeIfAbsent(spaceRef, k -> new LinkedHashSet<>()).add(roleProperty);
+    }
+
+    /**
+     * Returns the role properties learned for the given space.
+     *
+     * @param spaceRef the space ref to look up
+     * @return an unmodifiable set of registered role properties (empty if the space
+     *         has none, or if the space ref isn't registered)
+     */
+    public Set<RoleProperty> getRoleProperties(String spaceRef) {
+        Set<RoleProperty> props = roleProperties.get(spaceRef);
+        return props == null ? Collections.emptySet() : Collections.unmodifiableSet(props);
+    }
+
+    /**
+     * Records that the given source nanopub contributed extracted triples to the
+     * given space. Used at invalidation time to find which spaces need re-materializing
+     * when a source nanopub is invalidated.
+     *
+     * @param sourceNanopubUri the URI of the source nanopub
+     * @param spaceRef         the space ref the nanopub contributed to
+     */
+    public void recordSourceNanopub(IRI sourceNanopubUri, String spaceRef) {
+        sourceNanopubsToSpaceRefs.computeIfAbsent(sourceNanopubUri, k -> new LinkedHashSet<>()).add(spaceRef);
+    }
+
+    /**
+     * Returns the set of space refs the given source nanopub contributed to.
+     *
+     * @param sourceNanopubUri the URI of the source nanopub
+     * @return an unmodifiable set (empty if the nanopub contributed to no spaces)
+     */
+    public Set<String> getSpaceRefsForSource(IRI sourceNanopubUri) {
+        Set<String> refs = sourceNanopubsToSpaceRefs.get(sourceNanopubUri);
+        return refs == null ? Collections.emptySet() : Collections.unmodifiableSet(refs);
+    }
+
+    /**
+     * Removes the source-nanopub → space-refs mapping for the given source. Called
+     * after an invalidation has been propagated and the affected spaces have been
+     * marked dirty.
+     *
+     * @param sourceNanopubUri the URI of the source nanopub
+     * @return the set of space refs the source had contributed to before removal
+     *         (empty if it wasn't tracked)
+     */
+    public Set<String> removeSourceNanopub(IRI sourceNanopubUri) {
+        Set<String> refs = sourceNanopubsToSpaceRefs.remove(sourceNanopubUri);
         return refs == null ? Collections.emptySet() : Collections.unmodifiableSet(refs);
     }
 

--- a/src/main/java/com/knowledgepixels/query/SpacesAdminStore.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesAdminStore.java
@@ -1,0 +1,114 @@
+package com.knowledgepixels.query;
+
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.nanopub.vocabulary.NPA;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.knowledgepixels.query.vocabulary.NPAS;
+
+/**
+ * Admin-repo persistence for {@link SpaceRegistry}'s known {@code (spaceRef, spaceIri)}
+ * pairs. Mirrors the pattern used by {@link TrustStateLoader} for trust-state pointer
+ * persistence: pure I/O wrapper around {@link TripleStore}, with a {@link #bootstrap}
+ * call run once at startup and a {@link #persistSpace} call invoked whenever
+ * {@link NanopubLoader#detectAndRegisterSpaces} adds a new space.
+ *
+ * <p>Persisted shape (in the admin repo's {@link NPA#GRAPH}):
+ * <pre>{@code
+ *   <npas:spaceRef> npa:hasSpaceIri <spaceIRI> .
+ * }</pre>
+ *
+ * <p>Role properties and the source-nanopub reverse index are <em>not</em> persisted
+ * — they are re-derived as nanopubs flow through the loader. See
+ * {@code doc/plan-space-repositories.md}.
+ */
+public class SpacesAdminStore {
+
+    private static final Logger log = LoggerFactory.getLogger(SpacesAdminStore.class);
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    /**
+     * Predicate linking a space ref (subject in the {@code npas:} namespace) to its
+     * Space IRI. Defined locally rather than in a vocab class because it's strictly
+     * internal to space-registry persistence.
+     */
+    static final IRI NPA_HAS_SPACE_IRI = vf.createIRI(NPA.NAMESPACE, "hasSpaceIri");
+
+    private SpacesAdminStore() {
+    }
+
+    /**
+     * Loads any persisted {@code (spaceRef, spaceIri)} pairs from the admin repo and
+     * registers them in the given registry. Intended to run once at startup.
+     *
+     * <p>Safe to call on a fresh deployment (admin repo may be empty — registers
+     * nothing). Any failure is logged at INFO; the registry is left empty and the
+     * loader will rebuild it as nanopubs flow through.
+     *
+     * @param registry the registry to seed
+     */
+    public static void bootstrap(SpaceRegistry registry) {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(TripleStore.ADMIN_REPO)) {
+            String query = String.format("""
+                    SELECT ?ref ?iri WHERE {
+                      GRAPH <%s> {
+                        ?ref <%s> ?iri .
+                      }
+                    }
+                    """,
+                    NPA.GRAPH, NPA_HAS_SPACE_IRI);
+            int loaded = 0;
+            try (TupleQueryResult result =
+                         conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
+                while (result.hasNext()) {
+                    var binding = result.next();
+                    IRI refIri = (IRI) binding.getValue("ref");
+                    IRI spaceIri = (IRI) binding.getValue("iri");
+                    String iriStr = refIri.stringValue();
+                    if (!iriStr.startsWith(NPAS.NAMESPACE)) {
+                        log.warn("Skipping persisted space ref with unexpected IRI: {}", iriStr);
+                        continue;
+                    }
+                    String spaceRef = iriStr.substring(NPAS.NAMESPACE.length());
+                    String rootNanopubId = registry.getRootNanopubId(spaceRef);
+                    registry.registerSpace(rootNanopubId, spaceIri);
+                    loaded++;
+                }
+            }
+            if (loaded > 0) {
+                log.info("Spaces bootstrap: seeded {} space(s) from admin repo", loaded);
+            }
+        } catch (Exception ex) {
+            log.info("Spaces bootstrap: failed to read persisted spaces: {}", ex.toString());
+        }
+    }
+
+    /**
+     * Persists a newly-registered {@code (spaceRef, spaceIri)} pair into the admin
+     * repo. Idempotent: re-persisting the same pair is harmless (the SPARQL INSERT
+     * just re-asserts an existing triple).
+     *
+     * @param rootNanopubId artifact code of the root nanopub
+     * @param spaceIri      the Space IRI
+     */
+    public static void persistSpace(String rootNanopubId, IRI spaceIri) {
+        String spaceRef = rootNanopubId + "_" + Utils.createHash(spaceIri);
+        IRI refIri = NPAS.forSpaceRef(spaceRef);
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(TripleStore.ADMIN_REPO)) {
+            conn.begin(IsolationLevels.SERIALIZABLE);
+            conn.add(refIri, NPA_HAS_SPACE_IRI, spaceIri, NPA.GRAPH);
+            conn.commit();
+        } catch (Exception ex) {
+            log.info("Failed to persist space {}: {}", spaceRef, ex.toString());
+        }
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/SpacesAdminStore.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesAdminStore.java
@@ -11,7 +11,10 @@ import org.nanopub.vocabulary.NPA;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.knowledgepixels.query.vocabulary.GEN;
 import com.knowledgepixels.query.vocabulary.NPAS;
+
+import net.trustyuri.TrustyUriUtils;
 
 /**
  * Admin-repo persistence for {@link SpaceRegistry}'s known {@code (spaceRef, spaceIri)}
@@ -88,6 +91,77 @@ public class SpacesAdminStore {
             }
         } catch (Exception ex) {
             log.info("Spaces bootstrap: failed to read persisted spaces: {}", ex.toString());
+        }
+    }
+
+    /**
+     * Re-derives the known-spaces set by scanning the existing {@code type_<HASH>}
+     * repo for {@link GEN#SPACE}. For each {@code <spaceIri> gen:hasRootDefinition
+     * <rootUri>} triple found in any nanopub assertion there, registers the space
+     * in {@link SpaceRegistry} and persists it via {@link #persistSpace} (so the
+     * admin-repo state catches up).
+     *
+     * <p>Intended to run once at startup, after {@link #bootstrap}. Idempotent:
+     * spaces already known to the registry are detected via the {@code wasNew}
+     * signal and skipped. Lets existing deployments pick up space-defining
+     * nanopubs that were loaded before this code shipped, without a fresh DB.
+     *
+     * <p>If the type repo doesn't exist (no {@code gen:Space}-typed nanopub has
+     * ever been loaded), this is a no-op. Failures are logged at INFO and don't
+     * propagate; the loader will eventually re-derive state as new nanopubs flow.
+     *
+     * @param registry the registry to seed
+     */
+    public static void scanExistingSpaces(SpaceRegistry registry) {
+        String typeRepo = "type_" + Utils.createHash(GEN.SPACE);
+        if (!TripleStore.get().getRepositoryNames().contains(typeRepo)) {
+            log.info("Spaces scan: no {} repo yet — skipping", typeRepo);
+            return;
+        }
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(typeRepo)) {
+            // The type_<hash(gen:Space)> repo holds only gen:Space-typed nanopubs,
+            // so any hasRootDefinition triple in any assertion graph here belongs
+            // to a Space-defining nanopub. Walking np -> assertion graph keeps the
+            // result tied to its source nanopub for logging and provenance.
+            String query = """
+                    PREFIX np:  <http://www.nanopub.org/nschema#>
+                    PREFIX gen: <https://w3id.org/kpxl/gen/terms/>
+                    SELECT ?np ?spaceIri ?rootUri WHERE {
+                      GRAPH ?head {
+                        ?np a np:Nanopublication ;
+                            np:hasAssertion ?assertion .
+                      }
+                      GRAPH ?assertion {
+                        ?spaceIri gen:hasRootDefinition ?rootUri .
+                      }
+                    }
+                    """;
+            int seen = 0;
+            int registered = 0;
+            try (TupleQueryResult result =
+                         conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
+                while (result.hasNext()) {
+                    seen++;
+                    var binding = result.next();
+                    if (!(binding.getValue("spaceIri") instanceof IRI spaceIri)) continue;
+                    if (!(binding.getValue("rootUri") instanceof IRI rootUri)) continue;
+                    String rootNanopubId = TrustyUriUtils.getArtifactCode(rootUri.stringValue());
+                    if (rootNanopubId == null || rootNanopubId.isEmpty()) {
+                        log.warn("Spaces scan: ignoring {} — gen:hasRootDefinition target is not a trusty URI: {}",
+                                spaceIri, rootUri);
+                        continue;
+                    }
+                    SpaceRegistry.Registration reg = registry.registerSpace(rootNanopubId, spaceIri);
+                    if (reg.wasNew()) {
+                        persistSpace(rootNanopubId, spaceIri);
+                        registered++;
+                    }
+                }
+            }
+            log.info("Spaces scan: examined {} hasRootDefinition triple(s); newly registered {} space(s)",
+                    seen, registered);
+        } catch (Exception ex) {
+            log.info("Spaces scan: failed to scan {}: {}", typeRepo, ex.toString());
         }
     }
 

--- a/src/test/java/com/knowledgepixels/query/SpaceRegistryTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpaceRegistryTest.java
@@ -44,25 +44,28 @@ class SpaceRegistryTest {
     @Test
     void registerSpace_returnsExpectedSpaceRef() {
         IRI spaceA = Values.iri("https://example.org/spaceA");
-        String ref = SpaceRegistry.get().registerSpace("RA1", spaceA);
-        assertEquals("RA1_H(https://example.org/spaceA)", ref);
+        SpaceRegistry.Registration r = SpaceRegistry.get().registerSpace("RA1", spaceA);
+        assertEquals("RA1_H(https://example.org/spaceA)", r.spaceRef());
+        assertTrue(r.wasNew());
     }
 
     @Test
     void registerSpace_isIdempotent() {
         IRI spaceA = Values.iri("https://example.org/spaceA");
-        String first = SpaceRegistry.get().registerSpace("RA1", spaceA);
-        String second = SpaceRegistry.get().registerSpace("RA1", spaceA);
-        assertEquals(first, second);
+        SpaceRegistry.Registration first = SpaceRegistry.get().registerSpace("RA1", spaceA);
+        SpaceRegistry.Registration second = SpaceRegistry.get().registerSpace("RA1", spaceA);
+        assertEquals(first.spaceRef(), second.spaceRef());
+        assertTrue(first.wasNew());
+        assertFalse(second.wasNew());
         assertEquals(1, SpaceRegistry.get().getKnownSpaceRefs().size());
-        assertEquals(Set.of(first), SpaceRegistry.get().findSpaceRefsBySpaceIri(spaceA));
+        assertEquals(Set.of(first.spaceRef()), SpaceRegistry.get().findSpaceRefsBySpaceIri(spaceA));
     }
 
     @Test
     void twoRootsWithSameIri_produceTwoSpaceRefs() {
         IRI spaceA = Values.iri("https://example.org/spaceA");
-        String ref1 = SpaceRegistry.get().registerSpace("RA1", spaceA);
-        String ref2 = SpaceRegistry.get().registerSpace("RA2", spaceA);
+        String ref1 = SpaceRegistry.get().registerSpace("RA1", spaceA).spaceRef();
+        String ref2 = SpaceRegistry.get().registerSpace("RA2", spaceA).spaceRef();
         assertNotEquals(ref1, ref2);
 
         Set<String> found = SpaceRegistry.get().findSpaceRefsBySpaceIri(spaceA);
@@ -73,8 +76,8 @@ class SpaceRegistryTest {
     void oneRootWithTwoIris_produceTwoSpaceRefs() {
         IRI spaceA = Values.iri("https://example.org/spaceA");
         IRI spaceB = Values.iri("https://example.org/spaceB");
-        String refA = SpaceRegistry.get().registerSpace("RA1", spaceA);
-        String refB = SpaceRegistry.get().registerSpace("RA1", spaceB);
+        String refA = SpaceRegistry.get().registerSpace("RA1", spaceA).spaceRef();
+        String refB = SpaceRegistry.get().registerSpace("RA1", spaceB).spaceRef();
         assertNotEquals(refA, refB);
 
         assertEquals(Set.of(refA), SpaceRegistry.get().findSpaceRefsBySpaceIri(spaceA));
@@ -87,8 +90,8 @@ class SpaceRegistryTest {
         String expectedRef = "RA1_H(https://example.org/spaceA)";
 
         assertFalse(SpaceRegistry.get().isKnownSpace(expectedRef));
-        String ref = SpaceRegistry.get().registerSpace("RA1", spaceA);
-        assertEquals(expectedRef, ref);
+        SpaceRegistry.Registration r = SpaceRegistry.get().registerSpace("RA1", spaceA);
+        assertEquals(expectedRef, r.spaceRef());
         assertTrue(SpaceRegistry.get().isKnownSpace(expectedRef));
     }
 
@@ -124,6 +127,80 @@ class SpaceRegistryTest {
         SpaceRegistry.get().registerSpace("RA1", spaceA);
         Set<String> refs = SpaceRegistry.get().findSpaceRefsBySpaceIri(spaceA);
         assertThrows(UnsupportedOperationException.class, () -> refs.add("foo"));
+    }
+
+    @Test
+    void registerRoleProperty_storesAndReturnsTrueOnFirstAdd() {
+        IRI spaceIri = Values.iri("https://example.org/spaceA");
+        String ref = SpaceRegistry.get().registerSpace("RA1", spaceIri).spaceRef();
+        IRI predicate = Values.iri("https://example.org/hasMember");
+        IRI roleType = Values.iri("https://w3id.org/kpxl/gen/terms/MemberRole");
+        RoleProperty rp = new RoleProperty(predicate, roleType, RoleProperty.Direction.REGULAR);
+
+        assertTrue(SpaceRegistry.get().registerRoleProperty(ref, rp));
+        assertFalse(SpaceRegistry.get().registerRoleProperty(ref, rp));
+        assertEquals(Set.of(rp), SpaceRegistry.get().getRoleProperties(ref));
+    }
+
+    @Test
+    void registerRoleProperty_throwsForUnknownSpaceRef() {
+        IRI predicate = Values.iri("https://example.org/hasMember");
+        IRI roleType = Values.iri("https://w3id.org/kpxl/gen/terms/MemberRole");
+        RoleProperty rp = new RoleProperty(predicate, roleType, RoleProperty.Direction.REGULAR);
+        assertThrows(IllegalArgumentException.class,
+                () -> SpaceRegistry.get().registerRoleProperty("RA1_unknown", rp));
+    }
+
+    @Test
+    void getRoleProperties_emptyForKnownSpaceWithoutProperties() {
+        IRI spaceIri = Values.iri("https://example.org/spaceA");
+        String ref = SpaceRegistry.get().registerSpace("RA1", spaceIri).spaceRef();
+        assertTrue(SpaceRegistry.get().getRoleProperties(ref).isEmpty());
+    }
+
+    @Test
+    void getRoleProperties_returnsUnmodifiableSet() {
+        IRI spaceIri = Values.iri("https://example.org/spaceA");
+        String ref = SpaceRegistry.get().registerSpace("RA1", spaceIri).spaceRef();
+        IRI predicate = Values.iri("https://example.org/hasMember");
+        IRI roleType = Values.iri("https://w3id.org/kpxl/gen/terms/MemberRole");
+        SpaceRegistry.get().registerRoleProperty(ref,
+                new RoleProperty(predicate, roleType, RoleProperty.Direction.REGULAR));
+        Set<RoleProperty> props = SpaceRegistry.get().getRoleProperties(ref);
+        assertThrows(UnsupportedOperationException.class,
+                () -> props.add(new RoleProperty(predicate, roleType, RoleProperty.Direction.INVERSE)));
+    }
+
+    @Test
+    void recordSourceNanopub_buildsReverseIndex() {
+        IRI source = Values.iri("https://example.org/np/abc");
+        SpaceRegistry.get().recordSourceNanopub(source, "RA1_x");
+        SpaceRegistry.get().recordSourceNanopub(source, "RA2_y");
+        SpaceRegistry.get().recordSourceNanopub(source, "RA1_x"); // duplicate is no-op
+        assertEquals(Set.of("RA1_x", "RA2_y"), SpaceRegistry.get().getSpaceRefsForSource(source));
+    }
+
+    @Test
+    void getSpaceRefsForSource_emptyForUnknownSource() {
+        IRI source = Values.iri("https://example.org/np/never-seen");
+        assertTrue(SpaceRegistry.get().getSpaceRefsForSource(source).isEmpty());
+    }
+
+    @Test
+    void removeSourceNanopub_returnsAffectedSpacesAndClearsEntry() {
+        IRI source = Values.iri("https://example.org/np/abc");
+        SpaceRegistry.get().recordSourceNanopub(source, "RA1_x");
+        SpaceRegistry.get().recordSourceNanopub(source, "RA2_y");
+
+        Set<String> removed = SpaceRegistry.get().removeSourceNanopub(source);
+        assertEquals(Set.of("RA1_x", "RA2_y"), removed);
+        assertTrue(SpaceRegistry.get().getSpaceRefsForSource(source).isEmpty());
+    }
+
+    @Test
+    void removeSourceNanopub_returnsEmptyIfNotTracked() {
+        IRI source = Values.iri("https://example.org/np/never-tracked");
+        assertTrue(SpaceRegistry.get().removeSourceNanopub(source).isEmpty());
     }
 
 }


### PR DESCRIPTION
## Summary

PR-A of the Phase 1 sequence for #62. Three additions to the in-memory `SpaceRegistry` plus admin-repo persistence so known spaces survive restarts.

- New `RoleProperty` record (predicate, role type, regular/inverse direction). Populated by the loader's role-definition detection in PR-B and consumed by the materializer in PR-C.
- `SpaceRegistry` gains:
  - `roleProperties` map (`spaceRef → Set<RoleProperty>`) with register/get methods.
  - `sourceNanopubsToSpaceRefs` reverse index with record/get/remove methods (for invalidation propagation in PR-C).
  - `registerSpace` now returns a `Registration` record (`spaceRef + wasNew`) so callers can decide whether to trigger persistence side effects.
- New `SpacesAdminStore` (parallel to `TrustStateLoader`'s bootstrap pattern) persists `(spaceRef, spaceIri)` pairs into the admin repo's `npa:graph` as `<npas:spaceRef> npa:hasSpaceIri <spaceIRI>` triples. `bootstrap()` wired in `MainVerticle` startup.
- Role properties and the source-nanopub index are **not** persisted — they're re-derived as nanopubs flow through the loader.
- `NanopubLoader.detectAndRegisterSpaces` calls `SpacesAdminStore.persistSpace` for newly-registered spaces.

No new functionality observable to consumers yet (PR-B will add the producer for role properties and the source-nanopub records). PR-A's user-visible effect: known spaces survive a restart.

See `doc/plan-space-repositories.md` for the full design.

## Test plan

- [x] `mvn test` — 162/162 pass locally (8 new tests for the new APIs)
- [x] CI green