### PR TITLE
fix: skip nanopub-count/checksum init for non-tracking repos

### DIFF
--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -356,8 +356,10 @@ public class TripleStore {
                 // Full isolation, just in case.
                 conn.begin(IsolationLevels.SERIALIZABLE);
                 conn.add(NPA.THIS_REPO, NPA.HAS_REPO_INIT_ID, vf.createLiteral(repoInitId), NPA.GRAPH);
-                conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, vf.createLiteral(0L), NPA.GRAPH);
-                conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_CHECKSUM, vf.createLiteral(NanopubUtils.INIT_CHECKSUM), NPA.GRAPH);
+                if (tracksNanopubCountAndChecksum(repoName)) {
+                    conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, vf.createLiteral(0L), NPA.GRAPH);
+                    conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_CHECKSUM, vf.createLiteral(NanopubUtils.INIT_CHECKSUM), NPA.GRAPH);
+                }
                 if (repoName.startsWith("pubkey_") || repoName.startsWith("type_")) {
                     String h = repoName.replaceFirst("^[^_]+_", "");
                     conn.add(NPA.THIS_REPO, NPA.HAS_COVERAGE_ITEM, Utils.getObjectForHash(h), NPA.GRAPH);
@@ -369,6 +371,19 @@ public class TripleStore {
             // Refresh repository names cache
             invalidateRepositoryNamesCache();
         }
+    }
+
+    /**
+     * Whether the given repo participates in the cumulative nanopub-count / XOR-checksum
+     * tracking. Repos that maintain ad-hoc content (last30d expires entries; trust and
+     * spaces hold derived state, not raw nanopubs) skip the {@code npa:hasNanopubCount}
+     * and {@code npa:hasNanopubChecksum} initial triples — leaving them at {@code 0} and
+     * the empty-XOR placeholder forever would just be misleading.
+     */
+    private static boolean tracksNanopubCountAndChecksum(String repoName) {
+        return !repoName.equals("last30d")
+                && !repoName.equals("trust")
+                && !repoName.equals("spaces");
     }
 
 }


### PR DESCRIPTION
## Summary

`TripleStore.initNewRepo` currently writes `npa:hasNanopubCount = 0` and `npa:hasNanopubChecksum = <empty-XOR-placeholder>` for every repo on creation. Three repos never update these triples afterwards:

- **`last30d`** — content expires on a periodic cleanup; the loader uses a separate code path that doesn't track count/checksum.
- **`trust`** — holds derived snapshots, not raw nanopubs.
- **`spaces`** (when it lands in PR-B for #62) — holds derived authority data, not raw nanopubs.

Leaving the initial triples in place is misleading for anyone inspecting the admin graph. Skip emitting them for these three repo names.

## Caveats

- **Doesn't clean up existing repos.** `initNewRepo` only runs on first creation, so already-created `last30d` / `trust` repos keep their stale `0` count and all-A's checksum until manually dropped (one-line SPARQL DELETE).
- `spaces` is included now even though the repo doesn't exist yet — it'll be born clean when PR-B creates it.

## Test plan

- [x] `mvn test` — 154/154 pass locally
- [ ] CI green