### PR TITLE
fix: skip nanopub-count/checksum init for the admin repo too

### DIFF
--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -375,13 +375,19 @@ public class TripleStore {
 
     /**
      * Whether the given repo participates in the cumulative nanopub-count / XOR-checksum
-     * tracking. Repos that maintain ad-hoc content (last30d expires entries; trust and
-     * spaces hold derived state, not raw nanopubs) skip the {@code npa:hasNanopubCount}
-     * and {@code npa:hasNanopubChecksum} initial triples — leaving them at {@code 0} and
-     * the empty-XOR placeholder forever would just be misleading.
+     * tracking. Repos that don't hold raw nanopubs skip the
+     * {@code npa:hasNanopubCount} and {@code npa:hasNanopubChecksum} initial triples —
+     * leaving them at {@code 0} and the empty-XOR placeholder forever would just be
+     * misleading. Currently excluded:
+     * <ul>
+     *   <li>{@code admin} — holds metadata only.</li>
+     *   <li>{@code last30d} — content expires on a periodic cleanup.</li>
+     *   <li>{@code trust} and {@code spaces} — hold derived state, not raw nanopubs.</li>
+     * </ul>
      */
     private static boolean tracksNanopubCountAndChecksum(String repoName) {
-        return !repoName.equals("last30d")
+        return !repoName.equals(ADMIN_REPO)
+                && !repoName.equals("last30d")
                 && !repoName.equals("trust")
                 && !repoName.equals("spaces");
     }


### PR DESCRIPTION
## Summary

Follow-up to #69. The admin repo holds metadata only — no raw nanopubs ever land there, and nothing ever updates the cumulative `npa:hasNanopubCount` / `npa:hasNanopubChecksum`. The `0` and empty-XOR placeholder from `initNewRepo` sit there forever, just as misleading as they were on `last30d` / `trust` / `spaces`.

Add `admin` to the same skip-list.

## Caveats

Same as #69 — `initNewRepo` only runs on first creation, so existing admin repos keep their stale triples until manually dropped.

## Test plan

- [x] `mvn test` — 162/162 pass locally
- [x] CI green