### PR TITLE
perf: changes 5+6 — metrics off event loop, raise HTTP pool, consolidate clients

### DIFF
--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -428,8 +428,14 @@ public class MainVerticle extends AbstractVerticle {
         });
         proxyServer.listen(9393);
 
-        // Periodic metrics update
-        vertx.setPeriodic(1000, id -> collector.updateMetrics());
+        // Periodic metrics update. Runs on a dedicated single-thread scheduled executor
+        // (not on the Vert.x event loop) because `updateMetrics` can fall through to a
+        // synchronous HTTP call in `TripleStore.getRepositoryNames()` when the cache has
+        // been invalidated. `scheduleWithFixedDelay` naturally serialises ticks and cannot
+        // pile up if the work occasionally runs long. Same pattern as `JellyNanopubLoader.loadUpdates`
+        // below.
+        Executors.newSingleThreadScheduledExecutor()
+                .scheduleWithFixedDelay(collector::updateMetrics, 1, 1, TimeUnit.SECONDS);
 
 
         new Thread(() -> {

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -1,7 +1,7 @@
 package com.knowledgepixels.query;
 
 import org.apache.commons.exec.environment.EnvironmentUtils;
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
@@ -85,7 +85,24 @@ public class TripleStore {
         getRepository("empty");  // Make sure empty repo exists
     }
 
-    private final CloseableHttpClient httpclient = HttpClients.createDefault();
+    /**
+     * Shared HTTP client for all RDF4J traffic. Apache HttpClient treats all requests
+     * to a given host + port + protocol as one "route", so every `HTTPRepository` in
+     * this process funnels through this single client's connection pool — plus the
+     * two ad-hoc users in {@link #createRepo} and {@link #getRepositoryNames}, which
+     * have been consolidated onto this client too.
+     *
+     * <p>The Apache defaults (maxPerRoute=2 / maxTotal=20) throttle four concurrent
+     * loader-pool threads down to two-way parallelism at the HTTP layer — invisible
+     * client-side serialisation the code is actively fighting. Raised to 10 / 40
+     * here: comfortable headroom for the 4-thread loader pool plus admin-repo
+     * transactions and the metrics tick, small enough to be a conservative first
+     * step with room to grow later.
+     */
+    private final CloseableHttpClient httpclient = HttpClients.custom()
+            .setMaxConnPerRoute(10)
+            .setMaxConnTotal(40)
+            .build();
 
     @GeneratedFlagForDependentElements
     Repository getRepository(String name) {
@@ -209,7 +226,10 @@ public class TripleStore {
         if (!repoName.equals(ADMIN_REPO)) {
             getRepository(ADMIN_REPO);  // make sure admin repo is loaded first
         }
-        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+        // Uses the shared this.httpclient rather than a per-call client so it inherits
+        // the configured pool sizes (and, once change 1 of the fix plan lands, the
+        // socket/connection-request timeouts).
+        try {
             //log.info("Trying to creating repo " + name);
 
             // TODO new syntax somehow doesn't work for the Lucene case:
@@ -312,19 +332,22 @@ public class TripleStore {
 
             HttpUriRequest createRepoRequest = RequestBuilder.put().setUri(endpointBase + "repositories/" + repoName).addHeader("Content-Type", "text/turtle").setEntity(new StringEntity(createRepoQueryString)).build();
 
-            HttpResponse response = httpclient.execute(createRepoRequest);
-            int statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode == 409) {
-                //log.info("Already exists.");
-                getRepository(repoName).init();
-            } else if (statusCode >= 200 && statusCode < 300) {
-                //log.info("Successfully created.");
-                initNewRepo(repoName);
-            } else {
-                log.info("Status code: {}", response.getStatusLine().getStatusCode());
-                log.info(response.getStatusLine().getReasonPhrase());
-                String handledResponse = new BasicResponseHandler().handleResponse(response);
-                log.info("Response: {}", handledResponse);
+            // Response is try-with-resources'd so the connection is released back to
+            // the shared pool rather than leaked.
+            try (CloseableHttpResponse response = httpclient.execute(createRepoRequest)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == 409) {
+                    //log.info("Already exists.");
+                    getRepository(repoName).init();
+                } else if (statusCode >= 200 && statusCode < 300) {
+                    //log.info("Successfully created.");
+                    initNewRepo(repoName);
+                } else {
+                    log.info("Status code: {}", response.getStatusLine().getStatusCode());
+                    log.info(response.getStatusLine().getReasonPhrase());
+                    String handledResponse = new BasicResponseHandler().handleResponse(response);
+                    log.info("Response: {}", handledResponse);
+                }
             }
         } catch (IOException ex) {
             log.info("Could not create repo.", ex);
@@ -383,11 +406,12 @@ public class TripleStore {
                 return cachedRepositoryNames;
             }
             Map<String, Boolean> repositoryNames = null;
-            try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-                HttpResponse resp = httpclient.execute(RequestBuilder.get()
-                        .setUri(endpointBase + "/repositories")
-                        .addHeader("Content-Type", "text/csv")
-                        .build());
+            // Uses the shared this.httpclient; response try-with-resources releases
+            // the pooled connection when done.
+            try (CloseableHttpResponse resp = httpclient.execute(RequestBuilder.get()
+                    .setUri(endpointBase + "/repositories")
+                    .addHeader("Content-Type", "text/csv")
+                    .build())) {
                 BufferedReader reader = new BufferedReader(new InputStreamReader(resp.getEntity().getContent()));
                 int code = resp.getStatusLine().getStatusCode();
                 if (code < 200 || code >= 300) return null;

--- a/src/test/java/com/knowledgepixels/query/TripleStoreTest.java
+++ b/src/test/java/com/knowledgepixels/query/TripleStoreTest.java
@@ -5,7 +5,6 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.eclipse.rdf4j.repository.Repository;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
@@ -43,6 +42,28 @@ class TripleStoreTest {
         }
     }
 
+    /**
+     * Sets the shared {@code httpclient} field on a TripleStore mock. TripleStore now
+     * uses one shared Apache HttpClient for all outbound RDF4J traffic (previously
+     * getRepositoryNames built its own via {@code HttpClients.createDefault()}, which
+     * the tests mocked via {@code mockStatic(HttpClients.class)}). Since mocks don't
+     * run field initialisers, that field is null on a mock instance and must be
+     * injected via reflection for each test.
+     */
+    private void injectHttpClient(TripleStore mock, CloseableHttpClient client) {
+        final var field = ReflectionSupport.findFields(
+                TripleStore.class,
+                f -> f.getName().equals("httpclient"),
+                HierarchyTraversalMode.TOP_DOWN
+        ).getFirst();
+        field.setAccessible(true);
+        try {
+            field.set(mock, client);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Test
     void getRepoConnectionWithValidRepo() {
         TripleStore mock = mock(TripleStore.class);
@@ -63,13 +84,11 @@ class TripleStoreTest {
         TripleStore mock = mock(TripleStore.class, CALLS_REAL_METHODS);
         ReentrantReadWriteLock repoNamesCacheLock = initRepoNamesCacheLock(mock);
         CloseableHttpClient httpClientMock = mock(CloseableHttpClient.class);
+        injectHttpClient(mock, httpClientMock);
 
         when(httpClientMock.execute(any(HttpUriRequest.class))).thenThrow(new IOException());
 
-        try (var mockedStatic = mockStatic(HttpClients.class)) {
-            mockedStatic.when(HttpClients::createDefault).thenReturn(httpClientMock);
-            assertNull(mock.getRepositoryNames());
-        }
+        assertNull(mock.getRepositoryNames());
         assertEquals(0, repoNamesCacheLock.getReadLockCount());
         assertEquals(0, repoNamesCacheLock.getWriteHoldCount());
     }
@@ -79,6 +98,7 @@ class TripleStoreTest {
         TripleStore mock = mock(TripleStore.class, CALLS_REAL_METHODS);
         ReentrantReadWriteLock repoNamesCacheLock = initRepoNamesCacheLock(mock);
         CloseableHttpClient httpClientMock = mock(CloseableHttpClient.class);
+        injectHttpClient(mock, httpClientMock);
         CloseableHttpResponse responseMock = mock(CloseableHttpResponse.class);
 
         when(httpClientMock.execute(any(HttpUriRequest.class))).thenReturn(responseMock);
@@ -87,10 +107,7 @@ class TripleStoreTest {
         when(responseMock.getStatusLine()).thenReturn(mock(StatusLine.class));
         when(responseMock.getStatusLine().getStatusCode()).thenReturn(500);
 
-        try (var mockedStatic = mockStatic(HttpClients.class)) {
-            mockedStatic.when(HttpClients::createDefault).thenReturn(httpClientMock);
-            assertNull(mock.getRepositoryNames());
-        }
+        assertNull(mock.getRepositoryNames());
         assertEquals(0, repoNamesCacheLock.getReadLockCount());
         assertEquals(0, repoNamesCacheLock.getWriteHoldCount());
     }
@@ -100,6 +117,7 @@ class TripleStoreTest {
         TripleStore mock = mock(TripleStore.class, CALLS_REAL_METHODS);
         ReentrantReadWriteLock repoNamesCacheLock = initRepoNamesCacheLock(mock);
         CloseableHttpClient httpClientMock = mock(CloseableHttpClient.class);
+        injectHttpClient(mock, httpClientMock);
         CloseableHttpResponse responseMock = mock(CloseableHttpResponse.class);
 
         when(httpClientMock.execute(any(HttpUriRequest.class))).thenReturn(responseMock);
@@ -110,11 +128,8 @@ class TripleStoreTest {
         when(responseMock.getStatusLine()).thenReturn(mock(StatusLine.class));
         when(responseMock.getStatusLine().getStatusCode()).thenReturn(200);
 
-        try (var mockedStatic = mockStatic(HttpClients.class)) {
-            mockedStatic.when(HttpClients::createDefault).thenReturn(httpClientMock);
-            Set<String> result = mock.getRepositoryNames();
-            assertEquals(Set.of("repo1", "repo2"), result);
-        }
+        Set<String> result = mock.getRepositoryNames();
+        assertEquals(Set.of("repo1", "repo2"), result);
         assertEquals(0, repoNamesCacheLock.getReadLockCount());
         assertEquals(0, repoNamesCacheLock.getWriteHoldCount());
     }
@@ -124,6 +139,7 @@ class TripleStoreTest {
         TripleStore mock = mock(TripleStore.class, CALLS_REAL_METHODS);
         ReentrantReadWriteLock repoNamesCacheLock = initRepoNamesCacheLock(mock);
         CloseableHttpClient httpClientMock = mock(CloseableHttpClient.class);
+        injectHttpClient(mock, httpClientMock);
         CloseableHttpResponse responseMock = mock(CloseableHttpResponse.class);
 
         when(httpClientMock.execute(any(HttpUriRequest.class))).thenReturn(responseMock);
@@ -134,14 +150,11 @@ class TripleStoreTest {
         when(responseMock.getStatusLine()).thenReturn(mock(StatusLine.class));
         when(responseMock.getStatusLine().getStatusCode()).thenReturn(200);
 
-        try (var mockedStatic = mockStatic(HttpClients.class)) {
-            mockedStatic.when(HttpClients::createDefault).thenReturn(httpClientMock);
-            Set<String> firstCallResult = mock.getRepositoryNames();
-            Set<String> secondCallResult = mock.getRepositoryNames();
-            assertEquals(Set.of("repo1", "repo2"), firstCallResult);
-            assertEquals(firstCallResult, secondCallResult);
-            verify(httpClientMock, times(1)).execute(any(HttpUriRequest.class));
-        }
+        Set<String> firstCallResult = mock.getRepositoryNames();
+        Set<String> secondCallResult = mock.getRepositoryNames();
+        assertEquals(Set.of("repo1", "repo2"), firstCallResult);
+        assertEquals(firstCallResult, secondCallResult);
+        verify(httpClientMock, times(1)).execute(any(HttpUriRequest.class));
         assertEquals(0, repoNamesCacheLock.getReadLockCount());
         assertEquals(0, repoNamesCacheLock.getWriteHoldCount());
     }


### PR DESCRIPTION
## Summary

Second tranche of the ingestion-hang fix plan (changes 5 and 6 from `local/2026-04-19_nanopub-query_recommended_fix.md` in the `nanopub-registry` repo). Both touch the HTTP layer, so they ship together. Two commits.

### Change 5 — Move `MetricsCollector.updateMetrics()` off the event loop (`9e17243`)

`vertx.setPeriodic` scheduled `collector.updateMetrics()` on the Vert.x event loop. `updateMetrics()` calls `TripleStore.getRepositoryNames()` which falls through to a synchronous HTTP `GET /repositories` whenever its cache is invalidated by new-repo creation — blocking the event loop and showing up as `BlockedThreadChecker` warnings.

Replace with a dedicated `Executors.newSingleThreadScheduledExecutor()` + `scheduleWithFixedDelay`. Same pattern already in use for `JellyNanopubLoader.loadUpdates` a few lines below; plain `java.util.concurrent`, no Vert.x semantics required. `scheduleWithFixedDelay` serialises ticks and cannot pile up even if the inner HTTP call goes long.

No new races: `updateMetrics()` only touches thread-safe state (`AtomicInteger` gauges, volatile-backed `StatusController.getState()`, `ReadWriteLock`-guarded `TripleStore.getRepositoryNames()`).

### Change 6 — Raise HTTP pool sizes and consolidate on a shared client (`dbba486`)

Apache HttpClient's defaults are `maxPerRoute=2` / `maxTotal=20`. Since all RDF4J traffic shares one route (host+port+protocol, not path), the 4-thread `loadingPool` was being throttled to 2-way parallelism at the HTTP layer — invisible client-side serialisation the code was actively fighting. `StatusController.adminRepoConn` transactions (fire ~1.5×/s at test throughput) and the metrics tick share the same pool, so peak concurrent demand was 5-6+ behind 2 slots.

- Rebuild TripleStore's shared `httpclient` via `HttpClients.custom()` with `maxPerRoute=10`, `maxTotal=40`. Conservative first cut, room to raise further later.
- Consolidate the two ad-hoc `HttpClients.createDefault()` sites (`TripleStore.createRepo`, `TripleStore.getRepositoryNames`) onto the shared client. They now inherit the configured pool, and — once change 1 of the fix plan lands — will inherit the socket timeouts too. Responses wrapped in try-with-resources so pooled connections are released properly.

### Test plan

- [x] `mvn test` — 162/162 pass locally. `TripleStoreTest` updated to inject a mock `CloseableHttpClient` via reflection (same pattern the existing tests use for `repoNamesCacheLock`) since mocks don't run field initialisers.
- [x] Smoke test on the live local instance: confirm ingestion continues, no new HTTP errors, pool utilisation visible in the logs (under DEBUG Apache HttpClient prints `total allocated: N of 40`).

### Sequencing

Per the fix plan: tranche (a) — log hygiene, active-repo eviction skip, lock-free `getRegistrySetupId` — already merged in PR #73. This is tranche (b). Next: **changes 1 + 7 + 8 together** (socket timeouts, exponential backoff with jitter, circuit breaker) as a single atomic PR, because subsets of that triad are operationally worse than current state. Then change 9 on its own track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)