### PR TITLE
fix/feat: synchronise SpaceRegistry and add trust/spaces feature flags

### DIFF
--- a/src/main/java/com/knowledgepixels/query/FeatureFlags.java
+++ b/src/main/java/com/knowledgepixels/query/FeatureFlags.java
@@ -1,0 +1,61 @@
+package com.knowledgepixels.query;
+
+/**
+ * Operator-controlled feature flags, read from the environment on each call. Kept
+ * as a central table so operator-controlled features have consistent naming and a
+ * single place to audit. Both flags default to {@code true}, i.e. the feature is
+ * enabled unless explicitly disabled.
+ *
+ * <p>Disabling a flag makes the corresponding feature's entry points no-op:
+ * polling, materialisation, and auxiliary repo creation are all skipped. Callers
+ * don't need individual guards — the gated methods handle the check internally.
+ *
+ * <p>{@link MainVerticle#start(io.vertx.core.Promise)} logs a WARN at startup
+ * whenever either flag is {@code false}, so an accidentally-flagged production
+ * image is never silent.
+ *
+ * <p>Flags are re-read on each call rather than cached in {@code static final}
+ * fields — the per-call overhead is a single map lookup in
+ * {@link Utils#getEnvString(String, String)}, and call-time evaluation avoids
+ * awkward interactions with {@link org.mockito.Mockito#mockStatic} in tests.
+ */
+public final class FeatureFlags {
+
+    /**
+     * When {@code false}, the trust-state mirror is disabled:
+     * {@link TrustStateLoader#bootstrap()} and
+     * {@link TrustStateLoader#maybeUpdate(String)} become no-ops. The {@code trust}
+     * repo is never auto-created and no trust-state snapshot is ever fetched.
+     *
+     * <p>Controlled by the {@code NANOPUB_QUERY_ENABLE_TRUST_STATE} environment
+     * variable. Default: {@code true}.
+     *
+     * @return {@code true} if the trust-state mirror is enabled
+     */
+    public static boolean trustStateEnabled() {
+        return "true".equalsIgnoreCase(
+                Utils.getEnvString("NANOPUB_QUERY_ENABLE_TRUST_STATE", "true"));
+    }
+
+    /**
+     * When {@code false}, all spaces-related work is disabled:
+     * {@link NanopubLoader#detectAndRegisterSpaces},
+     * {@link SpacesAdminStore#bootstrap},
+     * {@link SpacesAdminStore#scanExistingSpaces}, and
+     * {@link SpacesAdminStore#persistSpace} become no-ops. The {@code spaces} repo
+     * is never auto-created and no space state is ever registered.
+     *
+     * <p>Controlled by the {@code NANOPUB_QUERY_ENABLE_SPACES} environment
+     * variable. Default: {@code true}.
+     *
+     * @return {@code true} if spaces processing is enabled
+     */
+    public static boolean spacesEnabled() {
+        return "true".equalsIgnoreCase(
+                Utils.getEnvString("NANOPUB_QUERY_ENABLE_SPACES", "true"));
+    }
+
+    private FeatureFlags() {
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -47,6 +47,15 @@ public class MainVerticle extends AbstractVerticle {
      */
     @Override
     public void start(Promise<Void> startPromise) throws Exception {
+        if (!FeatureFlags.trustStateEnabled()) {
+            log.warn("Trust state feature disabled via NANOPUB_QUERY_ENABLE_TRUST_STATE=false — "
+                    + "no trust snapshots will be fetched or materialised, and the 'trust' repo will not be auto-created.");
+        }
+        if (!FeatureFlags.spacesEnabled()) {
+            log.warn("Spaces feature disabled via NANOPUB_QUERY_ENABLE_SPACES=false — "
+                    + "no space-defining nanopubs will be registered, no extracts will be written, "
+                    + "and the 'spaces' repo will not be auto-created.");
+        }
         HttpClient httpClient = vertx.createHttpClient(
                 new HttpClientOptions()
                         .setConnectTimeout(Utils.getEnvInt("NANOPUB_QUERY_VERTX_CONNECT_TIMEOUT", 1000))

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -706,6 +706,7 @@ public class NanopubLoader {
      *         steps of #62.
      */
     static Set<String> detectAndRegisterSpaces(Nanopub np) {
+        if (!FeatureFlags.spacesEnabled()) return Collections.emptySet();
         boolean isSpaceTyped = false;
         for (IRI typeIri : NanopubUtils.getTypes(np)) {
             if (typeIri.equals(GEN.SPACE)) {

--- a/src/main/java/com/knowledgepixels/query/SpaceRegistry.java
+++ b/src/main/java/com/knowledgepixels/query/SpaceRegistry.java
@@ -21,6 +21,15 @@ import org.slf4j.LoggerFactory;
  * detection. Role-property tracking, per-source-nanopub reverse index, and admin-repo
  * persistence are added in later steps when they have a consumer. See
  * {@code doc/plan-space-repositories.md} for the full roadmap.
+ *
+ * <p><b>Thread safety.</b> All public methods that touch internal state are
+ * {@code synchronized} on the registry instance. The reverse index
+ * ({@code recordSourceNanopub} / {@code getSpaceRefsForSource} / {@code removeSourceNanopub})
+ * is written by loader-pool threads and read from other threads, so unsynchronised
+ * access to the backing {@link HashMap} would risk classic concurrent-modification
+ * hazards (lost updates, bucket corruption, infinite loops during rehashing). Methods
+ * that return sets return defensive snapshots, not live views, so callers can iterate
+ * without holding the monitor.
  */
 public class SpaceRegistry {
 
@@ -33,7 +42,7 @@ public class SpaceRegistry {
      *
      * @return the singleton instance
      */
-    public static SpaceRegistry get() {
+    public static synchronized SpaceRegistry get() {
         if (instance == null) {
             instance = new SpaceRegistry();
         }
@@ -68,7 +77,7 @@ public class SpaceRegistry {
      * @param spaceIri      the Space IRI declared in the root nanopub's assertion
      * @return the registration result: the space ref and whether it was newly added
      */
-    public Registration registerSpace(String rootNanopubId, IRI spaceIri) {
+    public synchronized Registration registerSpace(String rootNanopubId, IRI spaceIri) {
         String spaceRef = rootNanopubId + "_" + Utils.createHash(spaceIri);
         boolean added = knownSpaceRefs.add(spaceRef);
         spaceIriToSpaceRefs.computeIfAbsent(spaceIri, k -> new LinkedHashSet<>()).add(spaceRef);
@@ -84,7 +93,7 @@ public class SpaceRegistry {
      * @param spaceRef the space ref to check
      * @return {@code true} if known
      */
-    public boolean isKnownSpace(String spaceRef) {
+    public synchronized boolean isKnownSpace(String spaceRef) {
         return knownSpaceRefs.contains(spaceRef);
     }
 
@@ -104,12 +113,12 @@ public class SpaceRegistry {
     }
 
     /**
-     * Returns an unmodifiable view of all known space refs.
+     * Returns a snapshot of all known space refs.
      *
-     * @return all known space refs
+     * @return an immutable snapshot of all known space refs
      */
-    public Set<String> getKnownSpaceRefs() {
-        return Collections.unmodifiableSet(knownSpaceRefs);
+    public synchronized Set<String> getKnownSpaceRefs() {
+        return Set.copyOf(knownSpaceRefs);
     }
 
     /**
@@ -117,11 +126,11 @@ public class SpaceRegistry {
      * space refs can share a Space IRI when distinct root nanopubs both declare it.
      *
      * @param spaceIri the Space IRI to look up
-     * @return an unmodifiable set of matching space refs (empty if none are registered)
+     * @return an immutable snapshot of matching space refs (empty if none are registered)
      */
-    public Set<String> findSpaceRefsBySpaceIri(IRI spaceIri) {
+    public synchronized Set<String> findSpaceRefsBySpaceIri(IRI spaceIri) {
         Set<String> refs = spaceIriToSpaceRefs.get(spaceIri);
-        return refs == null ? Collections.emptySet() : Collections.unmodifiableSet(refs);
+        return refs == null ? Collections.emptySet() : Set.copyOf(refs);
     }
 
     /**
@@ -134,7 +143,7 @@ public class SpaceRegistry {
      * @return {@code true} if newly added, {@code false} if already known
      * @throws IllegalArgumentException if the space ref is not registered
      */
-    public boolean registerRoleProperty(String spaceRef, RoleProperty roleProperty) {
+    public synchronized boolean registerRoleProperty(String spaceRef, RoleProperty roleProperty) {
         if (!knownSpaceRefs.contains(spaceRef)) {
             throw new IllegalArgumentException("Unknown space ref: " + spaceRef);
         }
@@ -145,12 +154,12 @@ public class SpaceRegistry {
      * Returns the role properties learned for the given space.
      *
      * @param spaceRef the space ref to look up
-     * @return an unmodifiable set of registered role properties (empty if the space
+     * @return an immutable snapshot of registered role properties (empty if the space
      *         has none, or if the space ref isn't registered)
      */
-    public Set<RoleProperty> getRoleProperties(String spaceRef) {
+    public synchronized Set<RoleProperty> getRoleProperties(String spaceRef) {
         Set<RoleProperty> props = roleProperties.get(spaceRef);
-        return props == null ? Collections.emptySet() : Collections.unmodifiableSet(props);
+        return props == null ? Collections.emptySet() : Set.copyOf(props);
     }
 
     /**
@@ -161,7 +170,7 @@ public class SpaceRegistry {
      * @param sourceNanopubUri the URI of the source nanopub
      * @param spaceRef         the space ref the nanopub contributed to
      */
-    public void recordSourceNanopub(IRI sourceNanopubUri, String spaceRef) {
+    public synchronized void recordSourceNanopub(IRI sourceNanopubUri, String spaceRef) {
         sourceNanopubsToSpaceRefs.computeIfAbsent(sourceNanopubUri, k -> new LinkedHashSet<>()).add(spaceRef);
     }
 
@@ -169,11 +178,11 @@ public class SpaceRegistry {
      * Returns the set of space refs the given source nanopub contributed to.
      *
      * @param sourceNanopubUri the URI of the source nanopub
-     * @return an unmodifiable set (empty if the nanopub contributed to no spaces)
+     * @return an immutable snapshot (empty if the nanopub contributed to no spaces)
      */
-    public Set<String> getSpaceRefsForSource(IRI sourceNanopubUri) {
+    public synchronized Set<String> getSpaceRefsForSource(IRI sourceNanopubUri) {
         Set<String> refs = sourceNanopubsToSpaceRefs.get(sourceNanopubUri);
-        return refs == null ? Collections.emptySet() : Collections.unmodifiableSet(refs);
+        return refs == null ? Collections.emptySet() : Set.copyOf(refs);
     }
 
     /**
@@ -182,12 +191,12 @@ public class SpaceRegistry {
      * marked dirty.
      *
      * @param sourceNanopubUri the URI of the source nanopub
-     * @return the set of space refs the source had contributed to before removal
-     *         (empty if it wasn't tracked)
+     * @return an immutable snapshot of the space refs the source had contributed to
+     *         before removal (empty if it wasn't tracked)
      */
-    public Set<String> removeSourceNanopub(IRI sourceNanopubUri) {
+    public synchronized Set<String> removeSourceNanopub(IRI sourceNanopubUri) {
         Set<String> refs = sourceNanopubsToSpaceRefs.remove(sourceNanopubUri);
-        return refs == null ? Collections.emptySet() : Collections.unmodifiableSet(refs);
+        return refs == null ? Collections.emptySet() : Set.copyOf(refs);
     }
 
 }

--- a/src/main/java/com/knowledgepixels/query/SpacesAdminStore.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesAdminStore.java
@@ -59,6 +59,7 @@ public class SpacesAdminStore {
      * @param registry the registry to seed
      */
     public static void bootstrap(SpaceRegistry registry) {
+        if (!FeatureFlags.spacesEnabled()) return;
         try (RepositoryConnection conn = TripleStore.get().getRepoConnection(TripleStore.ADMIN_REPO)) {
             String query = String.format("""
                     SELECT ?ref ?iri WHERE {
@@ -113,6 +114,7 @@ public class SpacesAdminStore {
      * @param registry the registry to seed
      */
     public static void scanExistingSpaces(SpaceRegistry registry) {
+        if (!FeatureFlags.spacesEnabled()) return;
         String typeRepo = "type_" + Utils.createHash(GEN.SPACE);
         if (!TripleStore.get().getRepositoryNames().contains(typeRepo)) {
             log.info("Spaces scan: no {} repo yet — skipping", typeRepo);
@@ -174,6 +176,7 @@ public class SpacesAdminStore {
      * @param spaceIri      the Space IRI
      */
     public static void persistSpace(String rootNanopubId, IRI spaceIri) {
+        if (!FeatureFlags.spacesEnabled()) return;
         String spaceRef = rootNanopubId + "_" + Utils.createHash(spaceIri);
         IRI refIri = NPAS.forSpaceRef(spaceRef);
         try (RepositoryConnection conn = TripleStore.get().getRepoConnection(TripleStore.ADMIN_REPO)) {

--- a/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
@@ -88,6 +88,7 @@ public class TrustStateLoader {
      * scratch.
      */
     public static void bootstrap() {
+        if (!FeatureFlags.trustStateEnabled()) return;
         try (RepositoryConnection conn = TripleStore.get().getRepoConnection(TRUST_REPO)) {
             String query = String.format("""
                     SELECT ?s WHERE {
@@ -135,6 +136,7 @@ public class TrustStateLoader {
      *                          expose one
      */
     public static void maybeUpdate(String newTrustStateHash) {
+        if (!FeatureFlags.trustStateEnabled()) return;
         if (newTrustStateHash == null || newTrustStateHash.isEmpty()) return;
         String current = TrustStateRegistry.get().getCurrentHash().orElse(null);
         if (newTrustStateHash.equals(current)) return;

--- a/src/test/java/com/knowledgepixels/query/NanopubLoaderSpaceDetectionTest.java
+++ b/src/test/java/com/knowledgepixels/query/NanopubLoaderSpaceDetectionTest.java
@@ -48,6 +48,11 @@ class NanopubLoaderSpaceDetectionTest {
         mockedUtils = Mockito.mockStatic(Utils.class);
         mockedUtils.when(() -> Utils.createHash(any()))
                 .thenAnswer(inv -> "H(" + inv.getArgument(0) + ")");
+        // FeatureFlags.spacesEnabled() reads Utils.getEnvString. Under mockStatic the
+        // default answer is null, which would silently disable the feature — stub to
+        // return the passed-in default so production-default semantics apply in tests.
+        mockedUtils.when(() -> Utils.getEnvString(any(), any()))
+                .thenAnswer(inv -> inv.getArgument(1));
 
         // Stub NanopubUtils.getTypes so we can control nanopub-level types directly,
         // without having to construct realistic pubinfo statements.


### PR DESCRIPTION
## Summary

Two pre-work items for the ingestion-hang investigation (see `local/2026-04-18_nanopub-query_investigation.md` in the `nanopub-registry` repo):

1. **`SpaceRegistry` thread-safety fix** (commit 1) — the singleton registry was accessed across threads once loader-side space extraction (#62 PR-B1, #71) lands: main-thread writes via `registerSpace` from the `NanopubLoader` constructor, pool-thread writes via `recordSourceNanopub` from `loadSpaceExtracts`. Its backing `HashMap` / `LinkedHashSet` are not thread-safe, so concurrent access would risk lost updates, corrupted buckets, and the well-known concurrent-put infinite loop. Now every state-touching method is `synchronized` and get methods return `Set.copyOf` snapshots so callers iterate without holding the monitor.

2. **Feature flags for trust-state and spaces** (commit 2) — adds `NANOPUB_QUERY_ENABLE_TRUST_STATE` and `NANOPUB_QUERY_ENABLE_SPACES`, both default `true`. Gates `TrustStateLoader.bootstrap` / `maybeUpdate`, `NanopubLoader.detectAndRegisterSpaces`, and the `SpacesAdminStore` entry points. Two intended uses:
   - **Measurement on a test instance**: disables features that didn't exist in 1.8.0 so an ingestion-hang retest has a clean baseline.
   - **Per-instance production option**: operators can turn off features their instance doesn't need, trading functionality for reduced RDF4J load.

`MainVerticle.start` logs a WARN for each disabled flag at startup so an accidentally-flagged production image is never silent.

Flags are read per-call from the environment rather than cached in `static final` fields so `Mockito.mockStatic(Utils.class)` in existing tests doesn't accidentally disable features at class-load time. `NanopubLoaderSpaceDetectionTest` is updated to stub `Utils.getEnvString` to return its default value under the static mock.

## Notes

- This PR targets `main` and is intended to land **before** #71, so #71 inherits both the concurrency fix and the `NANOPUB_QUERY_ENABLE_SPACES` flag. #71's new `recordSourceNanopub` call site is the one that actually crosses the thread boundary; without this PR it would be a live bug in production with active spaces.
- The concurrency fix is independently correct and safe on `main` today — no `SpaceRegistry` read/write currently crosses threads without #71, but the class design is still unsafe and will be live-unsafe once #71 merges.

## Test plan

- [x] `mvn test` — 162/162 pass locally (existing test suite plus the stub addition in `NanopubLoaderSpaceDetectionTest`).
- [ ] Smoke test with both flags `false`: confirm `trust` and `spaces` repos are not auto-created, no `TrustStateLoader.maybeUpdate` HTTP calls, no space registration entries in the `SpaceRegistry` log, and the two startup WARN lines are present.
- [ ] Smoke test with default `true`: confirm unchanged behavior vs. current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)