### PR TITLE
chore(deps): batch dependency and plugin updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,12 +123,12 @@
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-repository-http</artifactId>
-      <version>5.1.2</version>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-sail-nativerdf</artifactId>
-      <version>5.1.2</version>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
     <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.21.0</version>
+      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
-    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.1</version>
+            <version>3.4.0</version>
             <executions>
               <execution>
                 <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
-    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
     <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
     <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.nanopub</groupId>
       <artifactId>nanopub</artifactId>
-      <version>1.86.1</version>
+      <version>1.86.2</version>
     </dependency>
     <!-- Temporary: dependency on Jitpack for snapshot builds -->
     <!-- <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-    <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
+    <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
     <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
 


### PR DESCRIPTION
## Summary

Routine dependency and build-plugin updates. Each bump is its own commit so individual changes can be reverted if needed. Full test suite (162 tests) passes after each commit.

**Direct dependencies:**
- `org.nanopub:nanopub` 1.86.1 → 1.86.2
- `org.eclipse.rdf4j:rdf4j-repository-http` 5.1.2 → 5.3.0
- `org.eclipse.rdf4j:rdf4j-sail-nativerdf` 5.1.2 → 5.3.0
- `org.mockito:mockito-core` 5.21.0 → 5.23.0

**Build plugins:**
- `maven-shade-plugin` 3.6.0 → 3.6.2
- `maven-surefire-plugin` 3.5.3 → 3.5.5
- `maven-compiler-plugin` 3.14.0 → 3.15.0
- `exec-maven-plugin` 3.5.0 → 3.6.3
- `maven-source-plugin` 3.3.1 → 3.4.0 (release profile)

## Not included

- **`micrometer-registry-prometheus` 1.10.13 → 1.16.x** — deliberately skipped. Micrometer 1.13 moved `PrometheusMeterRegistry` out of the `io.micrometer.prometheus` package, so a plain version bump breaks `MainVerticle.java:5` at runtime (`ClassNotFoundException`). Requires either a code migration to `io.micrometer.prometheusmetrics` or a switch to the `micrometer-registry-prometheus-simpleclient` artifact — out of scope here.
- Major-version / pre-release updates (Vert.x 5.x, JUnit 6.x, slf4j 2.1-alpha) — intentionally skipped.

## Test plan

- [x] `./mvnw test` passes (162 tests, 0 failures) after each commit
- [x] `./mvnw package` succeeds (shade plugin)
- [x] `./mvnw -Prelease package` succeeds (source plugin)