### PR TITLE
perf/feat: skip idle admin-repo writes + loader liveness diagnostics

### DIFF
--- a/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
@@ -53,6 +53,26 @@ public class JellyNanopubLoader {
     static final int BREAKER_THRESHOLD = 3;
     static final long BREAKER_PAUSE_MS = 30_000L;
 
+    /**
+     * Epoch-millis of the last successful {@code loadUpdates} invocation (whether it
+     * actually loaded a batch or was a "caught up, nothing to do" tick). Read by
+     * {@link MetricsCollector} to expose {@code registry.loader.last_successful_batch_age_seconds}
+     * so an operator can tell at a glance from Grafana whether an instance is still
+     * making progress. Updated on every non-exceptional return from loadUpdates,
+     * including idle returns — an instance that is caught up and correctly polling
+     * still counts as alive.
+     */
+    static volatile long lastSuccessfulBatchAtMs = 0L;
+
+    /**
+     * Heartbeat counter for loadUpdates invocations. A summary log line is emitted
+     * every {@link #HEARTBEAT_INTERVAL_INVOCATIONS} invocations so a truncated or
+     * sampled log still shows the loader's state evolving. At the default 2 s poll
+     * interval, 30 invocations ≈ 1 line per minute.
+     */
+    private static long loadUpdatesInvocations = 0L;
+    private static final long HEARTBEAT_INTERVAL_INVOCATIONS = 30;
+
     private static final Logger log = LoggerFactory.getLogger(JellyNanopubLoader.class);
 
     /**
@@ -180,14 +200,24 @@ public class JellyNanopubLoader {
                 StatusController.get().setRegistrySetupId(currentSetupId);
             }
 
-            StatusController.get().setLoadingUpdates(status.loadCounter);
             if (lastCommittedCounter >= targetCounter) {
+                // Nothing to do. Keep state at READY (setReady is idempotent) and
+                // skip the redundant setLoadingUpdates → setReady admin-repo write
+                // that the old flow did on every idle poll. Also reset the breaker
+                // counter — a successful "nothing to do" is still a successful tick
+                // and should clear stale failure state from earlier transient errors.
                 StatusController.get().setReady();
+                consecutiveBatchFailures = 0;
+                lastSuccessfulBatchAtMs = System.currentTimeMillis();
+                maybeLogHeartbeat(targetCounter, true);
                 return;
             }
+            StatusController.get().setLoadingUpdates(status.loadCounter);
             loadBatch(lastCommittedCounter, LoadingType.UPDATE);
             // Batch completed without an exception — reset the breaker counter.
             consecutiveBatchFailures = 0;
+            lastSuccessfulBatchAtMs = System.currentTimeMillis();
+            maybeLogHeartbeat(targetCounter, false);
             log.info("Loaded {} update(s). Counter: {}, target was: {}",
                     lastCommittedCounter - status.loadCounter, lastCommittedCounter, targetCounter);
             if (lastCommittedCounter < targetCounter) {
@@ -207,6 +237,20 @@ public class JellyNanopubLoader {
                 log.info("Failure Reason: ", e);
             }
         }
+    }
+
+    /**
+     * Emit a heartbeat summary log line roughly every
+     * {@link #HEARTBEAT_INTERVAL_INVOCATIONS} invocations of {@link #loadUpdates}.
+     * Lets an operator reconstruct loader progress from a sparse or sampled log
+     * export, independent of Prometheus retention.
+     */
+    private static void maybeLogHeartbeat(long targetCounter, boolean idle) {
+        loadUpdatesInvocations++;
+        if (loadUpdatesInvocations % HEARTBEAT_INTERVAL_INVOCATIONS != 0) return;
+        log.info("Loader heartbeat: counter={} target={} idle={} consecutiveBatchFailures={} breakerActive={}",
+                lastCommittedCounter, targetCounter, idle, consecutiveBatchFailures,
+                consecutiveBatchFailures >= BREAKER_THRESHOLD);
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/query/MetricsCollector.java
+++ b/src/main/java/com/knowledgepixels/query/MetricsCollector.java
@@ -45,6 +45,19 @@ public final class MetricsCollector {
                         () -> JellyNanopubLoader.consecutiveBatchFailures >= JellyNanopubLoader.BREAKER_THRESHOLD ? 1.0 : 0.0)
                 .description("1 if the loader circuit breaker is tripped (consecutive failures >= threshold), 0 otherwise")
                 .register(meterRegistry);
+        // Liveness signal that works without log access: seconds since the last
+        // non-exceptional loadUpdates return. Counts both "loaded a batch" and
+        // "caught up, nothing to do" as progress. An instance whose value climbs
+        // unbounded while peers stay low is stuck on something the other
+        // gauges don't capture.
+        Gauge.builder("registry.loader.last_successful_batch_age_seconds",
+                        () -> {
+                            long t = JellyNanopubLoader.lastSuccessfulBatchAtMs;
+                            if (t == 0L) return 0.0;    // not started yet
+                            return (System.currentTimeMillis() - t) / 1000.0;
+                        })
+                .description("Seconds since the last non-exceptional loadUpdates return (idle or loading)")
+                .register(meterRegistry);
 
         // Status label metrics
         for (final var status : StatusController.State.values()) {

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -359,7 +359,7 @@ public class NanopubLoader {
             if (timestamp != null) {
                 if (new Date().getTime() - timestamp.getTimeInMillis() < THIRTY_DAYS) {
                     if (FeatureFlags.last30dRepoEnabled()) {
-                        runTask.accept(() -> loadNanopubToLatest(allStatements));
+                        runTask.accept(() -> loadNanopubToLatest(np.getUri(), allStatements));
                     }
                 }
             }
@@ -424,7 +424,7 @@ public class NanopubLoader {
     private static long ONE_HOUR = 1000L * 60 * 60;
 
     @GeneratedFlagForDependentElements
-    private static void loadNanopubToLatest(List<Statement> statements) {
+    private static void loadNanopubToLatest(IRI npId, List<Statement> statements) {
         boolean success = false;
         int retries = 0;
         while (!success) {
@@ -458,16 +458,16 @@ public class NanopubLoader {
                 conn.commit();
                 success = true;
             } catch (Exception ex) {
-                log.warn("Could not load nanopub to last30d repo.", ex);
+                log.warn("Could not load nanopub {} to last30d repo.", npId, ex);
                 if (conn.isActive()) conn.rollback();
             }
             if (!success) {
                 retries++;
                 if (retries >= MAX_RETRIES) {
-                    throw new RuntimeException("Failed to load nanopub to last30d repo after " + MAX_RETRIES + " retries");
+                    throw new RuntimeException("Failed to load nanopub " + npId + " to last30d repo after " + MAX_RETRIES + " retries");
                 }
                 long delay = computeBackoffMillis(retries);
-                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
+                log.info("Retrying in {} ms for nanopub {} in last30d (attempt {}/{})...", delay, npId, retries, MAX_RETRIES);
                 try {
                     Thread.sleep(delay);
                 } catch (InterruptedException x) {
@@ -509,7 +509,7 @@ public class NanopubLoader {
                 conn.commit();
                 success = true;
             } catch (Exception ex) {
-                log.warn("Could not load nanopub to repo.", ex);
+                log.warn("Could not load nanopub {} to repo {}.", npId, repoName, ex);
                 if (conn.isActive()) conn.rollback();
             }
             if (!success) {
@@ -518,7 +518,7 @@ public class NanopubLoader {
                     throw new RuntimeException("Failed to load nanopub " + npId + " to repo " + repoName + " after " + MAX_RETRIES + " retries");
                 }
                 long delay = computeBackoffMillis(retries);
-                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
+                log.info("Retrying in {} ms for nanopub {} in repo {} (attempt {}/{})...", delay, npId, repoName, retries, MAX_RETRIES);
                 try {
                     Thread.sleep(delay);
                 } catch (InterruptedException x) {
@@ -600,7 +600,7 @@ public class NanopubLoader {
                 for (RepositoryConnection c : connections) c.commit();
                 success = true;
             } catch (Exception ex) {
-                log.warn("Could not load invalidate statements.", ex);
+                log.warn("Could not load invalidate statements for {}.", thisNp.getUri(), ex);
                 if (metaConn.isActive()) metaConn.rollback();
                 for (RepositoryConnection c : connections) {
                     if (c.isActive()) c.rollback();
@@ -615,7 +615,7 @@ public class NanopubLoader {
                     throw new RuntimeException("Failed to load invalidate statements for " + thisNp.getUri() + " after " + MAX_RETRIES + " retries");
                 }
                 long delay = computeBackoffMillis(retries);
-                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
+                log.info("Retrying in {} ms for invalidate statements of {} (attempt {}/{})...", delay, thisNp.getUri(), retries, MAX_RETRIES);
                 try {
                     Thread.sleep(delay);
                 } catch (InterruptedException x) {
@@ -658,7 +658,7 @@ public class NanopubLoader {
                 conn.commit();
                 success = true;
             } catch (Exception ex) {
-                log.warn("Could not load invalidating statements.", ex);
+                log.warn("Could not load invalidating statements for {}.", npId, ex);
                 if (conn.isActive()) conn.rollback();
             }
             if (!success) {
@@ -667,7 +667,7 @@ public class NanopubLoader {
                     throw new RuntimeException("Failed to get invalidating statements for " + npId + " after " + MAX_RETRIES + " retries");
                 }
                 long delay = computeBackoffMillis(retries);
-                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
+                log.info("Retrying in {} ms for invalidating statements of {} (attempt {}/{})...", delay, npId, retries, MAX_RETRIES);
                 try {
                     Thread.sleep(delay);
                 } catch (InterruptedException x) {
@@ -690,7 +690,7 @@ public class NanopubLoader {
                 conn.add(statements);
                 success = true;
             } catch (Exception ex) {
-                log.warn("Could not load note to repo.", ex);
+                log.warn("Could not load note to repo for {}.", subj, ex);
             }
             if (!success) {
                 retries++;
@@ -698,7 +698,7 @@ public class NanopubLoader {
                     throw new RuntimeException("Failed to load note to repo for " + subj + " after " + MAX_RETRIES + " retries");
                 }
                 long delay = computeBackoffMillis(retries);
-                log.info("Retrying in {} ms (attempt {}/{})...", delay, retries, MAX_RETRIES);
+                log.info("Retrying in {} ms for note on {} (attempt {}/{})...", delay, subj, retries, MAX_RETRIES);
                 try {
                     Thread.sleep(delay);
                 } catch (InterruptedException x) {

--- a/src/main/java/com/knowledgepixels/query/StatusController.java
+++ b/src/main/java/com/knowledgepixels/query/StatusController.java
@@ -208,6 +208,14 @@ public class StatusController {
             if (lastCommittedCounter > loadCounter) {
                 throw new IllegalStateException("Cannot update the load counter from " + lastCommittedCounter + " to " + loadCounter);
             }
+            // Idempotence guard: skip the admin-repo rewrite if the state and counter
+            // are already where we'd set them. A no-op loop iteration of the updates
+            // loader otherwise re-writes the same two triples hundreds of times an
+            // hour over a long idle tail, each write growing the admin-repo LMDB via
+            // copy-on-write.
+            if (state == State.LOADING_UPDATES && lastCommittedCounter == loadCounter) {
+                return;
+            }
             updateState(State.LOADING_UPDATES, loadCounter);
         }
     }

--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -125,6 +126,12 @@ public class TripleStore {
                     .setConnectionRequestTimeout(30_000)
                     .setConnectTimeout(10_000)
                     .build())
+            // Hygiene: kill pooled connections that RDF4J has quietly closed server-side
+            // before we try to reuse them. Without this, a half-broken connection is
+            // only noticed when the next request fails, spending the full socket-read
+            // timeout discovering it.
+            .evictExpiredConnections()
+            .evictIdleConnections(30, TimeUnit.SECONDS)
             .build();
 
     @GeneratedFlagForDependentElements
@@ -176,7 +183,15 @@ public class TripleStore {
             }
             AtomicInteger counter = openConnections.computeIfAbsent(name, k -> new AtomicInteger());
             counter.incrementAndGet();
-            return new CountingRepositoryConnection(repo, repo.getConnection(), counter);
+            try {
+                return new CountingRepositoryConnection(repo, repo.getConnection(), counter);
+            } catch (Throwable t) {
+                // If getConnection() or the wrapper constructor throws after we bumped
+                // the counter, decrement so the repo isn't pinned against eviction by
+                // a phantom "active" connection it doesn't actually have.
+                counter.decrementAndGet();
+                throw t;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to the 21 April infrastructure test. With the logs from that run accidentally deleted before analysis, this PR does two things:

1. Lands one causal-hypothesis fix that could plausibly explain the post-ingestion stuck-tail behaviour on query-1/2 without relying on any specific interpretation of the lost logs.
2. Adds diagnostics so the next test reproduces against a version that exposes enough signal to confirm the theory (or rule it out) from metrics + sparse log alone.

Three commits; all 162 tests pass locally.

### Commit 1 — `perf: skip redundant admin-repo writes on idle loadUpdates polls` (`f9cfd9a`)

**The hypothesis.** Each `loadUpdates` poll at 2 s intervals was hitting the admin repo twice even when there was nothing to do: once via `setLoadingUpdates(counter)` at the top (unconditionally) and once via `setReady()` in the finally block. Over a 12-hour idle tail that's ~86 000 admin-repo SERIALIZABLE transactions per instance, all rewriting the same two triples. LMDB's copy-on-write grows the admin-repo environment on every commit; after enough rewrites, per-transaction wall time can reach the hundreds of milliseconds. This could both drive sustained background RDF4J CPU and explain the readiness-gauge oscillation between 0.8 and 1.0 (per-poll non-READY window stretching as the admin-repo grows).

**The change.** In `JellyNanopubLoader.loadUpdates`, move `setLoadingUpdates` **after** the caught-up check. An idle poll now does zero admin-repo writes (`setReady()` is already idempotent on `state == READY`); an active poll still does two genuine transitions. Also reset `consecutiveBatchFailures` on the idle path so the breaker doesn't stay primed from earlier transient failures.

Belt-and-suspenders: `StatusController.setLoadingUpdates` also gets an idempotence guard — if state is already `LOADING_UPDATES` with the same counter, it returns without writing. Catches any future caller that makes the same no-op call.

**Risk.** Low. The only observable behaviour change during an idle tail is that the `registry.server.status{status="LOADING_UPDATES"}` gauge stays at 0 rather than flickering to 1 briefly each poll. Arguably more correct anyway. Existing `StatusControllerTest` passes unmodified.

### Commit 2 — `fix: harden TripleStore HTTP-client lifecycle` (`fbe4205`)

Two small defensive additions on the shared Apache HttpClient:

- **Counter-leak guard in `getRepoConnection`.** If `repo.getConnection()` or the wrapper constructor throws after the counter increment, the counter would be pinned at +1 forever, blocking eviction of that repo. Now decrements on exception.
- **Periodic eviction of idle/expired pooled connections.** `evictIdleConnections(30s)` + `evictExpiredConnections()` on the client builder. RDF4J can close pooled connections server-side without the client noticing; without these, a half-broken connection is only discovered when the next request hangs for the full 60 s socket-read timeout.

Risk: near-zero. Defensive hygiene, not a behaviour change.

### Commit 3 — `feat: add loader liveness diagnostics and URI-tagged warn/retry logs` (`0286085`)

If the causal fix in commit 1 is wrong, or only partially right, the next test needs to produce evidence that survives log loss. Three additions:

- **`registry.loader.last_successful_batch_age_seconds` Prometheus gauge.** Backed by `JellyNanopubLoader.lastSuccessfulBatchAtMs`, updated on every non-exceptional `loadUpdates` return. An instance whose value climbs unbounded while peers stay low is provably the stuck one, from Grafana alone.
- **Heartbeat log line in `loadUpdates`** every 30 invocations (~1/min at default poll interval): summarises counter / target / idle / consecutiveBatchFailures / breakerActive. Sparse enough to survive a truncated log export, dense enough to reconstruct the tail window.
- **Nanopub / resource identifier added to every catch-block WARN and every "Retrying in N ms" info line** across the five retry loops in `NanopubLoader`. PR #73's log-hygiene pass added levels and message text but missed tagging with the URI; that gap meant a stuck nanopub wasn't grep-able. Fixed now. `loadNanopubToLatest` gains an `IRI npId` parameter so it can self-tag.

Risk: zero. Pure additions / message format changes.

## Expected behaviour on the next test

- If commit 1's hypothesis is right: query-1/2-style stuck tails disappear. RDF4J CPU returns to idle post-ingestion. Readiness gauges stay at 1.0.
- If it's partially right: the tail shortens significantly but some residual asymmetry remains. Metrics + heartbeat logs say why.
- If it's wrong: tail reproduces at similar scale. `last_successful_batch_age_seconds` makes it visible in Grafana; heartbeat logs + URI-tagged retries make it analysable without full log capture.

Either way the next cluster retest becomes the decisive data point. Happy to pair on a post-retest analysis once logs are in.

## Test plan

- [x] `mvn test` — 162/162 pass locally.
- [ ] Local single-node smoke: confirm new gauges surface on `/metrics`, heartbeat log line appears ~once/min, URI shows up in a synthetic retry log.
- [ ] Cluster retest with logs actually preserved this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)