### PR TITLE
feat: extract admin grants and profile fields into the spaces repo (#62)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -521,8 +521,8 @@ public class MainVerticle extends AbstractVerticle {
             // so previously-known spaces survive a restart, then catch up on any
             // gen:Space-typed nanopubs that were already loaded before persistence
             // was wired up (so existing deployments don't need a fresh DB).
-            SpacesAdminStore.bootstrap(SpaceRegistry.get());
-            SpacesAdminStore.scanExistingSpaces(SpaceRegistry.get());
+            SpacesStateStore.bootstrap(SpaceRegistry.get());
+            SpacesStateStore.scanExistingSpaces(SpaceRegistry.get());
 
             // Start periodic nanopub loading
             log.info("Starting periodic nanopub loading...");

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -815,7 +815,7 @@ public class NanopubLoader {
             SpaceRegistry.Registration registration = SpaceRegistry.get().registerSpace(rootNanopubId, spaceIri);
             spaceRefs.add(registration.spaceRef());
             if (registration.wasNew()) {
-                SpacesStateStore.persistSpace(rootNanopubId, spaceIri);
+                SpacesStateStore.persistSpace(rootNanopubId, spaceIri, rootUri);
             }
         }
         return spaceRefs;

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -381,6 +381,14 @@ public class NanopubLoader {
                 runTask.accept(() -> loadNanopubToRepo(np.getUri(), allStatements, "type_" + Utils.createHash(typeIri)));
                 //			loadNanopubToRepo(np.getUri(), textStatements, "text-type_" + Utils.createHash(typeIri));
             }
+            // Project authority and profile contributions into the shared `spaces` repo.
+            // Computation is cheap (a walk over the assertion) so we do it inline; the
+            // write itself is parallelized with the other repo writes.
+            SpacesExtractor.ExtractionResult spaceExtracts =
+                    SpacesExtractor.extract(np, SpaceRegistry.get());
+            if (!spaceExtracts.statements().isEmpty()) {
+                runTask.accept(() -> loadSpaceExtracts(np.getUri(), spaceExtracts));
+            }
             //		for (IRI creatorIri : SimpleCreatorPattern.getCreators(np)) {
             //			// Exclude locally minted IRIs:
             //			if (creatorIri.stringValue().startsWith(np.getUri().stringValue())) continue;
@@ -676,6 +684,40 @@ public class NanopubLoader {
             }
         }
         return invalidatingStatements;
