### PR TITLE
fix/perf/feat: changes 1+7+8 — HTTP timeouts, exponential backoff, circuit breaker

### DIFF
--- a/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
@@ -33,6 +33,26 @@ public class JellyNanopubLoader {
     private static final int RETRY_DELAY_METADATA = 3000;
     private static final int RETRY_DELAY_JELLY = 5000;
 
+    /**
+     * Circuit-breaker state. Counts consecutive {@code loadUpdates} invocations in
+     * which the catch block fired; resets to zero on the next successful batch.
+     * Scheduled on the single-threaded executor in {@link MainVerticle}, so a plain
+     * {@code int} is enough — no concurrency.
+     *
+     * <p>When the counter reaches {@link #BREAKER_THRESHOLD}, the next invocation
+     * sleeps {@link #BREAKER_PAUSE_MS} before proceeding. Lets the saturated RDF4J
+     * drain instead of being hammered every {@link #UPDATES_POLL_INTERVAL} ms.
+     *
+     * <p>Depends on {@link com.knowledgepixels.query.TripleStore}'s socket timeouts
+     * (change 1 of the fix plan) to turn parked commits into propagating exceptions;
+     * without them, {@code loadBatch} can park forever, the catch never fires, and
+     * this counter stays at zero.
+     */
+    static volatile int consecutiveBatchFailures = 0;
+
+    static final int BREAKER_THRESHOLD = 3;
+    static final long BREAKER_PAUSE_MS = 30_000L;
+
     private static final Logger log = LoggerFactory.getLogger(JellyNanopubLoader.class);
 
     /**
@@ -105,6 +125,21 @@ public class JellyNanopubLoader {
      * calling it again.
      */
     public static void loadUpdates() {
+        // Circuit breaker: after BREAKER_THRESHOLD consecutive failed batches, pause
+        // before the next attempt so a saturated RDF4J can drain. Check happens before
+        // any RDF4J-touching work so the sleep isn't itself under the broken regime.
+        if (consecutiveBatchFailures >= BREAKER_THRESHOLD) {
+            log.warn("Circuit breaker active after {} consecutive batch failures; pausing {} ms before next attempt",
+                    consecutiveBatchFailures, BREAKER_PAUSE_MS);
+            try {
+                Thread.sleep(BREAKER_PAUSE_MS);
+            } catch (InterruptedException e) {
+                // Preserve interruption semantics so a graceful shutdown (e.g. via
+                // MainVerticle's shutdown hook) isn't blocked by the pause.
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
         try {
             final var status = StatusController.get().getState();
             lastCommittedCounter = status.loadCounter;
@@ -151,6 +186,8 @@ public class JellyNanopubLoader {
                 return;
             }
             loadBatch(lastCommittedCounter, LoadingType.UPDATE);
+            // Batch completed without an exception — reset the breaker counter.
+            consecutiveBatchFailures = 0;
             log.info("Loaded {} update(s). Counter: {}, target was: {}",
                     lastCommittedCounter - status.loadCounter, lastCommittedCounter, targetCounter);
             if (lastCommittedCounter < targetCounter) {
@@ -159,8 +196,9 @@ public class JellyNanopubLoader {
                         "but loaded only up to {}.", lastCommittedCounter);
             }
         } catch (Exception e) {
-            log.info("Failed to load updates. Current counter: {}", lastCommittedCounter);
-            log.info("Failure Reason: ", e);
+            consecutiveBatchFailures++;
+            log.warn("Failed to load updates. Current counter: {} (consecutive failures: {})",
+                    lastCommittedCounter, consecutiveBatchFailures, e);
         } finally {
             try {
                 StatusController.get().setReady();

--- a/src/main/java/com/knowledgepixels/query/MetricsCollector.java
+++ b/src/main/java/com/knowledgepixels/query/MetricsCollector.java
@@ -32,6 +32,20 @@ public final class MetricsCollector {
         Gauge.builder("registry.pubkey.repositories.counter", pubkeyRepositoriesCounter, AtomicInteger::get).register(meterRegistry);
         Gauge.builder("registry.full.repositories.counter", fullRepositoriesCounter, AtomicInteger::get).register(meterRegistry);
 
+        // Circuit-breaker observability: expose both the raw counter and a boolean
+        // "breaker active" flag. The boolean is redundant with counter >= threshold
+        // but much cleaner to visualise in Grafana (the counter can saturate well
+        // above the threshold during a sustained outage, which makes a single
+        // "is the breaker tripped?" alert awkward to express over the raw value).
+        Gauge.builder("registry.loader.consecutive_batch_failures",
+                        () -> (double) JellyNanopubLoader.consecutiveBatchFailures)
+                .description("Consecutive loadUpdates batches that threw an exception before succeeding")
+                .register(meterRegistry);
+        Gauge.builder("registry.loader.breaker_active",
+                        () -> JellyNanopubLoader.consecutiveBatchFailures >= JellyNanopubLoader.BREAKER_THRESHOLD ? 1.0 : 0.0)
+                .description("1 if the loader circuit breaker is tripped (consecutive failures >= threshold), 0 otherwise")
+                .register(meterRegistry);
+
         // Status label metrics
         for (final var status : StatusController.State.values()) {
             AtomicInteger stateGauge = new AtomicInteger(0);

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -38,6 +38,7 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Consumer;
 
@@ -48,8 +49,37 @@ public class NanopubLoader {
 
     private static HttpClient httpClient;
     private static final ThreadPoolExecutor loadingPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(4);
-    private static final int MAX_RETRIES = 30;
-    private static final int RETRY_DELAY_MS = 10000;
+
+    /**
+     * Retry budget for the five (with #71 merged: six) structurally identical
+     * retry loops in this file. Previously the shape was flat {@code 10 s × 30} —
+     * five minutes of constant hammering at RDF4J that did not help a slow server.
+     * The new shape is bounded exponential backoff with ±50 % jitter:
+     * {@code base = 1, 2, 4, 8, 16, 32, 60, 60 s} for attempts 1…8, each perturbed
+     * by up to half its base value. Jitter prevents the 4-thread loadingPool from
+     * retrying in lock-step after a shared RDF4J failure (GC pause / overload spike).
+     * Worst-case wall time per failing task drops from ~35 min (post-change-1
+     * timeouts × 30 flat retries) to ~11 min (8 retries × 60 s timeout + backoff
+     * sleeps). This is the figure that sets the circuit-breaker trip time in
+     * {@link JellyNanopubLoader}.
+     */
+    private static final int MAX_RETRIES = 8;
+    private static final long[] BACKOFF_BASE_MS =
+            {1_000L, 2_000L, 4_000L, 8_000L, 16_000L, 32_000L, 60_000L, 60_000L};
+
+    /**
+     * Returns the sleep delay in ms for the given 1-indexed retry attempt. Delay
+     * is {@link #BACKOFF_BASE_MS}{@code [attempt-1]} perturbed by ±50 % uniform
+     * jitter, clamped to be non-negative.
+     *
+     * @param attempt 1-indexed retry attempt number
+     * @return the computed sleep delay in ms
+     */
+    static long computeBackoffMillis(int attempt) {
+        long base = BACKOFF_BASE_MS[Math.min(attempt - 1, BACKOFF_BASE_MS.length - 1)];
+        long jitter = ThreadLocalRandom.current().nextLong(base + 1) - base / 2;
+        return Math.max(0L, base + jitter);
+    }
     private Nanopub np;
     private NanopubSignatureElement el = null;
     private List<Statement> metaStatements = new ArrayList<>();
@@ -430,10 +460,12 @@ public class NanopubLoader {
                 if (retries >= MAX_RETRIES) {
                     throw new RuntimeException("Failed to load nanopub to last30d repo after " + MAX_RETRIES + " retries");
                 }
-                log.info("Retrying in 10 seconds (attempt {}/{})...", retries, MAX_RETRIES);
+                long delay = computeBackoffMillis(retries);
+                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
                 try {
-                    Thread.sleep(RETRY_DELAY_MS);
+                    Thread.sleep(delay);
                 } catch (InterruptedException x) {
+                    Thread.currentThread().interrupt();
                 }
             }
         }
@@ -479,10 +511,12 @@ public class NanopubLoader {
                 if (retries >= MAX_RETRIES) {
                     throw new RuntimeException("Failed to load nanopub " + npId + " to repo " + repoName + " after " + MAX_RETRIES + " retries");
                 }
-                log.info("Retrying in 10 seconds (attempt {}/{})...", retries, MAX_RETRIES);
+                long delay = computeBackoffMillis(retries);
+                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
                 try {
-                    Thread.sleep(RETRY_DELAY_MS);
+                    Thread.sleep(delay);
                 } catch (InterruptedException x) {
+                    Thread.currentThread().interrupt();
                 }
             }
         }
@@ -574,10 +608,12 @@ public class NanopubLoader {
                 if (retries >= MAX_RETRIES) {
                     throw new RuntimeException("Failed to load invalidate statements for " + thisNp.getUri() + " after " + MAX_RETRIES + " retries");
                 }
-                log.info("Retrying in 10 seconds (attempt {}/{})...", retries, MAX_RETRIES);
+                long delay = computeBackoffMillis(retries);
+                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
                 try {
-                    Thread.sleep(RETRY_DELAY_MS);
+                    Thread.sleep(delay);
                 } catch (InterruptedException x) {
+                    Thread.currentThread().interrupt();
                 }
             }
         }
@@ -624,10 +660,12 @@ public class NanopubLoader {
                 if (retries >= MAX_RETRIES) {
                     throw new RuntimeException("Failed to get invalidating statements for " + npId + " after " + MAX_RETRIES + " retries");
                 }
-                log.info("Retrying in 10 seconds (attempt {}/{})...", retries, MAX_RETRIES);
+                long delay = computeBackoffMillis(retries);
+                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
                 try {
-                    Thread.sleep(RETRY_DELAY_MS);
+                    Thread.sleep(delay);
                 } catch (InterruptedException x) {
+                    Thread.currentThread().interrupt();
                 }
             }
         }
@@ -653,10 +691,12 @@ public class NanopubLoader {
                 if (retries >= MAX_RETRIES) {
                     throw new RuntimeException("Failed to load note to repo for " + subj + " after " + MAX_RETRIES + " retries");
                 }
-                log.info("Retrying in 10 seconds (attempt {}/{})...", retries, MAX_RETRIES);
+                long delay = computeBackoffMillis(retries);
+                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
                 try {
-                    Thread.sleep(RETRY_DELAY_MS);
+                    Thread.sleep(delay);
                 } catch (InterruptedException x) {
+                    Thread.currentThread().interrupt();
                 }
             }
         }

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.query;
 
 import org.apache.commons.exec.environment.EnvironmentUtils;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
@@ -98,10 +99,32 @@ public class TripleStore {
      * here: comfortable headroom for the 4-thread loader pool plus admin-repo
      * transactions and the metrics tick, small enough to be a conservative first
      * step with room to grow later.
+     *
+     * <p>Timeouts set via {@code setDefaultRequestConfig}:
+     * <ul>
+     *   <li><b>socket-read = 60 s</b> — an individual HTTP response body must arrive
+     *       within this window. Healthy per-nanopub commits complete in milliseconds,
+     *       so 60 s is pure safety margin; its job is to turn the silent "threads
+     *       parked forever inside a commit" wedge (observed in the April test) into
+     *       a recoverable error that feeds the existing retry path.</li>
+     *   <li><b>connection-request = 30 s</b> — a caller waiting for a pooled connection
+     *       gives up after this long. Prevents the invisible self-deadlock in
+     *       {@code loadInvalidateStatements} (one thread holding N connections while
+     *       waiting for an (N+1)th) from hanging forever.</li>
+     *   <li><b>connect = 10 s</b> — kills TCP handshakes that stall. Generous but
+     *       bounded.</li>
+     * </ul>
+     * Without these defaults, HttpClient uses {@code -1} everywhere, which means
+     * "wait forever".
      */
     private final CloseableHttpClient httpclient = HttpClients.custom()
             .setMaxConnPerRoute(10)
             .setMaxConnTotal(40)
+            .setDefaultRequestConfig(RequestConfig.custom()
+                    .setSocketTimeout(60_000)
+                    .setConnectionRequestTimeout(30_000)
+                    .setConnectTimeout(10_000)
+                    .build())
             .build();
 
     @GeneratedFlagForDependentElements


### PR DESCRIPTION
## Summary

The behaviourally load-bearing triad from the ingestion-hang fix plan — three changes that must ship together because landing any alone is operationally worse than current state. Detailed rationale in `local/2026-04-19_nanopub-query_recommended_fix.md` in the `nanopub-registry` repo.

### Change 1 — bounded HTTP timeouts on `TripleStore` client (`98e8e36`)

Apache HttpClient's defaults are `-1` everywhere: "wait forever". Under a slow RDF4J, loader threads park indefinitely inside a commit — the most likely mechanism behind "pods wedge until manually restarted" in the April test.

Add `setDefaultRequestConfig` on the shared client: socket-read 60 s, connection-request 30 s, connect 10 s. Normal commits run in ms so these are safety margins; their job is to turn silent wedges into propagating exceptions that feed the retry path (change 7) and the breaker (change 8).

### Change 7 — exponential backoff with jitter in retry loops (`32533ee`)

The five (six, once #71 lands) structurally-identical retry loops in `NanopubLoader` used flat 10 s × 30 retries. Post-change-1 that pushes worst-case to ~35 min per failing task.

Replace with bounded exponential backoff (1, 2, 4, 8, 16, 32, 60, 60 s over 8 attempts) plus ±50 % jitter. Worst-case drops to ~11 min. Jitter matters more than before because short initial delays (1, 2, 4 s) would otherwise cluster the 4-thread pool into lock-step retries on shared RDF4J failures.

Retry count dropping 30→8 is a real semantic change: transient outages longer than ~11 min that would have eventually succeeded now propagate as `RuntimeException`. For the April failure shape that's desirable — faster failure propagation feeds the breaker sooner. `InterruptedException` now correctly restores the interrupt flag.

### Change 8 — conservative circuit breaker in `JellyNanopubLoader` (`253fab8`)

The missing backpressure: today the loader keeps pulling the next batch every 2 s even while RDF4J is drowning.

Track `consecutiveBatchFailures`; at threshold 3, sleep 30 s before the next invocation. Scheduled on `MainVerticle`'s single-threaded executor, so a plain `volatile int` is enough. `InterruptedException` re-raises the interrupt flag so shutdown isn't blocked by a breaker pause.

With change 1 + change 7 in place, a single failing batch takes ~8–11 min to throw, so three consecutive failures take ~30 min before first trip. Acceptable for the April failure shape (hours-long stuck runs); transforms "stuck forever" into "stuck 30 min then self-heals".

Expose two Micrometer gauges: the raw counter and a `breaker_active` boolean (redundant with counter ≥ threshold but cleaner for Grafana alerting).

Also promoted the `"Failed to load updates"` log to `warn` and folded it into one line with the consecutive-failure count, matching the PR #73 log-hygiene pattern.

## New operational signatures after this PR

Expected post-deployment; not bugs:

- 30 s pauses roughly every ~30 min under sustained overload (breaker tripping — correct behaviour).
- `"Retrying in X ms (attempt N/8)"` log lines where X grows exponentially, no longer a flat 10 s.
- `SocketTimeoutException` in loader logs under RDF4J pressure (previously the thread parked silently).
- Ingestion-rate graph visibly oscillating under load rather than cleanly plateauing.

Monitoring thresholds keyed on "zero progress for X minutes" or "ingestion rate below N" may need adjusting to avoid false pages during breaker pauses or multi-minute retry windows.

## Test plan

- [x] `mvn test` — 162/162 pass locally.
- [ ] Smoke test on the live local instance: confirm ingestion continues at healthy rate, no spurious breaker trips under normal load, breaker metrics exposed on `/metrics`.
- [ ] Verify `SocketTimeoutException` class appears in logs if / when a slow RDF4J response occurs.

## What's next

Change 9 (the env-var flags to skip writes to `full` / `last30d` / `text`) lands on a separate track — it's both a test-instance measurement tool and a per-instance production option, not part of this triad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)