### PR TITLE
fix/perf: changes 2+3+4 — log hygiene, active-repo eviction skip, lock-free setupId getter

### DIFF
--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -422,7 +422,7 @@ public class NanopubLoader {
                 conn.commit();
                 success = true;
             } catch (Exception ex) {
-                log.info("Could not get environment variable", ex);
+                log.warn("Could not load nanopub to last30d repo.", ex);
                 if (conn.isActive()) conn.rollback();
             }
             if (!success) {
@@ -471,7 +471,7 @@ public class NanopubLoader {
                 conn.commit();
                 success = true;
             } catch (Exception ex) {
-                log.info("Could not load nanopub to repo. ", ex);
+                log.warn("Could not load nanopub to repo.", ex);
                 if (conn.isActive()) conn.rollback();
             }
             if (!success) {
@@ -560,7 +560,7 @@ public class NanopubLoader {
                 for (RepositoryConnection c : connections) c.commit();
                 success = true;
             } catch (Exception ex) {
-                log.info("Could not load invalidate statements. ", ex);
+                log.warn("Could not load invalidate statements.", ex);
                 if (metaConn.isActive()) metaConn.rollback();
                 for (RepositoryConnection c : connections) {
                     if (c.isActive()) c.rollback();
@@ -616,7 +616,7 @@ public class NanopubLoader {
                 conn.commit();
                 success = true;
             } catch (Exception ex) {
-                log.info("Could not load invalidating statements. ", ex);
+                log.warn("Could not load invalidating statements.", ex);
                 if (conn.isActive()) conn.rollback();
             }
             if (!success) {
@@ -646,7 +646,7 @@ public class NanopubLoader {
                 conn.add(statements);
                 success = true;
             } catch (Exception ex) {
-                log.info("Could not load note to repo. ", ex);
+                log.warn("Could not load note to repo.", ex);
             }
             if (!success) {
                 retries++;
@@ -668,8 +668,7 @@ public class NanopubLoader {
                 return true;
             }
         } catch (GeneralSecurityException ex) {
-            log.info("Error for signature element {}", el.getUri());
-            log.info("Error", ex);
+            log.warn("Signature validation failed for signature element {}", el.getUri(), ex);
         }
         return false;
     }
@@ -749,7 +748,7 @@ public class NanopubLoader {
                 loaded = true;
             }
         } catch (Exception ex) {
-            log.info("Could no load nanopub. ", ex);
+            log.warn("Could not check whether nanopub is loaded.", ex);
         }
         return loaded;
     }

--- a/src/main/java/com/knowledgepixels/query/StatusController.java
+++ b/src/main/java/com/knowledgepixels/query/StatusController.java
@@ -57,7 +57,7 @@ public class StatusController {
     private boolean initialized = false;
     private volatile State state = null;
     private volatile long lastCommittedCounter = -1;
-    private Long registrySetupId = null;
+    private volatile Long registrySetupId = null;
     private RepositoryConnection adminRepoConn;
 
     /**
@@ -243,9 +243,14 @@ public class StatusController {
      * @return the registry setup ID, or null if not yet known
      */
     public Long getRegistrySetupId() {
-        synchronized (this) {
-            return registrySetupId;
-        }
+        // Lock-free read: field is volatile, writers still hold synchronized(this)
+        // so there are no concurrent writers. applyGlobalHeaders in MainVerticle
+        // calls this on every inbound request on the Vert.x event loop — blocking
+        // here behind updateState's admin-repo transaction was a BlockedThreadChecker
+        // hazard. The DB-commit-first order in the setter (setRegistrySetupId)
+        // means a reader can observe the previous value for the few ms between DB
+        // commit and field assignment; no caller depends on stronger consistency.
+        return registrySetupId;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -13,6 +13,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.base.RepositoryConnectionWrapper;
 import org.eclipse.rdf4j.repository.http.HTTPRepository;
 import org.nanopub.NanopubUtils;
 import org.nanopub.vocabulary.NPA;
@@ -24,6 +25,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -42,6 +46,14 @@ public class TripleStore {
     private static final Logger log = LoggerFactory.getLogger(TripleStore.class);
 
     private final Map<String, Repository> repositories = new LinkedHashMap<>();
+
+    /**
+     * Per-repo open-connection counter, read by the eviction loop to skip repos that
+     * still have live connections. Incremented in {@link #getRepoConnection(String)}
+     * just before the connection is handed out and decremented via a
+     * {@link RepositoryConnectionWrapper} that intercepts {@code close()} exactly once.
+     */
+    private final ConcurrentHashMap<String, AtomicInteger> openConnections = new ConcurrentHashMap<>();
 
     private String endpointBase = null;
     private String endpointType = null;
@@ -78,12 +90,8 @@ public class TripleStore {
     @GeneratedFlagForDependentElements
     Repository getRepository(String name) {
         synchronized (this) {
-            while (repositories.size() > 100) {
-                Entry<String, Repository> e = repositories.entrySet().iterator().next();
-                repositories.remove(e.getKey());
-                log.info("Shutting down repo: {}", e.getKey());
-                e.getValue().shutDown();
-                log.info("Shutdown complete");
+            if (repositories.size() > 100) {
+                evictIdleRepos();
             }
             if (repositories.containsKey(name)) {
                 // Move to the end of the list:
@@ -116,11 +124,84 @@ public class TripleStore {
      */
     @GeneratedFlagForDependentElements
     public RepositoryConnection getRepoConnection(String name) {
-        Repository repo = getRepository(name);
-        if (repo == null) {
-            return null;
+        // The increment has to happen under the same monitor that guards eviction,
+        // otherwise another thread could evict this repo in the window between
+        // getRepository() returning and the counter going above zero. getConnection()
+        // on HTTPRepository is local (it doesn't do HTTP), so holding the lock here
+        // is cheap.
+        synchronized (this) {
+            Repository repo = getRepository(name);
+            if (repo == null) {
+                return null;
+            }
+            AtomicInteger counter = openConnections.computeIfAbsent(name, k -> new AtomicInteger());
+            counter.incrementAndGet();
+            return new CountingRepositoryConnection(repo, repo.getConnection(), counter);
         }
-        return repo.getConnection();
+    }
+
+    /**
+     * Evicts the eldest cache entries until either the size is back within the
+     * 100-entry cap or every remaining entry has at least one open connection.
+     * The cap is load-bearing — each cached entry keeps an LMDB environment alive
+     * on the RDF4J server (in-memory cache, mmap pages, native memory), so
+     * exceeding it by much risks server-side OOM. Actively-used repos are skipped
+     * rather than shut down, because {@link org.eclipse.rdf4j.repository.http.HTTPRepository#shutDown()}
+     * closes the session manager and kills any live transaction on that repo with
+     * a connection-close error (the {@code MMapIndexInput – Already closed}
+     * failure mode observed on query-3 in the April test). The cache self-converges
+     * as active repos become idle.
+     */
+    @GeneratedFlagForDependentElements
+    private void evictIdleRepos() {
+        List<String> skipped = new ArrayList<>();
+        Iterator<Entry<String, Repository>> iter = repositories.entrySet().iterator();
+        while (iter.hasNext() && repositories.size() > 100) {
+            Entry<String, Repository> e = iter.next();
+            AtomicInteger active = openConnections.get(e.getKey());
+            if (active != null && active.get() > 0) {
+                skipped.add(e.getKey());
+                continue;
+            }
+            iter.remove();
+            log.info("Shutting down repo: {}", e.getKey());
+            e.getValue().shutDown();
+            log.info("Shutdown complete");
+        }
+        if (!skipped.isEmpty()) {
+            log.warn("Skipped eviction for {} active repo(s); cache size is now {} (cap 100). Active names: {}",
+                    skipped.size(), repositories.size(), skipped);
+        }
+    }
+
+    /**
+     * Minimal wrapper around a delegate {@link RepositoryConnection} whose only job
+     * is to decrement the per-repo open-connection counter exactly once when the
+     * caller closes it. Uses {@link AtomicBoolean} so that repeated/idempotent
+     * {@code close()} calls (common with try-with-resources plus explicit close)
+     * don't decrement more than once.
+     */
+    private static final class CountingRepositoryConnection extends RepositoryConnectionWrapper {
+
+        private final AtomicInteger counter;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        CountingRepositoryConnection(Repository repo, RepositoryConnection delegate, AtomicInteger counter) {
+            super(repo, delegate);
+            this.counter = counter;
+        }
+
+        @Override
+        public void close() {
+            try {
+                super.close();
+            } finally {
+                if (closed.compareAndSet(false, true)) {
+                    counter.decrementAndGet();
+                }
+            }
+        }
+
     }
 
     @GeneratedFlagForDependentElements


### PR DESCRIPTION
## Summary

First orthogonal-and-zero-risk tranche of the ingestion-hang fix plan (changes 2, 3, 4 from `local/2026-04-19_nanopub-query_recommended_fix.md` in the `nanopub-registry` repo). Three independent fixes, each a separate commit.

### Change 2 — log hygiene in `NanopubLoader` (`3fa5527`)

- Line 425 logged `"Could not get environment variable"` from a catch handling a transaction failure (copy-paste from an unrelated site). Replaced with an accurate message.
- Line 752 had a typo: `"Could no load nanopub."`. Fixed.
- Lines 671–672 in `hasValidSignature` collapsed into one `log.warn` with context.
- All exception-path `log.info(...)` calls in the file promoted to `log.warn(...)` (lines 425, 474, 563, 619, 649, 752 plus the consolidated signature log). Deployments filtering to WARN+ now capture the entries an operator would most want during an ingestion-failure investigation.

No behaviour change beyond log level and message text.

### Change 4 — lock-free `StatusController.getRegistrySetupId()` (`de14135`)

The getter was called from `applyGlobalHeaders` on every inbound request on the event loop, taking `synchronized(this)` — the same monitor that `updateState` holds across a SERIALIZABLE admin-repo transaction over HTTP. At test throughput `updateState` fires ~1.5 times/s, so under RDF4J pressure the monitor is held a large fraction of the time and every probe blocks behind it.

Make the field `volatile` and drop the sync wrapper. Setter is unchanged — its DB-commit-first order (the opposite of `updateState`'s memory-first order) means readers may briefly observe the old value after a DB commit, which no caller depends on.

Matches the pattern the 1.7.0 fix (`3209b71`) applied to `state`/`lastCommittedCounter`.

### Change 3 — skip eviction for actively-used repos in `TripleStore` (`ab70cd2`)

Eviction shut down the eldest LRU entry whenever the 100-repo cap was exceeded. If the eldest had a live connection with an open transaction, `HTTPRepository.shutDown()` killed that transaction with a connection-close error — the most plausible cause of the two rare `MMapIndexInput – Already closed` failures on query-3 in the April test.

Keep the 100-repo cap (load-bearing: each entry keeps an LMDB environment alive on the RDF4J server; raising it risks server-side OOM). Instead track open connections per repo name and skip eviction for repos with `count > 0`, logging a warning when that happens. Cache self-converges as active repos become idle.

Implementation:
- `ConcurrentHashMap<String, AtomicInteger> openConnections`
- Connections wrapped in a minimal `CountingRepositoryConnection` (extends `RepositoryConnectionWrapper`) that decrements exactly once on close (`AtomicBoolean` guards double-decrement for idempotent try-with-resources + explicit close).
- Increment happens under the same monitor that guards eviction, so there's no race where a fetched repo could be evicted before its counter rises. `HTTPRepository.getConnection()` is local (no HTTP), so holding the lock there is cheap.

## Test plan

- [x] `mvn test` — 162/162 pass locally.
- [x] Smoke test: drive enough distinct `pubkey_*`/`type_*` repos to exceed the 100-entry cap under load and confirm (a) eviction fires for idle repos, (b) the new "Skipped eviction for N active repo(s)" warning appears if it ever does, (c) no `MMapIndexInput – Already closed` failures.
- [ ] Grafana: after deployment, confirm fewer `BlockedThreadChecker` warnings from the request-path lock (change 4).

## Relation to other work

- Sequencing per the fix plan: this PR is tranche (a) — orthogonal, zero-regression. The next tranche (changes 5 and 6 — metrics off event loop, HTTP pool size) is a separate PR.
- Changes 1, 7, 8 (socket timeouts, exponential backoff, circuit breaker) ship as one atomic PR after this and before change 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)