+    }
+
+    private static void loadSpaceExtracts(IRI npUri, SpacesExtractor.ExtractionResult result) {
+        boolean success = false;
+        int retries = 0;
+        while (!success) {
+            RepositoryConnection conn = TripleStore.get().getRepoConnection("spaces");
+            try (conn) {
+                conn.begin(IsolationLevels.SERIALIZABLE);
+                conn.add(result.statements());
+                conn.commit();
+                success = true;
+            } catch (Exception ex) {
+                log.warn("Could not load space extracts.", ex);
+                if (conn.isActive()) conn.rollback();
+            }
+            if (!success) {
+                retries++;
+                if (retries >= MAX_RETRIES) {
+                    throw new RuntimeException("Failed to load space extracts after " + MAX_RETRIES + " retries");
+                }
+                long delay = computeBackoffMillis(retries);
+                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException x) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+        // Reverse index: only after the write commits.
+        for (String spaceRef : result.spaceRefs()) {
+            SpaceRegistry.get().recordSourceNanopub(npUri, spaceRef);
+        }
     }
 
     @GeneratedFlagForDependentElements

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -815,7 +815,7 @@ public class NanopubLoader {
             SpaceRegistry.Registration registration = SpaceRegistry.get().registerSpace(rootNanopubId, spaceIri);
             spaceRefs.add(registration.spaceRef());
             if (registration.wasNew()) {
-                SpacesAdminStore.persistSpace(rootNanopubId, spaceIri);
+                SpacesStateStore.persistSpace(rootNanopubId, spaceIri);
             }
         }
         return spaceRefs;

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -1,0 +1,174 @@
+package com.knowledgepixels.query;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubUtils;
+
+import com.google.common.hash.Hashing;
+import com.knowledgepixels.query.vocabulary.GEN;
+import com.knowledgepixels.query.vocabulary.NPAS;
+import com.knowledgepixels.query.vocabulary.NPAX;
+import com.knowledgepixels.query.vocabulary.SpaceAuthority;
+import com.knowledgepixels.query.vocabulary.SpaceExtract;
+
+/**
+ * Identifies the contributions a nanopub makes to known spaces and produces
+ * the corresponding extract triples for the {@code spaces} repo.
+ *
+ * <p>This first iteration covers two extract kinds:
+ *
+ * <ul>
+ *   <li>{@link SpaceExtract#ADMIN_GRANT} — for any assertion of the form
+ *       {@code <spaceIri> gen:hasAdmin <agent>} where {@code spaceIri} is
+ *       registered in {@link SpaceRegistry}. One extract per
+ *       {@code (spaceRef, granted-agent)}.</li>
+ *   <li>{@link SpaceExtract#PROFILE_FIELD} — for any assertion whose subject
+ *       is the Space IRI of a space defined by *this* nanopub (i.e. a
+ *       {@code gen:Space}-typed nanopub with a matching
+ *       {@code gen:hasRootDefinition}). One extract per
+ *       {@code (spaceRef, predicate, value)}, except for the
+ *       {@code gen:hasRootDefinition} and {@code gen:hasAdmin} triples
+ *       themselves (the former is structural; the latter is captured
+ *       independently as an admin grant).</li>
+ * </ul>
+ *
+ * <p>Maintainer grants, role definitions, role assignments, and view-display
+ * extracts come in a follow-up PR. The extractor is purely a triple producer:
+ * given a {@link Nanopub} and the current {@link SpaceRegistry} state it
+ * returns context-tagged statements (graph IRI = {@code npas:<spaceRef>}) plus
+ * the set of space refs the nanopub contributed to. The caller decides when
+ * to commit them and how to record the source-nanopub reverse index.
+ *
+ * <p>See {@code doc/plan-space-repositories.md}.
+ */
+public class SpacesExtractor {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    /**
+     * Result of an extraction pass over a single nanopub.
+     *
+     * @param statements   the extract triples to write to the {@code spaces} repo;
+     *                     each carries its target named graph as its context
+     * @param spaceRefs    the space refs this nanopub contributed extracts to —
+     *                     the caller should record the reverse mapping via
+     *                     {@link SpaceRegistry#recordSourceNanopub}
+     */
+    public record ExtractionResult(List<Statement> statements, Set<String> spaceRefs) { }
+
+    private SpacesExtractor() {
+    }
+
+    /**
+     * Extracts everything the given nanopub contributes to known spaces.
+     *
+     * @param np       the nanopub to inspect
+     * @param registry the registry whose state determines which Space IRIs are known
+     * @return the extract triples and the set of space refs the nanopub contributed to
+     */
+    public static ExtractionResult extract(Nanopub np, SpaceRegistry registry) {
+        List<Statement> out = new ArrayList<>();
+        Set<String> contributedSpaces = new LinkedHashSet<>();
+
+        // (1) Admin-grant extracts: any <spaceIri> gen:hasAdmin <agent> where
+        // spaceIri is currently registered in SpaceRegistry. The publisher
+        // check (i.e. is the publisher actually entitled to grant admin?)
+        // happens at materialization time, not here.
+        for (Statement st : np.getAssertion()) {
+            if (!GEN.HAS_ADMIN.equals(st.getPredicate())) continue;
+            if (!(st.getSubject() instanceof IRI spaceIri)) continue;
+            if (!(st.getObject() instanceof IRI grantedAgent)) continue;
+            for (String spaceRef : registry.findSpaceRefsBySpaceIri(spaceIri)) {
+                emitAdminGrant(out, spaceRef, np.getUri(), grantedAgent);
+                contributedSpaces.add(spaceRef);
+            }
+        }
+
+        // (2) Profile-field extracts: only when this nanopub itself defines a
+        // space. Extract every triple in the assertion whose subject is the
+        // declared Space IRI, except the structural gen:hasRootDefinition (a
+        // detection signal) and gen:hasAdmin (handled above).
+        Set<IRI> definedSpaceIris = collectDefinedSpaceIris(np);
+        if (!definedSpaceIris.isEmpty()) {
+            for (Statement st : np.getAssertion()) {
+                if (!(st.getSubject() instanceof IRI subjectIri)) continue;
+                if (!definedSpaceIris.contains(subjectIri)) continue;
+                IRI predicate = st.getPredicate();
+                if (GEN.HAS_ROOT_DEFINITION.equals(predicate)) continue;
+                if (GEN.HAS_ADMIN.equals(predicate)) continue;
+                // Skip the structural rdf:type gen:Space marker, but keep other
+                // type triples (declared subtypes like gen:Alliance / gen:Project).
+                if (RDF.TYPE.equals(predicate) && GEN.SPACE.equals(st.getObject())) continue;
+                for (String spaceRef : registry.findSpaceRefsBySpaceIri(subjectIri)) {
+                    emitProfileField(out, spaceRef, np.getUri(), predicate, st.getObject());
+                    contributedSpaces.add(spaceRef);
+                }
+            }
+        }
+
+        return new ExtractionResult(out, contributedSpaces);
+    }
+
+    private static Set<IRI> collectDefinedSpaceIris(Nanopub np) {
+        boolean isSpaceTyped = false;
+        for (IRI typeIri : NanopubUtils.getTypes(np)) {
+            if (GEN.SPACE.equals(typeIri)) {
+                isSpaceTyped = true;
+                break;
+            }
+        }
+        if (!isSpaceTyped) return Set.of();
+        Set<IRI> defined = new LinkedHashSet<>();
+        for (Statement st : np.getAssertion()) {
+            if (!GEN.HAS_ROOT_DEFINITION.equals(st.getPredicate())) continue;
+            if (st.getSubject() instanceof IRI spaceIri) {
+                defined.add(spaceIri);
+            }
+        }
+        return defined;
+    }
+
+    private static void emitAdminGrant(List<Statement> out, String spaceRef, IRI sourceNp, IRI grantedAgent) {
+        IRI graph = NPAS.forSpaceRef(spaceRef);
+        IRI extract = NPAX.forHash(extractHash(spaceRef, sourceNp, SpaceExtract.ADMIN_GRANT, grantedAgent.stringValue()));
+        out.add(vf.createStatement(extract, RDF.TYPE, SpaceExtract.EXTRACT, graph));
+        out.add(vf.createStatement(extract, SpaceExtract.EXTRACT_KIND, SpaceExtract.ADMIN_GRANT, graph));
+        out.add(vf.createStatement(extract, SpaceAuthority.AGENT, grantedAgent, graph));
+        out.add(vf.createStatement(extract, SpaceAuthority.VIA_NANOPUB, sourceNp, graph));
+    }
+
+    private static void emitProfileField(List<Statement> out, String spaceRef, IRI sourceNp, IRI predicate, Value value) {
+        IRI graph = NPAS.forSpaceRef(spaceRef);
+        // value.stringValue() is sufficient for hashing — IRIs and literals both produce a stable string.
+        // Including the predicate IRI separates "same value, different predicate" extracts.
+        String payload = predicate.stringValue() + "|" + value.stringValue();
+        IRI extract = NPAX.forHash(extractHash(spaceRef, sourceNp, SpaceExtract.PROFILE_FIELD, payload));
+        out.add(vf.createStatement(extract, RDF.TYPE, SpaceExtract.EXTRACT, graph));
+        out.add(vf.createStatement(extract, SpaceExtract.EXTRACT_KIND, SpaceExtract.PROFILE_FIELD, graph));
+        out.add(vf.createStatement(extract, SpaceExtract.FIELD_KEY, predicate, graph));
+        out.add(vf.createStatement(extract, SpaceExtract.FIELD_VALUE, value, graph));
+        out.add(vf.createStatement(extract, SpaceAuthority.VIA_NANOPUB, sourceNp, graph));
+    }
+
+    /**
+     * Computes the deterministic hash that identifies an extract within the
+     * spaces repo. Stable across re-extraction of the same source nanopub for
+     * the same space, so re-running the loader produces no duplicates.
+     */
+    static String extractHash(String spaceRef, IRI sourceNp, IRI extractKind, String payload) {
+        String input = spaceRef + "|" + sourceNp.stringValue() + "|" + extractKind.stringValue() + "|" + payload;
+        return Hashing.sha256().hashString(input, StandardCharsets.UTF_8).toString();
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -86,15 +86,17 @@ public class SpacesExtractor {
 
         // (1) Role-assertion extracts: any <spaceIri> gen:hasAdmin <agent> where
         // spaceIri is currently registered in SpaceRegistry. The triple is in
-        // inverse direction (subject = space, object = agent). The publisher
-        // check (is the publisher actually entitled to grant?) happens at
-        // materialization time, not here.
+        // inverse direction (subject = space, object = agent). gen:hasAdmin is
+        // a built-in predicate hardcoded to gen:AdminRole. The publisher check
+        // (is the publisher actually entitled to grant?) happens at materialization
+        // time, not here.
         for (Statement st : np.getAssertion()) {
             if (!GEN.HAS_ADMIN.equals(st.getPredicate())) continue;
             if (!(st.getSubject() instanceof IRI spaceIri)) continue;
             if (!(st.getObject() instanceof IRI grantedAgent)) continue;
             for (String spaceRef : registry.findSpaceRefsBySpaceIri(spaceIri)) {
-                emitRoleAssertion(out, spaceRef, np.getUri(), GEN.HAS_ADMIN, SpaceExtract.INVERSE, grantedAgent);
+                emitRoleAssertion(out, spaceRef, np.getUri(),
+                        GEN.HAS_ADMIN, SpaceExtract.INVERSE, GEN.ADMIN_ROLE, grantedAgent);
                 contributedSpaces.add(spaceRef);
             }
         }
@@ -144,13 +146,18 @@ public class SpacesExtractor {
     }
 
     private static void emitRoleAssertion(List<Statement> out, String spaceRef, IRI sourceNp,
-                                          IRI rolePredicate, IRI direction, IRI assignedAgent) {
+                                          IRI rolePredicate, IRI direction, IRI role, IRI assignedAgent) {
         IRI graph = NPAS.forSpaceRef(spaceRef);
+        // role is intentionally not in the hash — it's a function of the
+        // predicate (multiple predicates may map to the same role) so adding
+        // it would not increase discrimination, and keeping it out means a
+        // future change to the role binding doesn't churn extract IRIs.
         String payload = rolePredicate.stringValue() + "|" + direction.stringValue() + "|" + assignedAgent.stringValue();
         IRI extract = NPAX.forHash(extractHash(spaceRef, sourceNp, SpaceExtract.ROLE_ASSERTION, payload));
         out.add(vf.createStatement(extract, RDF.TYPE, SpaceExtract.ROLE_ASSERTION, graph));
         out.add(vf.createStatement(extract, SpaceExtract.ROLE_PREDICATE, rolePredicate, graph));
         out.add(vf.createStatement(extract, SpaceExtract.ROLE_DIRECTION, direction, graph));
+        out.add(vf.createStatement(extract, SpaceAuthority.ROLE, role, graph));
         out.add(vf.createStatement(extract, SpaceAuthority.AGENT, assignedAgent, graph));
         out.add(vf.createStatement(extract, SpaceAuthority.VIA_NANOPUB, sourceNp, graph));
     }

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -29,10 +29,13 @@ import com.knowledgepixels.query.vocabulary.SpaceExtract;
  * <p>This first iteration covers two extract classes:
  *
  * <ul>
- *   <li>{@link SpaceExtract#ADMIN_GRANT} ({@code npa:AdminGrant}) — for any
- *       assertion of the form {@code <spaceIri> gen:hasAdmin <agent>} where
- *       {@code spaceIri} is registered in {@link SpaceRegistry}. One extract
- *       per {@code (spaceRef, granted-agent)}.</li>
+ *   <li>{@link SpaceExtract#ROLE_ASSERTION} ({@code npa:RoleAssertion}) — for
+ *       any assertion of the form {@code <spaceIri> gen:hasAdmin <agent>}
+ *       where {@code spaceIri} is registered in {@link SpaceRegistry}.
+ *       Built-in role properties ({@code gen:hasAdmin}, future
+ *       {@code gen:hasMaintainer}) are extracted with the predicate and
+ *       direction recorded directly; PR-B2 will add the same shape for
+ *       learned role properties from role-definition nanopubs.</li>
  *   <li>{@link SpaceExtract#PROFILE_FIELD} ({@code npa:ProfileField}) — for
  *       any assertion whose subject is the Space IRI of a space defined by
  *       *this* nanopub (i.e. a {@code gen:Space}-typed nanopub with a matching
@@ -40,7 +43,7 @@ import com.knowledgepixels.query.vocabulary.SpaceExtract;
  *       {@code (spaceRef, predicate, value)}, except for the
  *       {@code gen:hasRootDefinition} and {@code gen:hasAdmin} triples
  *       themselves (the former is structural; the latter is captured
- *       independently as an admin grant).</li>
+ *       independently as a role assertion).</li>
  * </ul>
  *
  * <p>Maintainer grants, role definitions, role assignments, and view-display
@@ -81,16 +84,17 @@ public class SpacesExtractor {
         List<Statement> out = new ArrayList<>();
         Set<String> contributedSpaces = new LinkedHashSet<>();
 
-        // (1) Admin-grant extracts: any <spaceIri> gen:hasAdmin <agent> where
-        // spaceIri is currently registered in SpaceRegistry. The publisher
-        // check (i.e. is the publisher actually entitled to grant admin?)
-        // happens at materialization time, not here.
+        // (1) Role-assertion extracts: any <spaceIri> gen:hasAdmin <agent> where
+        // spaceIri is currently registered in SpaceRegistry. The triple is in
+        // inverse direction (subject = space, object = agent). The publisher
+        // check (is the publisher actually entitled to grant?) happens at
+        // materialization time, not here.
         for (Statement st : np.getAssertion()) {
             if (!GEN.HAS_ADMIN.equals(st.getPredicate())) continue;
             if (!(st.getSubject() instanceof IRI spaceIri)) continue;
             if (!(st.getObject() instanceof IRI grantedAgent)) continue;
             for (String spaceRef : registry.findSpaceRefsBySpaceIri(spaceIri)) {
-                emitAdminGrant(out, spaceRef, np.getUri(), grantedAgent);
+                emitRoleAssertion(out, spaceRef, np.getUri(), GEN.HAS_ADMIN, SpaceExtract.INVERSE, grantedAgent);
                 contributedSpaces.add(spaceRef);
             }
         }
@@ -139,11 +143,15 @@ public class SpacesExtractor {
         return defined;
     }
 
-    private static void emitAdminGrant(List<Statement> out, String spaceRef, IRI sourceNp, IRI grantedAgent) {
+    private static void emitRoleAssertion(List<Statement> out, String spaceRef, IRI sourceNp,
+                                          IRI rolePredicate, IRI direction, IRI assignedAgent) {
         IRI graph = NPAS.forSpaceRef(spaceRef);
-        IRI extract = NPAX.forHash(extractHash(spaceRef, sourceNp, SpaceExtract.ADMIN_GRANT, grantedAgent.stringValue()));
-        out.add(vf.createStatement(extract, RDF.TYPE, SpaceExtract.ADMIN_GRANT, graph));
-        out.add(vf.createStatement(extract, SpaceAuthority.AGENT, grantedAgent, graph));
+        String payload = rolePredicate.stringValue() + "|" + direction.stringValue() + "|" + assignedAgent.stringValue();
+        IRI extract = NPAX.forHash(extractHash(spaceRef, sourceNp, SpaceExtract.ROLE_ASSERTION, payload));
+        out.add(vf.createStatement(extract, RDF.TYPE, SpaceExtract.ROLE_ASSERTION, graph));
+        out.add(vf.createStatement(extract, SpaceExtract.ROLE_PREDICATE, rolePredicate, graph));
+        out.add(vf.createStatement(extract, SpaceExtract.ROLE_DIRECTION, direction, graph));
+        out.add(vf.createStatement(extract, SpaceAuthority.AGENT, assignedAgent, graph));
         out.add(vf.createStatement(extract, SpaceAuthority.VIA_NANOPUB, sourceNp, graph));
     }
 

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -86,17 +86,19 @@ public class SpacesExtractor {
 
         // (1) Role-assertion extracts: any <spaceIri> gen:hasAdmin <agent> where
         // spaceIri is currently registered in SpaceRegistry. The triple is in
-        // inverse direction (subject = space, object = agent). gen:hasAdmin is
-        // a built-in predicate hardcoded to gen:AdminRole. The publisher check
-        // (is the publisher actually entitled to grant?) happens at materialization
-        // time, not here.
+        // inverse direction (subject = space, object = agent). The role IRI
+        // isn't recorded on the extract — Nanodash's admin role lives in a
+        // published role-definition nanopub, not in a hardcoded class IRI;
+        // PR-B2 will start emitting that link once role definitions are
+        // extracted. The publisher check (is the publisher actually entitled
+        // to grant?) happens at materialization time, not here.
         for (Statement st : np.getAssertion()) {
             if (!GEN.HAS_ADMIN.equals(st.getPredicate())) continue;
             if (!(st.getSubject() instanceof IRI spaceIri)) continue;
             if (!(st.getObject() instanceof IRI grantedAgent)) continue;
             for (String spaceRef : registry.findSpaceRefsBySpaceIri(spaceIri)) {
                 emitRoleAssertion(out, spaceRef, np.getUri(),
-                        GEN.HAS_ADMIN, SpaceExtract.INVERSE, GEN.ADMIN_ROLE, grantedAgent);
+                        GEN.HAS_ADMIN, SpaceExtract.INVERSE, grantedAgent);
                 contributedSpaces.add(spaceRef);
             }
         }
@@ -146,18 +148,13 @@ public class SpacesExtractor {
     }
 
     private static void emitRoleAssertion(List<Statement> out, String spaceRef, IRI sourceNp,
-                                          IRI rolePredicate, IRI direction, IRI role, IRI assignedAgent) {
+                                          IRI rolePredicate, IRI direction, IRI assignedAgent) {
         IRI graph = NPAS.forSpaceRef(spaceRef);
-        // role is intentionally not in the hash — it's a function of the
-        // predicate (multiple predicates may map to the same role) so adding
-        // it would not increase discrimination, and keeping it out means a
-        // future change to the role binding doesn't churn extract IRIs.
         String payload = rolePredicate.stringValue() + "|" + direction.stringValue() + "|" + assignedAgent.stringValue();
         IRI extract = NPAX.forHash(extractHash(spaceRef, sourceNp, SpaceExtract.ROLE_ASSERTION, payload));
         out.add(vf.createStatement(extract, RDF.TYPE, SpaceExtract.ROLE_ASSERTION, graph));
         out.add(vf.createStatement(extract, SpaceExtract.ROLE_PREDICATE, rolePredicate, graph));
         out.add(vf.createStatement(extract, SpaceExtract.ROLE_DIRECTION, direction, graph));
-        out.add(vf.createStatement(extract, SpaceAuthority.ROLE, role, graph));
         out.add(vf.createStatement(extract, SpaceAuthority.AGENT, assignedAgent, graph));
         out.add(vf.createStatement(extract, SpaceAuthority.VIA_NANOPUB, sourceNp, graph));
     }

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -26,16 +26,16 @@ import com.knowledgepixels.query.vocabulary.SpaceExtract;
  * Identifies the contributions a nanopub makes to known spaces and produces
  * the corresponding extract triples for the {@code spaces} repo.
  *
- * <p>This first iteration covers two extract kinds:
+ * <p>This first iteration covers two extract classes:
  *
  * <ul>
- *   <li>{@link SpaceExtract#ADMIN_GRANT} — for any assertion of the form
- *       {@code <spaceIri> gen:hasAdmin <agent>} where {@code spaceIri} is
- *       registered in {@link SpaceRegistry}. One extract per
- *       {@code (spaceRef, granted-agent)}.</li>
- *   <li>{@link SpaceExtract#PROFILE_FIELD} — for any assertion whose subject
- *       is the Space IRI of a space defined by *this* nanopub (i.e. a
- *       {@code gen:Space}-typed nanopub with a matching
+ *   <li>{@link SpaceExtract#ADMIN_GRANT} ({@code npa:AdminGrant}) — for any
+ *       assertion of the form {@code <spaceIri> gen:hasAdmin <agent>} where
+ *       {@code spaceIri} is registered in {@link SpaceRegistry}. One extract
+ *       per {@code (spaceRef, granted-agent)}.</li>
+ *   <li>{@link SpaceExtract#PROFILE_FIELD} ({@code npa:ProfileField}) — for
+ *       any assertion whose subject is the Space IRI of a space defined by
+ *       *this* nanopub (i.e. a {@code gen:Space}-typed nanopub with a matching
  *       {@code gen:hasRootDefinition}). One extract per
  *       {@code (spaceRef, predicate, value)}, except for the
  *       {@code gen:hasRootDefinition} and {@code gen:hasAdmin} triples
@@ -142,8 +142,7 @@ public class SpacesExtractor {
     private static void emitAdminGrant(List<Statement> out, String spaceRef, IRI sourceNp, IRI grantedAgent) {
         IRI graph = NPAS.forSpaceRef(spaceRef);
         IRI extract = NPAX.forHash(extractHash(spaceRef, sourceNp, SpaceExtract.ADMIN_GRANT, grantedAgent.stringValue()));
-        out.add(vf.createStatement(extract, RDF.TYPE, SpaceExtract.EXTRACT, graph));
-        out.add(vf.createStatement(extract, SpaceExtract.EXTRACT_KIND, SpaceExtract.ADMIN_GRANT, graph));
+        out.add(vf.createStatement(extract, RDF.TYPE, SpaceExtract.ADMIN_GRANT, graph));
         out.add(vf.createStatement(extract, SpaceAuthority.AGENT, grantedAgent, graph));
         out.add(vf.createStatement(extract, SpaceAuthority.VIA_NANOPUB, sourceNp, graph));
     }
@@ -154,8 +153,7 @@ public class SpacesExtractor {
         // Including the predicate IRI separates "same value, different predicate" extracts.
         String payload = predicate.stringValue() + "|" + value.stringValue();
         IRI extract = NPAX.forHash(extractHash(spaceRef, sourceNp, SpaceExtract.PROFILE_FIELD, payload));
-        out.add(vf.createStatement(extract, RDF.TYPE, SpaceExtract.EXTRACT, graph));
-        out.add(vf.createStatement(extract, SpaceExtract.EXTRACT_KIND, SpaceExtract.PROFILE_FIELD, graph));
+        out.add(vf.createStatement(extract, RDF.TYPE, SpaceExtract.PROFILE_FIELD, graph));
         out.add(vf.createStatement(extract, SpaceExtract.FIELD_KEY, predicate, graph));
         out.add(vf.createStatement(extract, SpaceExtract.FIELD_VALUE, value, graph));
         out.add(vf.createStatement(extract, SpaceAuthority.VIA_NANOPUB, sourceNp, graph));
@@ -164,10 +162,12 @@ public class SpacesExtractor {
     /**
      * Computes the deterministic hash that identifies an extract within the
      * spaces repo. Stable across re-extraction of the same source nanopub for
-     * the same space, so re-running the loader produces no duplicates.
+     * the same space, so re-running the loader produces no duplicates. The
+     * extract-class IRI participates so changing the kind of an otherwise
+     * identical payload would yield a different IRI.
      */
-    static String extractHash(String spaceRef, IRI sourceNp, IRI extractKind, String payload) {
-        String input = spaceRef + "|" + sourceNp.stringValue() + "|" + extractKind.stringValue() + "|" + payload;
+    static String extractHash(String spaceRef, IRI sourceNp, IRI extractClass, String payload) {
+        String input = spaceRef + "|" + sourceNp.stringValue() + "|" + extractClass.stringValue() + "|" + payload;
         return Hashing.sha256().hashString(input, StandardCharsets.UTF_8).toString();
     }
 

--- a/src/main/java/com/knowledgepixels/query/SpacesStateStore.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesStateStore.java
@@ -24,8 +24,14 @@ import net.trustyuri.TrustyUriUtils;
  *
  * <p>Persisted shape (in the {@code spaces} repo's {@link NPA#GRAPH}):
  * <pre>{@code
- *   <npas:spaceRef> npa:hasSpaceIri <spaceIRI> .
+ *   <npas:spaceRef> npa:hasSpaceIri    <spaceIRI> ;
+ *                   npa:hasRootNanopub <rootNanopubURI> .
  * }</pre>
+ *
+ * <p>The artifact code is encoded in the space ref itself, but the full root
+ * nanopub URI isn't reconstructable in general (the same trusty artifact code
+ * can be hosted under different namespace prefixes), so we store it explicitly
+ * for query convenience.
  *
  * <p>Putting it in the spaces repo (rather than the global admin repo) makes the
  * spaces repo self-contained: a single SPARQL query against {@code spaces}
@@ -50,6 +56,14 @@ public class SpacesStateStore {
      * internal to space-registry persistence.
      */
     static final IRI NPA_HAS_SPACE_IRI = vf.createIRI(NPA.NAMESPACE, "hasSpaceIri");
+
+    /**
+     * Predicate linking a space ref to the URI of its root nanopub. The artifact
+     * code is encoded in the space ref, but the full URI isn't recoverable from
+     * it alone — same trusty artifact code can be hosted under different namespace
+     * prefixes. Stored explicitly for query convenience.
+     */
+    static final IRI NPA_HAS_ROOT_NANOPUB = vf.createIRI(NPA.NAMESPACE, "hasRootNanopub");
 
     private SpacesStateStore() {
     }
@@ -161,7 +175,7 @@ public class SpacesStateStore {
                     }
                     SpaceRegistry.Registration reg = registry.registerSpace(rootNanopubId, spaceIri);
                     if (reg.wasNew()) {
-                        persistSpace(rootNanopubId, spaceIri);
+                        persistSpace(rootNanopubId, spaceIri, rootUri);
                         registered++;
                     }
                 }
@@ -174,20 +188,23 @@ public class SpacesStateStore {
     }
 
     /**
-     * Persists a newly-registered {@code (spaceRef, spaceIri)} pair into the
-     * spaces repo. Idempotent: re-persisting the same pair is harmless (the
-     * SPARQL INSERT just re-asserts an existing triple).
+     * Persists a newly-registered space into the spaces repo, recording both the
+     * Space IRI and the full root-nanopub URI. Idempotent: re-persisting the same
+     * triples is harmless.
      *
-     * @param rootNanopubId artifact code of the root nanopub
-     * @param spaceIri      the Space IRI
+     * @param rootNanopubId  artifact code of the root nanopub
+     * @param spaceIri       the Space IRI
+     * @param rootNanopubUri the full URI of the root nanopub (as stated in the
+     *                       defining {@code gen:hasRootDefinition} triple)
      */
-    public static void persistSpace(String rootNanopubId, IRI spaceIri) {
+    public static void persistSpace(String rootNanopubId, IRI spaceIri, IRI rootNanopubUri) {
         if (!FeatureFlags.spacesEnabled()) return;
         String spaceRef = rootNanopubId + "_" + Utils.createHash(spaceIri);
         IRI refIri = NPAS.forSpaceRef(spaceRef);
         try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
             conn.begin(IsolationLevels.SERIALIZABLE);
             conn.add(refIri, NPA_HAS_SPACE_IRI, spaceIri, NPA.GRAPH);
+            conn.add(refIri, NPA_HAS_ROOT_NANOPUB, rootNanopubUri, NPA.GRAPH);
             conn.commit();
         } catch (Exception ex) {
             log.info("Failed to persist space {}: {}", spaceRef, ex.toString());

--- a/src/main/java/com/knowledgepixels/query/SpacesStateStore.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesStateStore.java
@@ -17,26 +17,32 @@ import com.knowledgepixels.query.vocabulary.NPAS;
 import net.trustyuri.TrustyUriUtils;
 
 /**
- * Admin-repo persistence for {@link SpaceRegistry}'s known {@code (spaceRef, spaceIri)}
- * pairs. Mirrors the pattern used by {@link TrustStateLoader} for trust-state pointer
- * persistence: pure I/O wrapper around {@link TripleStore}, with a {@link #bootstrap}
- * call run once at startup and a {@link #persistSpace} call invoked whenever
- * {@link NanopubLoader#detectAndRegisterSpaces} adds a new space.
+ * Persistence for {@link SpaceRegistry}'s known {@code (spaceRef, spaceIri)} pairs,
+ * stored in the {@code spaces} repo's {@link NPA#GRAPH} alongside the per-space
+ * extract data. Mirrors the trust-state pattern, where the trust repo holds both
+ * the snapshots and its own pointer metadata in {@code npa:graph}.
  *
- * <p>Persisted shape (in the admin repo's {@link NPA#GRAPH}):
+ * <p>Persisted shape (in the {@code spaces} repo's {@link NPA#GRAPH}):
  * <pre>{@code
  *   <npas:spaceRef> npa:hasSpaceIri <spaceIRI> .
  * }</pre>
  *
- * <p>Role properties and the source-nanopub reverse index are <em>not</em> persisted
- * — they are re-derived as nanopubs flow through the loader. See
+ * <p>Putting it in the spaces repo (rather than the global admin repo) makes the
+ * spaces repo self-contained: a single SPARQL query against {@code spaces}
+ * answers both "what spaces exist?" and "what extracts has each accumulated?".
+ *
+ * <p>Role properties and the source-nanopub reverse index are <em>not</em>
+ * persisted — they are re-derived as nanopubs flow through the loader. See
  * {@code doc/plan-space-repositories.md}.
  */
-public class SpacesAdminStore {
+public class SpacesStateStore {
 
-    private static final Logger log = LoggerFactory.getLogger(SpacesAdminStore.class);
+    private static final Logger log = LoggerFactory.getLogger(SpacesStateStore.class);
 
     private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    /** Local name of the repository that holds per-space extract data and registry persistence. */
+    static final String SPACES_REPO = "spaces";
 
     /**
      * Predicate linking a space ref (subject in the {@code npas:} namespace) to its
@@ -45,22 +51,22 @@ public class SpacesAdminStore {
      */
     static final IRI NPA_HAS_SPACE_IRI = vf.createIRI(NPA.NAMESPACE, "hasSpaceIri");
 
-    private SpacesAdminStore() {
+    private SpacesStateStore() {
     }
 
     /**
-     * Loads any persisted {@code (spaceRef, spaceIri)} pairs from the admin repo and
-     * registers them in the given registry. Intended to run once at startup.
+     * Loads any persisted {@code (spaceRef, spaceIri)} pairs from the spaces repo
+     * and registers them in the given registry. Intended to run once at startup.
      *
-     * <p>Safe to call on a fresh deployment (admin repo may be empty — registers
-     * nothing). Any failure is logged at INFO; the registry is left empty and the
-     * loader will rebuild it as nanopubs flow through.
+     * <p>Safe to call on a fresh deployment (the spaces repo may not even exist —
+     * auto-created, found empty, seeded nothing). Any failure is logged at INFO;
+     * the registry is left empty and the loader will rebuild it as nanopubs flow.
      *
      * @param registry the registry to seed
      */
     public static void bootstrap(SpaceRegistry registry) {
         if (!FeatureFlags.spacesEnabled()) return;
-        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(TripleStore.ADMIN_REPO)) {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
             String query = String.format("""
                     SELECT ?ref ?iri WHERE {
                       GRAPH <%s> {
@@ -88,7 +94,7 @@ public class SpacesAdminStore {
                 }
             }
             if (loaded > 0) {
-                log.info("Spaces bootstrap: seeded {} space(s) from admin repo", loaded);
+                log.info("Spaces bootstrap: seeded {} space(s) from spaces repo", loaded);
             }
         } catch (Exception ex) {
             log.info("Spaces bootstrap: failed to read persisted spaces: {}", ex.toString());
@@ -100,7 +106,7 @@ public class SpacesAdminStore {
      * repo for {@link GEN#SPACE}. For each {@code <spaceIri> gen:hasRootDefinition
      * <rootUri>} triple found in any nanopub assertion there, registers the space
      * in {@link SpaceRegistry} and persists it via {@link #persistSpace} (so the
-     * admin-repo state catches up).
+     * spaces-repo state catches up).
      *
      * <p>Intended to run once at startup, after {@link #bootstrap}. Idempotent:
      * spaces already known to the registry are detected via the {@code wasNew}
@@ -168,9 +174,9 @@ public class SpacesAdminStore {
     }
 
     /**
-     * Persists a newly-registered {@code (spaceRef, spaceIri)} pair into the admin
-     * repo. Idempotent: re-persisting the same pair is harmless (the SPARQL INSERT
-     * just re-asserts an existing triple).
+     * Persists a newly-registered {@code (spaceRef, spaceIri)} pair into the
+     * spaces repo. Idempotent: re-persisting the same pair is harmless (the
+     * SPARQL INSERT just re-asserts an existing triple).
      *
      * @param rootNanopubId artifact code of the root nanopub
      * @param spaceIri      the Space IRI
@@ -179,7 +185,7 @@ public class SpacesAdminStore {
         if (!FeatureFlags.spacesEnabled()) return;
         String spaceRef = rootNanopubId + "_" + Utils.createHash(spaceIri);
         IRI refIri = NPAS.forSpaceRef(spaceRef);
-        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(TripleStore.ADMIN_REPO)) {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
             conn.begin(IsolationLevels.SERIALIZABLE);
             conn.add(refIri, NPA_HAS_SPACE_IRI, spaceIri, NPA.GRAPH);
             conn.commit();

--- a/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
@@ -36,10 +36,4 @@ public class GEN {
      */
     public static final IRI HAS_ADMIN = VocabUtils.createIRI(NAMESPACE, "hasAdmin");
 
-    /**
-     * The hardcoded admin role IRI. {@link #HAS_ADMIN} assertions are bound to this role.
-     * Future user-defined roles use IRIs declared by their role-definition nanopubs.
-     */
-    public static final IRI ADMIN_ROLE = VocabUtils.createIRI(NAMESPACE, "AdminRole");
-
 }

--- a/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
@@ -30,4 +30,10 @@ public class GEN {
      */
     public static final IRI HAS_ROOT_DEFINITION = VocabUtils.createIRI(NAMESPACE, "hasRootDefinition");
 
+    /**
+     * Predicate granting admin role for a space: {@code <spaceIri> gen:hasAdmin <agent>}.
+     * In the MVP this is the only admin-granting mechanism (no user-defined admin roles).
+     */
+    public static final IRI HAS_ADMIN = VocabUtils.createIRI(NAMESPACE, "hasAdmin");
+
 }

--- a/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
@@ -36,4 +36,10 @@ public class GEN {
      */
     public static final IRI HAS_ADMIN = VocabUtils.createIRI(NAMESPACE, "hasAdmin");
 
+    /**
+     * The hardcoded admin role IRI. {@link #HAS_ADMIN} assertions are bound to this role.
+     * Future user-defined roles use IRIs declared by their role-definition nanopubs.
+     */
+    public static final IRI ADMIN_ROLE = VocabUtils.createIRI(NAMESPACE, "AdminRole");
+
 }

--- a/src/main/java/com/knowledgepixels/query/vocabulary/NPAX.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/NPAX.java
@@ -1,0 +1,35 @@
+package com.knowledgepixels.query.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
+import org.nanopub.vocabulary.VocabUtils;
+
+/**
+ * Namespace declaration for extract IRIs in the {@code spaces} repo.
+ *
+ * <p>Each extract is identified by {@code npax:<extractHash>}, expanded from
+ * {@code http://purl.org/nanopub/admin/extract/}. The hash is
+ * {@code SHA-256(spaceRef + "|" + sourceNanopubUri + "|" + extractKindLocalName + "|" + payload)}
+ * — deterministic, so re-extracting the same source nanopub for the same
+ * space yields the same IRI (idempotent re-extraction; no duplicates).
+ */
+public class NPAX {
+
+    public static final String NAMESPACE = "http://purl.org/nanopub/admin/extract/";
+    public static final String PREFIX = "npax";
+    public static final Namespace NS = VocabUtils.createNamespace(PREFIX, NAMESPACE);
+
+    private NPAX() {
+    }
+
+    /**
+     * Mints the extract IRI for the given hash.
+     *
+     * @param extractHash 64-hex-char SHA-256 of the extract's stable inputs
+     * @return the IRI {@code npax:<extractHash>}
+     */
+    public static IRI forHash(String extractHash) {
+        return VocabUtils.createIRI(NAMESPACE, extractHash);
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpaceExtract.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpaceExtract.java
@@ -14,25 +14,54 @@ import org.nanopub.vocabulary.VocabUtils;
  * extract-kind class:
  *
  * <pre>{@code
- * npax:<hash> a npa:AdminGrant ;
- *             npa:viaNanopub <sourceNp> ;
- *             … kind-specific payload predicates … .
+ * npax:<hash> a npa:RoleAssertion ;
+ *             npa:rolePredicate gen:hasAdmin ;
+ *             npa:roleDirection npa:inverse ;
+ *             npa:agent         <orcid:…> ;
+ *             npa:viaNanopub    <sourceNp> .
  * }</pre>
  *
  * <p>Class IRIs discriminate the kind directly via {@code rdf:type} (mirroring
  * the trust-state pattern with {@code npa:TrustState} / {@code npa:AccountState}).
- * Payload predicates ({@link #FIELD_KEY}, {@link #FIELD_VALUE}, plus shared
- * {@link SpaceAuthority#AGENT}) carry the kind-specific detail.
+ *
+ * <p>Note on naming: the validated, materialized counterpart of a role
+ * assertion is {@code npa:RoleAssignment} (see {@link SpaceAuthority}). The
+ * extract layer uses {@code npa:RoleAssertion} ("someone asserted this") to
+ * keep the validated name {@code npa:RoleAssignment} ("this assignment is
+ * resolved/valid") clean for consumer queries.
  *
  * <p>See {@code doc/plan-space-repositories.md}.
  */
 public class SpaceExtract {
 
-    /** Extract class: a {@code gen:hasAdmin} grant (granted agent in {@link SpaceAuthority#AGENT}). */
-    public static final IRI ADMIN_GRANT = createIRI("AdminGrant");
+    /**
+     * Extract class: an assertion that an agent has been assigned a role for a
+     * space, via some role property (built-in like {@code gen:hasAdmin} or
+     * learned from a role-definition nanopub). Carries
+     * {@link #ROLE_PREDICATE}, {@link #ROLE_DIRECTION}, and
+     * {@link SpaceAuthority#AGENT}. The materializer resolves
+     * predicate-to-role and validates publisher entitlement separately.
+     */
+    public static final IRI ROLE_ASSERTION = createIRI("RoleAssertion");
 
     /** Extract class: a profile field about the Space IRI (carries {@link #FIELD_KEY} + {@link #FIELD_VALUE}). */
     public static final IRI PROFILE_FIELD = createIRI("ProfileField");
+
+    /** Predicate of the role-property used in the underlying assignment triple. */
+    public static final IRI ROLE_PREDICATE = createIRI("rolePredicate");
+
+    /**
+     * Direction of the role-property in the underlying assignment triple — one of
+     * {@link #REGULAR} ({@code <member> <predicate> <space>}) or {@link #INVERSE}
+     * ({@code <space> <predicate> <member>}).
+     */
+    public static final IRI ROLE_DIRECTION = createIRI("roleDirection");
+
+    /** {@link #ROLE_DIRECTION} value: regular — assignment triple is {@code <member> <predicate> <space>}. */
+    public static final IRI REGULAR = createIRI("regular");
+
+    /** {@link #ROLE_DIRECTION} value: inverse — assignment triple is {@code <space> <predicate> <member>}. */
+    public static final IRI INVERSE = createIRI("inverse");
 
     /** Predicate of the extracted profile triple (e.g. {@code dcterms:description}, {@code owl:sameAs}). */
     public static final IRI FIELD_KEY = createIRI("fieldKey");

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpaceExtract.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpaceExtract.java
@@ -1,0 +1,56 @@
+package com.knowledgepixels.query.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.nanopub.vocabulary.NPA;
+import org.nanopub.vocabulary.VocabUtils;
+
+/**
+ * IRIs in the {@code npa:} namespace used for <em>extract</em> objects in a
+ * space's named graph in the {@code spaces} repo.
+ *
+ * <p>Extracts are the loader's per-source-nanopub contributions — the inputs
+ * the materializer (see {@link SpaceAuthority}) iterates to compute closures
+ * and produce the validated authority view. Each extract has the shape:
+ *
+ * <pre>{@code
+ * npax:<hash> a npa:Extract ;
+ *             npa:extractKind <kind> ;
+ *             npa:viaNanopub  <sourceNp> ;
+ *             … kind-specific payload predicates … .
+ * }</pre>
+ *
+ * <p>Kind individuals enumerate what the extract represents (admin grant,
+ * profile field, etc.). Payload predicates (e.g. {@link #FIELD_KEY},
+ * {@link #FIELD_VALUE}, plus shared {@link SpaceAuthority#AGENT}) carry the
+ * kind-specific detail.
+ *
+ * <p>See {@code doc/plan-space-repositories.md}.
+ */
+public class SpaceExtract {
+
+    /** RDF type for extract objects. */
+    public static final IRI EXTRACT = createIRI("Extract");
+
+    /** Tags an {@link #EXTRACT} object with one of the extract-kind individuals below. */
+    public static final IRI EXTRACT_KIND = createIRI("extractKind");
+
+    /** Extract kind: a {@code gen:hasAdmin} grant (object = granted agent IRI in {@link SpaceAuthority#AGENT}). */
+    public static final IRI ADMIN_GRANT = createIRI("adminGrant");
+
+    /** Extract kind: a profile field about the Space IRI (carries {@link #FIELD_KEY} + {@link #FIELD_VALUE}). */
+    public static final IRI PROFILE_FIELD = createIRI("profileField");
+
+    /** Predicate of the extracted profile triple (e.g. {@code dcterms:description}, {@code owl:sameAs}). */
+    public static final IRI FIELD_KEY = createIRI("fieldKey");
+
+    /** Object of the extracted profile triple — IRI or literal. */
+    public static final IRI FIELD_VALUE = createIRI("fieldValue");
+
+    private SpaceExtract() {
+    }
+
+    private static IRI createIRI(String localName) {
+        return VocabUtils.createIRI(NPA.NAMESPACE, localName);
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpaceExtract.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpaceExtract.java
@@ -17,17 +17,16 @@ import org.nanopub.vocabulary.VocabUtils;
  * npax:<hash> a npa:RoleAssertion ;
  *             npa:rolePredicate gen:hasAdmin ;
  *             npa:roleDirection npa:inverse ;
- *             npa:role          gen:AdminRole ;
  *             npa:agent         <orcid:…> ;
  *             npa:viaNanopub    <sourceNp> .
  * }</pre>
  *
- * <p>{@code npa:role} carries the resolved role IRI. For built-in predicates
- * ({@code gen:hasAdmin}, future {@code gen:hasMaintainer}) it's hardcoded; for
- * learned predicates from role-definition nanopubs it's looked up via
- * {@link com.knowledgepixels.query.SpaceRegistry}. Multiple predicates can map
- * to the same role, so this link lets consumer queries group by role without
- * enumerating predicates.
+ * <p>The role IRI is intentionally absent from PR-B1 extracts — Nanodash's
+ * roles are declared in published role-definition nanopubs (e.g. the global
+ * "Build-in admin role" nanopub), not in hardcoded class IRIs. PR-B2 will
+ * extract those role definitions and add an {@code npa:role} link to role
+ * assertions so consumer queries can group by role without enumerating
+ * predicates.
  *
  * <p>Class IRIs discriminate the kind directly via {@code rdf:type} (mirroring
  * the trust-state pattern with {@code npa:TrustState} / {@code npa:AccountState}).

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpaceExtract.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpaceExtract.java
@@ -10,35 +10,29 @@ import org.nanopub.vocabulary.VocabUtils;
  *
  * <p>Extracts are the loader's per-source-nanopub contributions — the inputs
  * the materializer (see {@link SpaceAuthority}) iterates to compute closures
- * and produce the validated authority view. Each extract has the shape:
+ * and produce the validated authority view. Each extract is an instance of one
+ * extract-kind class:
  *
  * <pre>{@code
- * npax:<hash> a npa:Extract ;
- *             npa:extractKind <kind> ;
- *             npa:viaNanopub  <sourceNp> ;
+ * npax:<hash> a npa:AdminGrant ;
+ *             npa:viaNanopub <sourceNp> ;
  *             … kind-specific payload predicates … .
  * }</pre>
  *
- * <p>Kind individuals enumerate what the extract represents (admin grant,
- * profile field, etc.). Payload predicates (e.g. {@link #FIELD_KEY},
- * {@link #FIELD_VALUE}, plus shared {@link SpaceAuthority#AGENT}) carry the
- * kind-specific detail.
+ * <p>Class IRIs discriminate the kind directly via {@code rdf:type} (mirroring
+ * the trust-state pattern with {@code npa:TrustState} / {@code npa:AccountState}).
+ * Payload predicates ({@link #FIELD_KEY}, {@link #FIELD_VALUE}, plus shared
+ * {@link SpaceAuthority#AGENT}) carry the kind-specific detail.
  *
  * <p>See {@code doc/plan-space-repositories.md}.
  */
 public class SpaceExtract {
 
-    /** RDF type for extract objects. */
-    public static final IRI EXTRACT = createIRI("Extract");
+    /** Extract class: a {@code gen:hasAdmin} grant (granted agent in {@link SpaceAuthority#AGENT}). */
+    public static final IRI ADMIN_GRANT = createIRI("AdminGrant");
 
-    /** Tags an {@link #EXTRACT} object with one of the extract-kind individuals below. */
-    public static final IRI EXTRACT_KIND = createIRI("extractKind");
-
-    /** Extract kind: a {@code gen:hasAdmin} grant (object = granted agent IRI in {@link SpaceAuthority#AGENT}). */
-    public static final IRI ADMIN_GRANT = createIRI("adminGrant");
-
-    /** Extract kind: a profile field about the Space IRI (carries {@link #FIELD_KEY} + {@link #FIELD_VALUE}). */
-    public static final IRI PROFILE_FIELD = createIRI("profileField");
+    /** Extract class: a profile field about the Space IRI (carries {@link #FIELD_KEY} + {@link #FIELD_VALUE}). */
+    public static final IRI PROFILE_FIELD = createIRI("ProfileField");
 
     /** Predicate of the extracted profile triple (e.g. {@code dcterms:description}, {@code owl:sameAs}). */
     public static final IRI FIELD_KEY = createIRI("fieldKey");

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpaceExtract.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpaceExtract.java
@@ -17,9 +17,17 @@ import org.nanopub.vocabulary.VocabUtils;
  * npax:<hash> a npa:RoleAssertion ;
  *             npa:rolePredicate gen:hasAdmin ;
  *             npa:roleDirection npa:inverse ;
+ *             npa:role          gen:AdminRole ;
  *             npa:agent         <orcid:…> ;
  *             npa:viaNanopub    <sourceNp> .
  * }</pre>
+ *
+ * <p>{@code npa:role} carries the resolved role IRI. For built-in predicates
+ * ({@code gen:hasAdmin}, future {@code gen:hasMaintainer}) it's hardcoded; for
+ * learned predicates from role-definition nanopubs it's looked up via
+ * {@link com.knowledgepixels.query.SpaceRegistry}. Multiple predicates can map
+ * to the same role, so this link lets consumer queries group by role without
+ * enumerating predicates.
  *
  * <p>Class IRIs discriminate the kind directly via {@code rdf:type} (mirroring
  * the trust-state pattern with {@code npa:TrustState} / {@code npa:AccountState}).

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -1,0 +1,306 @@
+package com.knowledgepixels.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubUtils;
+
+import com.knowledgepixels.query.vocabulary.GEN;
+import com.knowledgepixels.query.vocabulary.NPAS;
+import com.knowledgepixels.query.vocabulary.NPAX;
+import com.knowledgepixels.query.vocabulary.SpaceAuthority;
+import com.knowledgepixels.query.vocabulary.SpaceExtract;
+
+class SpacesExtractorTest {
+
+    private static final String ROOT_NP_AC = "RA1234567890123456789012345678901234567890123";
+    private static final String OTHER_NP_AC = "RA9999999999999999999999999999999999999999999";
+    private static final IRI ROOT_NP_URI = Values.iri("https://w3id.org/np/" + ROOT_NP_AC);
+    private static final IRI OTHER_NP_URI = Values.iri("https://w3id.org/np/" + OTHER_NP_AC);
+    private static final IRI SPACE_A = Values.iri("https://example.org/spaceA");
+    private static final IRI SPACE_B = Values.iri("https://example.org/spaceB");
+    private static final IRI ALICE = Values.iri("https://orcid.org/0000-0000-0000-0001");
+    private static final IRI BOB = Values.iri("https://orcid.org/0000-0000-0000-0002");
+
+    private MockedStatic<Utils> mockedUtils;
+    private MockedStatic<NanopubUtils> mockedNanopubUtils;
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException, IllegalAccessException {
+        Field instance = SpaceRegistry.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+
+        mockedUtils = Mockito.mockStatic(Utils.class);
+        mockedUtils.when(() -> Utils.createHash(any()))
+                .thenAnswer(inv -> "H(" + inv.getArgument(0) + ")");
+        // FeatureFlags.spacesEnabled() reads Utils.getEnvString. Under mockStatic the
+        // default answer is null, which would silently disable the feature and cause
+        // detectAndRegisterSpaces to no-op — stub to return the passed-in default so
+        // production-default semantics apply in tests.
+        mockedUtils.when(() -> Utils.getEnvString(any(), any()))
+                .thenAnswer(inv -> inv.getArgument(1));
+
+        mockedNanopubUtils = Mockito.mockStatic(NanopubUtils.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedUtils.close();
+        mockedNanopubUtils.close();
+    }
+
+    private Nanopub mockNanopub(IRI npUri, Set<IRI> types, Set<Statement> assertion) {
+        Nanopub np = mock(Nanopub.class);
+        when(np.getUri()).thenReturn(npUri);
+        when(np.getAssertion()).thenReturn(assertion);
+        mockedNanopubUtils.when(() -> NanopubUtils.getTypes(np)).thenReturn(types);
+        return np;
+    }
+
+    private Statement triple(IRI s, IRI p, Value o) {
+        return Values.getValueFactory().createStatement(s, p, o);
+    }
+
+    private String spaceRef(String npAc, IRI spaceIri) {
+        return npAc + "_H(" + spaceIri + ")";
+    }
+
+    private static Statement findOne(Set<Statement> stmts, IRI subj, IRI pred) {
+        Statement found = null;
+        for (Statement s : stmts) {
+            if (s.getSubject().equals(subj) && s.getPredicate().equals(pred)) {
+                if (found != null) {
+                    throw new AssertionError("Multiple matches for " + subj + " " + pred);
+                }
+                found = s;
+            }
+        }
+        return found;
+    }
+
+    // -------- admin-grant extraction --------
+
+    @Test
+    void unknownSpace_producesNoExtracts() {
+        // SpaceRegistry is empty — no Space IRIs are registered.
+        Set<Statement> assertion = new LinkedHashSet<>();
+        assertion.add(triple(SPACE_A, GEN.HAS_ADMIN, ALICE));
+        Nanopub np = mockNanopub(OTHER_NP_URI, Set.of(), assertion);
+
+        SpacesExtractor.ExtractionResult result = SpacesExtractor.extract(np, SpaceRegistry.get());
+
+        assertTrue(result.statements().isEmpty());
+        assertTrue(result.spaceRefs().isEmpty());
+    }
+
+    @Test
+    void adminGrantInSpaceDefiningNanopub_producesAdminExtract() {
+        // Root nanopub defines space A and grants admin to Alice.
+        Set<Statement> assertion = new LinkedHashSet<>();
+        assertion.add(triple(SPACE_A, RDF.TYPE, GEN.SPACE));
+        assertion.add(triple(SPACE_A, GEN.HAS_ROOT_DEFINITION, ROOT_NP_URI));
+        assertion.add(triple(SPACE_A, GEN.HAS_ADMIN, ALICE));
+        Nanopub np = mockNanopub(ROOT_NP_URI, Set.of(GEN.SPACE), assertion);
+
+        // Pre-register space A so the extractor knows about it.
+        NanopubLoader.detectAndRegisterSpaces(np);
+
+        SpacesExtractor.ExtractionResult result = SpacesExtractor.extract(np, SpaceRegistry.get());
+
+        String ref = spaceRef(ROOT_NP_AC, SPACE_A);
+        assertEquals(Set.of(ref), result.spaceRefs());
+
+        // Find the admin-grant extract object.
+        Set<Statement> stmts = new LinkedHashSet<>(result.statements());
+        IRI graph = NPAS.forSpaceRef(ref);
+        // Locate the extract IRI by the kind triple.
+        IRI extractIri = null;
+        for (Statement s : stmts) {
+            if (SpaceExtract.EXTRACT_KIND.equals(s.getPredicate())
+                    && SpaceExtract.ADMIN_GRANT.equals(s.getObject())) {
+                extractIri = (IRI) s.getSubject();
+                break;
+            }
+        }
+        assertEquals(NPAX.NAMESPACE,
+                extractIri.stringValue().substring(0, NPAX.NAMESPACE.length()),
+                "extract IRI must use the npax: namespace");
+
+        // Expect the four shape triples, all in the per-space graph context.
+        assertEquals(SpaceExtract.EXTRACT, findOne(stmts, extractIri, RDF.TYPE).getObject());
+        assertEquals(SpaceExtract.ADMIN_GRANT, findOne(stmts, extractIri, SpaceExtract.EXTRACT_KIND).getObject());
+        assertEquals(ALICE, findOne(stmts, extractIri, SpaceAuthority.AGENT).getObject());
+        assertEquals(ROOT_NP_URI, findOne(stmts, extractIri, SpaceAuthority.VIA_NANOPUB).getObject());
+        for (Statement s : stmts) {
+            if (s.getSubject().equals(extractIri)) {
+                assertEquals(graph, s.getContext(), "extract triples must be in the per-space named graph");
+            }
+        }
+    }
+
+    @Test
+    void adminGrantFromOtherNanopub_extractsToKnownSpace() {
+        // Pre-register space A via its root nanopub.
+        Set<Statement> rootAssertion = new LinkedHashSet<>();
+        rootAssertion.add(triple(SPACE_A, RDF.TYPE, GEN.SPACE));
+        rootAssertion.add(triple(SPACE_A, GEN.HAS_ROOT_DEFINITION, ROOT_NP_URI));
+        rootAssertion.add(triple(SPACE_A, GEN.HAS_ADMIN, ALICE));
+        NanopubLoader.detectAndRegisterSpaces(
+                mockNanopub(ROOT_NP_URI, Set.of(GEN.SPACE), rootAssertion));
+
+        // Now an unrelated nanopub asserts gen:hasAdmin for the known space.
+        Set<Statement> otherAssertion = new LinkedHashSet<>();
+        otherAssertion.add(triple(SPACE_A, GEN.HAS_ADMIN, BOB));
+        Nanopub other = mockNanopub(OTHER_NP_URI, Set.of(), otherAssertion);
+
+        SpacesExtractor.ExtractionResult result = SpacesExtractor.extract(other, SpaceRegistry.get());
+
+        String ref = spaceRef(ROOT_NP_AC, SPACE_A);
+        assertEquals(Set.of(ref), result.spaceRefs());
+        // Exactly one admin-grant extract for Bob.
+        long bobExtracts = result.statements().stream()
+                .filter(s -> SpaceAuthority.AGENT.equals(s.getPredicate()) && BOB.equals(s.getObject()))
+                .count();
+        assertEquals(1, bobExtracts);
+    }
+
+    @Test
+    void adminGrantHashes_areDeterministicAcrossExtractions() {
+        Set<Statement> assertion = new LinkedHashSet<>();
+        assertion.add(triple(SPACE_A, RDF.TYPE, GEN.SPACE));
+        assertion.add(triple(SPACE_A, GEN.HAS_ROOT_DEFINITION, ROOT_NP_URI));
+        assertion.add(triple(SPACE_A, GEN.HAS_ADMIN, ALICE));
+        Nanopub np1 = mockNanopub(ROOT_NP_URI, Set.of(GEN.SPACE), assertion);
+        NanopubLoader.detectAndRegisterSpaces(np1);
+        SpacesExtractor.ExtractionResult r1 = SpacesExtractor.extract(np1, SpaceRegistry.get());
+
+        // Build a second nanopub mock with the exact same content.
+        Nanopub np2 = mockNanopub(ROOT_NP_URI, Set.of(GEN.SPACE), assertion);
+        SpacesExtractor.ExtractionResult r2 = SpacesExtractor.extract(np2, SpaceRegistry.get());
+
+        // Same inputs → same extract IRIs (so RDF4J set semantics dedupes on re-loading).
+        Set<IRI> subjects1 = r1.statements().stream().map(s -> (IRI) s.getSubject())
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        Set<IRI> subjects2 = r2.statements().stream().map(s -> (IRI) s.getSubject())
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        assertEquals(subjects1, subjects2);
+    }
+
+    @Test
+    void adminGrantHashes_differAcrossSpacesAndAgents() {
+        // Two spaces, two agents — every (space, agent) pair gets its own extract IRI.
+        String h1 = SpacesExtractor.extractHash(spaceRef(ROOT_NP_AC, SPACE_A), ROOT_NP_URI,
+                SpaceExtract.ADMIN_GRANT, ALICE.stringValue());
+        String h2 = SpacesExtractor.extractHash(spaceRef(ROOT_NP_AC, SPACE_A), ROOT_NP_URI,
+                SpaceExtract.ADMIN_GRANT, BOB.stringValue());
+        String h3 = SpacesExtractor.extractHash(spaceRef(ROOT_NP_AC, SPACE_B), ROOT_NP_URI,
+                SpaceExtract.ADMIN_GRANT, ALICE.stringValue());
+        assertNotEquals(h1, h2);
+        assertNotEquals(h1, h3);
+        assertNotEquals(h2, h3);
+    }
+
+    // -------- profile-field extraction --------
+
+    @Test
+    void profileFields_areExtractedFromSpaceDefiningNanopub() {
+        Set<Statement> assertion = new LinkedHashSet<>();
+        assertion.add(triple(SPACE_A, RDF.TYPE, GEN.SPACE));
+        assertion.add(triple(SPACE_A, GEN.HAS_ROOT_DEFINITION, ROOT_NP_URI));
+        assertion.add(triple(SPACE_A, DCTERMS.DESCRIPTION, Values.literal("Space A")));
+        assertion.add(triple(SPACE_A, OWL.SAMEAS, Values.iri("https://other.example/spaceA-alt")));
+        Nanopub np = mockNanopub(ROOT_NP_URI, Set.of(GEN.SPACE), assertion);
+
+        NanopubLoader.detectAndRegisterSpaces(np);
+        SpacesExtractor.ExtractionResult result = SpacesExtractor.extract(np, SpaceRegistry.get());
+
+        // We expect: 0 admin-grant extracts (none in this assertion),
+        // 2 profile-field extracts (description, sameAs).
+        long profileExtracts = result.statements().stream()
+                .filter(s -> SpaceExtract.PROFILE_FIELD.equals(s.getObject())
+                        && SpaceExtract.EXTRACT_KIND.equals(s.getPredicate()))
+                .count();
+        assertEquals(2, profileExtracts);
+
+        // Each profile extract carries fieldKey and fieldValue.
+        long fieldKeyTriples = result.statements().stream()
+                .filter(s -> SpaceExtract.FIELD_KEY.equals(s.getPredicate()))
+                .count();
+        assertEquals(2, fieldKeyTriples);
+    }
+
+    @Test
+    void profileFields_skipStructuralAndAuthorityTriples() {
+        Set<Statement> assertion = new LinkedHashSet<>();
+        assertion.add(triple(SPACE_A, RDF.TYPE, GEN.SPACE));
+        assertion.add(triple(SPACE_A, GEN.HAS_ROOT_DEFINITION, ROOT_NP_URI));
+        assertion.add(triple(SPACE_A, GEN.HAS_ADMIN, ALICE));
+        Nanopub np = mockNanopub(ROOT_NP_URI, Set.of(GEN.SPACE), assertion);
+
+        NanopubLoader.detectAndRegisterSpaces(np);
+        SpacesExtractor.ExtractionResult result = SpacesExtractor.extract(np, SpaceRegistry.get());
+
+        // The only profile field would be rdf:type gen:Space — but neither
+        // gen:hasRootDefinition nor gen:hasAdmin should appear as profile fields.
+        // (rdf:type is currently treated as a profile field since it's not in the skip list.)
+        long roots = result.statements().stream()
+                .filter(s -> SpaceExtract.FIELD_KEY.equals(s.getPredicate())
+                        && GEN.HAS_ROOT_DEFINITION.equals(s.getObject()))
+                .count();
+        long admins = result.statements().stream()
+                .filter(s -> SpaceExtract.FIELD_KEY.equals(s.getPredicate())
+                        && GEN.HAS_ADMIN.equals(s.getObject()))
+                .count();
+        assertEquals(0, roots);
+        assertEquals(0, admins);
+    }
+
+    @Test
+    void profileFields_areNotExtractedFromNonSpaceDefiningNanopub() {
+        // Pre-register space A.
+        Set<Statement> rootAssertion = new LinkedHashSet<>();
+        rootAssertion.add(triple(SPACE_A, RDF.TYPE, GEN.SPACE));
+        rootAssertion.add(triple(SPACE_A, GEN.HAS_ROOT_DEFINITION, ROOT_NP_URI));
+        NanopubLoader.detectAndRegisterSpaces(
+                mockNanopub(ROOT_NP_URI, Set.of(GEN.SPACE), rootAssertion));
+
+        // A *non*-space-defining nanopub mentions the Space IRI (e.g. someone
+        // tries to set its description from outside). We do NOT extract this
+        // as a profile field — only space-defining nanopubs contribute profile.
+        Set<Statement> otherAssertion = new LinkedHashSet<>();
+        otherAssertion.add(triple(SPACE_A, DCTERMS.DESCRIPTION, Values.literal("Hijacked!")));
+        Nanopub other = mockNanopub(OTHER_NP_URI, Set.of(), otherAssertion);
+
+        SpacesExtractor.ExtractionResult result = SpacesExtractor.extract(other, SpaceRegistry.get());
+
+        long profileExtracts = result.statements().stream()
+                .filter(s -> SpaceExtract.PROFILE_FIELD.equals(s.getObject())
+                        && SpaceExtract.EXTRACT_KIND.equals(s.getPredicate()))
+                .count();
+        assertEquals(0, profileExtracts);
+        assertTrue(result.spaceRefs().isEmpty());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -147,10 +147,11 @@ class SpacesExtractorTest {
                 extractIri.stringValue().substring(0, NPAX.NAMESPACE.length()),
                 "extract IRI must use the npax: namespace");
 
-        // Expect the five shape triples, all in the per-space graph context.
+        // Expect the six shape triples, all in the per-space graph context.
         assertEquals(SpaceExtract.ROLE_ASSERTION, findOne(stmts, extractIri, RDF.TYPE).getObject());
         assertEquals(GEN.HAS_ADMIN, findOne(stmts, extractIri, SpaceExtract.ROLE_PREDICATE).getObject());
         assertEquals(SpaceExtract.INVERSE, findOne(stmts, extractIri, SpaceExtract.ROLE_DIRECTION).getObject());
+        assertEquals(GEN.ADMIN_ROLE, findOne(stmts, extractIri, SpaceAuthority.ROLE).getObject());
         assertEquals(ALICE, findOne(stmts, extractIri, SpaceAuthority.AGENT).getObject());
         assertEquals(ROOT_NP_URI, findOne(stmts, extractIri, SpaceAuthority.VIA_NANOPUB).getObject());
         for (Statement s : stmts) {

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -132,13 +132,12 @@ class SpacesExtractorTest {
         String ref = spaceRef(ROOT_NP_AC, SPACE_A);
         assertEquals(Set.of(ref), result.spaceRefs());
 
-        // Find the admin-grant extract object.
+        // Find the admin-grant extract object via its rdf:type.
         Set<Statement> stmts = new LinkedHashSet<>(result.statements());
         IRI graph = NPAS.forSpaceRef(ref);
-        // Locate the extract IRI by the kind triple.
         IRI extractIri = null;
         for (Statement s : stmts) {
-            if (SpaceExtract.EXTRACT_KIND.equals(s.getPredicate())
+            if (RDF.TYPE.equals(s.getPredicate())
                     && SpaceExtract.ADMIN_GRANT.equals(s.getObject())) {
                 extractIri = (IRI) s.getSubject();
                 break;
@@ -148,9 +147,8 @@ class SpacesExtractorTest {
                 extractIri.stringValue().substring(0, NPAX.NAMESPACE.length()),
                 "extract IRI must use the npax: namespace");
 
-        // Expect the four shape triples, all in the per-space graph context.
-        assertEquals(SpaceExtract.EXTRACT, findOne(stmts, extractIri, RDF.TYPE).getObject());
-        assertEquals(SpaceExtract.ADMIN_GRANT, findOne(stmts, extractIri, SpaceExtract.EXTRACT_KIND).getObject());
+        // Expect the three shape triples, all in the per-space graph context.
+        assertEquals(SpaceExtract.ADMIN_GRANT, findOne(stmts, extractIri, RDF.TYPE).getObject());
         assertEquals(ALICE, findOne(stmts, extractIri, SpaceAuthority.AGENT).getObject());
         assertEquals(ROOT_NP_URI, findOne(stmts, extractIri, SpaceAuthority.VIA_NANOPUB).getObject());
         for (Statement s : stmts) {
@@ -239,8 +237,8 @@ class SpacesExtractorTest {
         // We expect: 0 admin-grant extracts (none in this assertion),
         // 2 profile-field extracts (description, sameAs).
         long profileExtracts = result.statements().stream()
-                .filter(s -> SpaceExtract.PROFILE_FIELD.equals(s.getObject())
-                        && SpaceExtract.EXTRACT_KIND.equals(s.getPredicate()))
+                .filter(s -> RDF.TYPE.equals(s.getPredicate())
+                        && SpaceExtract.PROFILE_FIELD.equals(s.getObject()))
                 .count();
         assertEquals(2, profileExtracts);
 
@@ -296,8 +294,8 @@ class SpacesExtractorTest {
         SpacesExtractor.ExtractionResult result = SpacesExtractor.extract(other, SpaceRegistry.get());
 
         long profileExtracts = result.statements().stream()
-                .filter(s -> SpaceExtract.PROFILE_FIELD.equals(s.getObject())
-                        && SpaceExtract.EXTRACT_KIND.equals(s.getPredicate()))
+                .filter(s -> RDF.TYPE.equals(s.getPredicate())
+                        && SpaceExtract.PROFILE_FIELD.equals(s.getObject()))
                 .count();
         assertEquals(0, profileExtracts);
         assertTrue(result.spaceRefs().isEmpty());

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -147,11 +147,10 @@ class SpacesExtractorTest {
                 extractIri.stringValue().substring(0, NPAX.NAMESPACE.length()),
                 "extract IRI must use the npax: namespace");
 
-        // Expect the six shape triples, all in the per-space graph context.
+        // Expect the five shape triples, all in the per-space graph context.
         assertEquals(SpaceExtract.ROLE_ASSERTION, findOne(stmts, extractIri, RDF.TYPE).getObject());
         assertEquals(GEN.HAS_ADMIN, findOne(stmts, extractIri, SpaceExtract.ROLE_PREDICATE).getObject());
         assertEquals(SpaceExtract.INVERSE, findOne(stmts, extractIri, SpaceExtract.ROLE_DIRECTION).getObject());
-        assertEquals(GEN.ADMIN_ROLE, findOne(stmts, extractIri, SpaceAuthority.ROLE).getObject());
         assertEquals(ALICE, findOne(stmts, extractIri, SpaceAuthority.AGENT).getObject());
         assertEquals(ROOT_NP_URI, findOne(stmts, extractIri, SpaceAuthority.VIA_NANOPUB).getObject());
         for (Statement s : stmts) {

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -116,7 +116,7 @@ class SpacesExtractorTest {
     }
 
     @Test
-    void adminGrantInSpaceDefiningNanopub_producesAdminExtract() {
+    void adminGrantInSpaceDefiningNanopub_producesRoleAssertionExtract() {
         // Root nanopub defines space A and grants admin to Alice.
         Set<Statement> assertion = new LinkedHashSet<>();
         assertion.add(triple(SPACE_A, RDF.TYPE, GEN.SPACE));
@@ -132,13 +132,13 @@ class SpacesExtractorTest {
         String ref = spaceRef(ROOT_NP_AC, SPACE_A);
         assertEquals(Set.of(ref), result.spaceRefs());
 
-        // Find the admin-grant extract object via its rdf:type.
+        // Find the role-assertion extract object via its rdf:type.
         Set<Statement> stmts = new LinkedHashSet<>(result.statements());
         IRI graph = NPAS.forSpaceRef(ref);
         IRI extractIri = null;
         for (Statement s : stmts) {
             if (RDF.TYPE.equals(s.getPredicate())
-                    && SpaceExtract.ADMIN_GRANT.equals(s.getObject())) {
+                    && SpaceExtract.ROLE_ASSERTION.equals(s.getObject())) {
                 extractIri = (IRI) s.getSubject();
                 break;
             }
@@ -147,8 +147,10 @@ class SpacesExtractorTest {
                 extractIri.stringValue().substring(0, NPAX.NAMESPACE.length()),
                 "extract IRI must use the npax: namespace");
 
-        // Expect the three shape triples, all in the per-space graph context.
-        assertEquals(SpaceExtract.ADMIN_GRANT, findOne(stmts, extractIri, RDF.TYPE).getObject());
+        // Expect the five shape triples, all in the per-space graph context.
+        assertEquals(SpaceExtract.ROLE_ASSERTION, findOne(stmts, extractIri, RDF.TYPE).getObject());
+        assertEquals(GEN.HAS_ADMIN, findOne(stmts, extractIri, SpaceExtract.ROLE_PREDICATE).getObject());
+        assertEquals(SpaceExtract.INVERSE, findOne(stmts, extractIri, SpaceExtract.ROLE_DIRECTION).getObject());
         assertEquals(ALICE, findOne(stmts, extractIri, SpaceAuthority.AGENT).getObject());
         assertEquals(ROOT_NP_URI, findOne(stmts, extractIri, SpaceAuthority.VIA_NANOPUB).getObject());
         for (Statement s : stmts) {
@@ -177,7 +179,7 @@ class SpacesExtractorTest {
 
         String ref = spaceRef(ROOT_NP_AC, SPACE_A);
         assertEquals(Set.of(ref), result.spaceRefs());
-        // Exactly one admin-grant extract for Bob.
+        // Exactly one role-assertion extract for Bob.
         long bobExtracts = result.statements().stream()
                 .filter(s -> SpaceAuthority.AGENT.equals(s.getPredicate()) && BOB.equals(s.getObject()))
                 .count();
@@ -185,7 +187,7 @@ class SpacesExtractorTest {
     }
 
     @Test
-    void adminGrantHashes_areDeterministicAcrossExtractions() {
+    void roleAssertionHashes_areDeterministicAcrossExtractions() {
         Set<Statement> assertion = new LinkedHashSet<>();
         assertion.add(triple(SPACE_A, RDF.TYPE, GEN.SPACE));
         assertion.add(triple(SPACE_A, GEN.HAS_ROOT_DEFINITION, ROOT_NP_URI));
@@ -207,14 +209,16 @@ class SpacesExtractorTest {
     }
 
     @Test
-    void adminGrantHashes_differAcrossSpacesAndAgents() {
-        // Two spaces, two agents — every (space, agent) pair gets its own extract IRI.
+    void roleAssertionHashes_differAcrossSpacesAgentsAndPredicates() {
+        String pAdmin = GEN.HAS_ADMIN.stringValue();
+        String dInverse = SpaceExtract.INVERSE.stringValue();
+        // Same predicate + direction, vary space and agent.
         String h1 = SpacesExtractor.extractHash(spaceRef(ROOT_NP_AC, SPACE_A), ROOT_NP_URI,
-                SpaceExtract.ADMIN_GRANT, ALICE.stringValue());
+                SpaceExtract.ROLE_ASSERTION, pAdmin + "|" + dInverse + "|" + ALICE.stringValue());
         String h2 = SpacesExtractor.extractHash(spaceRef(ROOT_NP_AC, SPACE_A), ROOT_NP_URI,
-                SpaceExtract.ADMIN_GRANT, BOB.stringValue());
+                SpaceExtract.ROLE_ASSERTION, pAdmin + "|" + dInverse + "|" + BOB.stringValue());
         String h3 = SpacesExtractor.extractHash(spaceRef(ROOT_NP_AC, SPACE_B), ROOT_NP_URI,
-                SpaceExtract.ADMIN_GRANT, ALICE.stringValue());
+                SpaceExtract.ROLE_ASSERTION, pAdmin + "|" + dInverse + "|" + ALICE.stringValue());
         assertNotEquals(h1, h2);
         assertNotEquals(h1, h3);
         assertNotEquals(h2, h3);


### PR DESCRIPTION
## Summary

PR-B1 of Phase 1 for #62. First slice of loader-side extraction: admin grants and root-nanopub profile fields. Maintainer grants, role definitions, role assignments and view displays follow in PR-B2.

### What lands

- **`vocabulary/NPAX.java`** — `npax:` namespace for extract IRIs. Each extract gets a deterministic IRI `npax:<sha256(spaceRef + "|" + sourceNp + "|" + extractKind + "|" + payload)>` so re-extracting the same source nanopub for the same space is idempotent (RDF4J set semantics dedupes).
- **`vocabulary/SpaceExtract.java`** — `npa:` predicates for extract objects: `Extract` type, `extractKind` discriminator, `adminGrant` / `profileField` kind individuals, `fieldKey` / `fieldValue` payload predicates.
- **`vocabulary/GEN.java`** — `HAS_ADMIN` constant.
- **`SpacesExtractor.java`** — pure-logic extractor: walks an assertion, emits admin-grant extracts for any `<spaceIri> gen:hasAdmin <agent>` where `spaceIri` is a known Space IRI, and profile-field extracts for any non-structural triple about a Space IRI defined by *this* nanopub. Returns `ExtractionResult(statements, spaceRefs)`; statements carry their target named graph (`npas:<spaceRef>`) as context.
- **`NanopubLoader.loadSpaceExtracts`** — writes extracts to the `spaces` repo in one serializable transaction; on commit, records the source-nanopub → space-refs reverse mapping in `SpaceRegistry` for future invalidation propagation. Submitted to the existing loading task pool from `executeLoading`.

### Notes

- The `spaces` repo is auto-created on first write via the existing `TripleStore.getRepository` path. PR #69 / #70 already put it on the no-checksum-tracking list, so it boots clean.
- Publisher validation is **not** done here — the extractor unconditionally extracts any `gen:hasAdmin` triple whose subject is a known Space IRI. The materializer (PR-C) is responsible for closure validation.
- Profile-field extraction skips the structural `gen:hasRootDefinition` and `gen:hasAdmin` triples (the former is a detection signal; the latter is captured separately as an admin grant). It also skips `rdf:type gen:Space` itself (also structural) but keeps other rdf:type triples (declared subtypes like `gen:Alliance` / `gen:Project`).
- Profile fields are only extracted from space-defining nanopubs — random third-party nanopubs that mention a Space IRI do not contribute profile data.

See `doc/plan-space-repositories.md` for the full design.

## Test plan

- [x] `mvn test` — 170/170 pass locally (8 new SpacesExtractor tests covering admin-grant emission, hash determinism, profile-field skipping, and isolation between space-defining and other nanopubs)
- [x] CI green
- [ ] Local verification: load a few `gen:Space`-typed nanopubs, confirm `spaces` repo populates with `npa:Extract` triples in the per-space named graphs.