### PR TITLE
feat: materializer scaffolding — mirror + pointer + orphan cleanup (#62, PR 2a/3)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -1,0 +1,364 @@
+package com.knowledgepixels.query;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryResult;
+import org.nanopub.vocabulary.NPA;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.knowledgepixels.query.vocabulary.NPAT;
+import com.knowledgepixels.query.vocabulary.SpacesVocab;
+
+/**
+ * Drives the space-state materialization pipeline: detects trust-state flips,
+ * mirrors the approved {@code (agent, pubkey)} rows from the {@code trust} repo
+ * into a fresh {@code npass:<T>_<M>} graph in the {@code spaces} repo, runs the
+ * per-tier validation loops (stubbed in PR 2a), flips the
+ * {@code npa:hasCurrentSpaceState} pointer, and drops the previous graph. Also
+ * cleans up orphan {@code npass:*} graphs on startup.
+ *
+ * <p>See {@code doc/plan-space-repositories.md} — this implements the "Full
+ * build" procedure plus pointer management and the mirror step. Per-tier SPARQL
+ * UPDATE loops, the incremental cycle, and the periodic-rebuild flag follow in
+ * PRs 2b and 2c.
+ */
+public final class AuthorityResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthorityResolver.class);
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String SPACES_REPO = "spaces";
+    private static final String TRUST_REPO = "trust";
+
+    /** NPA constants pulled in locally (trust-side). */
+    private static final IRI NPA_HAS_CURRENT_TRUST_STATE =
+            vf.createIRI(NPA.NAMESPACE, "hasCurrentTrustState");
+    private static final IRI NPA_ACCOUNT_STATE = vf.createIRI(NPA.NAMESPACE, "AccountState");
+    private static final IRI NPA_AGENT = vf.createIRI(NPA.NAMESPACE, "agent");
+    private static final IRI NPA_PUBKEY = vf.createIRI(NPA.NAMESPACE, "pubkey");
+    private static final IRI NPA_TRUST_STATUS = vf.createIRI(NPA.NAMESPACE, "trustStatus");
+    private static final IRI NPA_LOADED = vf.createIRI(NPA.NAMESPACE, "loaded");
+    private static final IRI NPA_TO_LOAD = vf.createIRI(NPA.NAMESPACE, "toLoad");
+
+    /**
+     * Trust-approved set: rows with one of these {@code npa:trustStatus} values
+     * are mirrored into the space-state graph. Per
+     * {@code doc/design-trust-state-repos.md}, these are the two "authority-
+     * approving" statuses; {@code npa:contested}, {@code npa:skipped}, and the
+     * transient statuses are distinct values of the same predicate and are
+     * excluded automatically by this positive-list filter.
+     */
+    private static final Set<IRI> APPROVED_SET = Set.of(NPA_LOADED, NPA_TO_LOAD);
+
+    private static AuthorityResolver instance;
+
+    /** Returns the singleton. */
+    public static synchronized AuthorityResolver get() {
+        if (instance == null) {
+            instance = new AuthorityResolver();
+        }
+        return instance;
+    }
+
+    private AuthorityResolver() {
+    }
+
+    // ---------------- Public entry points ----------------
+
+    /**
+     * Poll entry point: checks the current trust-state hash against the active
+     * space-state graph's hash component; if they differ (or no space-state graph
+     * exists yet), runs a full build. Safe to call repeatedly on a schedule —
+     * when the hashes match, it's a no-op. Gated by
+     * {@link FeatureFlags#spacesEnabled()}.
+     */
+    public void tick() {
+        if (!FeatureFlags.spacesEnabled()) return;
+        String trustStateHash = TrustStateRegistry.get().getCurrentHash().orElse(null);
+        if (trustStateHash == null) {
+            log.debug("AuthorityResolver.tick: no current trust state yet — skipping");
+            return;
+        }
+        String currentGraphName = getCurrentSpaceStateGraphLocalName();
+        if (currentGraphName != null && currentGraphName.startsWith(trustStateHash + "_")) {
+            log.debug("AuthorityResolver.tick: already on trust state {}", abbrev(trustStateHash));
+            return;
+        }
+        log.info("AuthorityResolver.tick: trust-state flip detected (now {}); running full build",
+                abbrev(trustStateHash));
+        runFullBuild(trustStateHash);
+    }
+
+    /**
+     * Startup cleanup: drop any {@code npass:*} graph that the
+     * {@code npa:hasCurrentSpaceState} pointer isn't pointing at. Orphans come
+     * from crashes mid-build. Safe to call at any time; idempotent.
+     */
+    public void cleanOrphans() {
+        if (!FeatureFlags.spacesEnabled()) return;
+        IRI current = getCurrentSpaceStateGraph();
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
+            int dropped = 0;
+            try (RepositoryResult<org.eclipse.rdf4j.model.Resource> ctxs = conn.getContextIDs()) {
+                List<IRI> toDrop = new ArrayList<>();
+                while (ctxs.hasNext()) {
+                    org.eclipse.rdf4j.model.Resource ctx = ctxs.next();
+                    if (!(ctx instanceof IRI iri)) continue;
+                    if (!iri.stringValue().startsWith(SpacesVocab.NPASS_NAMESPACE)) continue;
+                    if (iri.equals(current)) continue;
+                    toDrop.add(iri);
+                }
+                for (IRI iri : toDrop) {
+                    conn.begin(IsolationLevels.SERIALIZABLE);
+                    conn.clear(iri);
+                    conn.commit();
+                    dropped++;
+                    log.info("AuthorityResolver.cleanOrphans: dropped orphan graph {}", iri);
+                }
+            }
+            if (dropped == 0) {
+                log.debug("AuthorityResolver.cleanOrphans: no orphan space-state graphs");
+            }
+        } catch (Exception ex) {
+            log.info("AuthorityResolver.cleanOrphans: failed: {}", ex.toString());
+        }
+    }
+
+    // ---------------- Full build ----------------
+
+    /**
+     * Mutex-protected full build of the space-state graph for the given trust
+     * state. Captures {@code M = currentLoadCounter}, mirrors trust-approved
+     * rows, (PR 2b: runs per-tier UPDATE loops from scratch), stamps
+     * {@code processedUpTo = M}, flips the pointer, drops the previous graph.
+     */
+    synchronized void runFullBuild(String trustStateHash) {
+        long loadCounter = getCurrentLoadCounter();
+        IRI newGraph = SpacesVocab.forSpaceState(trustStateHash, loadCounter);
+        IRI oldGraph = getCurrentSpaceStateGraph();
+        if (newGraph.equals(oldGraph)) {
+            log.debug("AuthorityResolver.runFullBuild: already current at {}", newGraph);
+            return;
+        }
+
+        // 1. Mirror trust-approved rows into the new graph.
+        int mirrored = mirrorTrustState(trustStateHash, newGraph);
+
+        // 2. PR 2b placeholder: per-tier UPDATE loops would run here.
+
+        // 3. Stamp processedUpTo inside the new graph.
+        writeProcessedUpTo(newGraph, loadCounter);
+
+        // 4. Flip the current-space-state pointer.
+        flipPointer(newGraph);
+
+        // 5. Drop the old graph if one existed.
+        if (oldGraph != null) {
+            dropGraph(oldGraph);
+        }
+
+        log.info("AuthorityResolver: full build complete — graph={} mirrored={} rows loadCounter={}",
+                newGraph, mirrored, loadCounter);
+    }
+
+    /**
+     * Copies trust-approved {@code npa:AccountState} rows from {@code npat:<T>}
+     * in the {@code trust} repo into {@code newGraph} in the {@code spaces} repo,
+     * inside one spaces-side serializable transaction.
+     *
+     * @return number of rows mirrored (useful for metrics / logging)
+     */
+    int mirrorTrustState(String trustStateHash, IRI newGraph) {
+        IRI trustStateIri = NPAT.forHash(trustStateHash);
+        int count = 0;
+        try (RepositoryConnection trustConn = TripleStore.get().getRepoConnection(TRUST_REPO);
+             RepositoryConnection spacesConn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
+            trustConn.begin(IsolationLevels.READ_COMMITTED);
+            spacesConn.begin(IsolationLevels.SERIALIZABLE);
+            // Walk rdf:type triples in the trust state's graph; for each AccountState,
+            // check status and copy the approved ones verbatim (minus status-specific
+            // detail triples, which we don't need for validation).
+            try (RepositoryResult<Statement> typeRows = trustConn.getStatements(
+                    null, RDF.TYPE, NPA_ACCOUNT_STATE, trustStateIri)) {
+                while (typeRows.hasNext()) {
+                    Statement st = typeRows.next();
+                    if (!(st.getSubject() instanceof IRI accountStateIri)) continue;
+                    Value status = trustConn.getStatements(accountStateIri, NPA_TRUST_STATUS, null, trustStateIri)
+                            .stream().findFirst().map(Statement::getObject).orElse(null);
+                    if (!(status instanceof IRI statusIri) || !APPROVED_SET.contains(statusIri)) continue;
+                    Value agent = trustConn.getStatements(accountStateIri, NPA_AGENT, null, trustStateIri)
+                            .stream().findFirst().map(Statement::getObject).orElse(null);
+                    Value pubkey = trustConn.getStatements(accountStateIri, NPA_PUBKEY, null, trustStateIri)
+                            .stream().findFirst().map(Statement::getObject).orElse(null);
+                    if (agent == null || pubkey == null) {
+                        log.warn("AuthorityResolver.mirror: account {} missing agent or pubkey; skipping",
+                                accountStateIri);
+                        continue;
+                    }
+                    spacesConn.add(accountStateIri, RDF.TYPE, NPA_ACCOUNT_STATE, newGraph);
+                    spacesConn.add(accountStateIri, NPA_AGENT, agent, newGraph);
+                    spacesConn.add(accountStateIri, NPA_PUBKEY, pubkey, newGraph);
+                    spacesConn.add(accountStateIri, NPA_TRUST_STATUS, statusIri, newGraph);
+                    count++;
+                }
+            }
+            spacesConn.commit();
+            trustConn.commit();
+        }
+        return count;
+    }
+
+    // ---------------- Pointer + counter helpers ----------------
+
+    /**
+     * Reads the current {@code npa:hasCurrentSpaceState} pointer from the
+     * {@code npa:graph} admin graph of the {@code spaces} repo. Returns
+     * {@code null} if no pointer exists yet.
+     */
+    IRI getCurrentSpaceStateGraph() {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
+            Value v = Utils.getObjectForPattern(conn, NPA.GRAPH, NPA.THIS_REPO,
+                    SpacesVocab.HAS_CURRENT_SPACE_STATE);
+            return (v instanceof IRI iri) ? iri : null;
+        } catch (Exception ex) {
+            log.warn("AuthorityResolver: failed to read hasCurrentSpaceState pointer: {}", ex.toString());
+            return null;
+        }
+    }
+
+    /** Convenience: local-name of the current space-state graph IRI. */
+    private String getCurrentSpaceStateGraphLocalName() {
+        IRI iri = getCurrentSpaceStateGraph();
+        if (iri == null) return null;
+        String s = iri.stringValue();
+        if (!s.startsWith(SpacesVocab.NPASS_NAMESPACE)) return null;
+        return s.substring(SpacesVocab.NPASS_NAMESPACE.length());
+    }
+
+    long getCurrentLoadCounter() {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
+            Value v = Utils.getObjectForPattern(conn, NPA.GRAPH, NPA.THIS_REPO,
+                    SpacesVocab.CURRENT_LOAD_COUNTER);
+            if (v == null) return 0;
+            try {
+                return Long.parseLong(v.stringValue());
+            } catch (NumberFormatException ex) {
+                log.warn("AuthorityResolver: non-numeric currentLoadCounter: {}", v);
+                return 0;
+            }
+        } catch (Exception ex) {
+            log.warn("AuthorityResolver: failed to read currentLoadCounter: {}", ex.toString());
+            return 0;
+        }
+    }
+
+    /**
+     * Atomic pointer flip: a single SPARQL {@code DELETE … INSERT … WHERE}
+     * replaces the old pointer with the new one in one statement, so readers
+     * never see a zero-pointer window.
+     */
+    void flipPointer(IRI newGraph) {
+        String update = String.format("""
+                DELETE { GRAPH <%s> { <%s> <%s> ?old } }
+                INSERT { GRAPH <%s> { <%s> <%s> <%s> } }
+                WHERE  { OPTIONAL { GRAPH <%s> { <%s> <%s> ?old } } }
+                """,
+                NPA.GRAPH, NPA.THIS_REPO, SpacesVocab.HAS_CURRENT_SPACE_STATE,
+                NPA.GRAPH, NPA.THIS_REPO, SpacesVocab.HAS_CURRENT_SPACE_STATE, newGraph,
+                NPA.GRAPH, NPA.THIS_REPO, SpacesVocab.HAS_CURRENT_SPACE_STATE);
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
+            conn.begin(IsolationLevels.SERIALIZABLE);
+            conn.prepareUpdate(QueryLanguage.SPARQL, update).execute();
+            conn.commit();
+        }
+    }
+
+    void writeProcessedUpTo(IRI graph, long loadCounter) {
+        String update = String.format("""
+                DELETE { GRAPH <%s> { <%s> <%s> ?old } }
+                INSERT { GRAPH <%s> { <%s> <%s> "%d"^^<http://www.w3.org/2001/XMLSchema#long> } }
+                WHERE  { OPTIONAL { GRAPH <%s> { <%s> <%s> ?old } } }
+                """,
+                graph, graph, SpacesVocab.PROCESSED_UP_TO,
+                graph, graph, SpacesVocab.PROCESSED_UP_TO, loadCounter,
+                graph, graph, SpacesVocab.PROCESSED_UP_TO);
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
+            conn.begin(IsolationLevels.SERIALIZABLE);
+            conn.prepareUpdate(QueryLanguage.SPARQL, update).execute();
+            conn.commit();
+        }
+    }
+
+    /**
+     * Reads {@code processedUpTo} from the given space-state graph.
+     * Returns {@code -1} if absent (graph not fully built yet).
+     */
+    long readProcessedUpTo(IRI graph) {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
+            String query = String.format(
+                    "SELECT ?n WHERE { GRAPH <%s> { <%s> <%s> ?n } }",
+                    graph, graph, SpacesVocab.PROCESSED_UP_TO);
+            try (TupleQueryResult r = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
+                if (!r.hasNext()) return -1;
+                BindingSet b = r.next();
+                return Long.parseLong(b.getBinding("n").getValue().stringValue());
+            }
+        } catch (Exception ex) {
+            log.warn("AuthorityResolver: failed to read processedUpTo for {}: {}", graph, ex.toString());
+            return -1;
+        }
+    }
+
+    void dropGraph(IRI graph) {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
+            conn.begin(IsolationLevels.SERIALIZABLE);
+            conn.clear(graph);
+            conn.commit();
+            log.info("AuthorityResolver: dropped old space-state graph {}", graph);
+        }
+    }
+
+    // ---------------- Trust-repo pointer lookup (used by TrustStateRegistry's bootstrap) ----------------
+
+    /**
+     * Queries the {@code trust} repo directly for the current trust-state hash.
+     * Prefer {@link TrustStateRegistry#getCurrentHash()} in normal operation —
+     * this helper exists for tests and diagnostics.
+     *
+     * @return the current trust-state hash, or empty if none is set
+     */
+    Optional<String> readTrustRepoCurrentHash() {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(TRUST_REPO)) {
+            Value v = Utils.getObjectForPattern(conn, NPA.GRAPH, NPA.THIS_REPO,
+                    NPA_HAS_CURRENT_TRUST_STATE);
+            if (!(v instanceof IRI iri)) return Optional.empty();
+            String s = iri.stringValue();
+            if (!s.startsWith(NPAT.NAMESPACE)) return Optional.empty();
+            return Optional.of(s.substring(NPAT.NAMESPACE.length()));
+        } catch (Exception ex) {
+            log.warn("AuthorityResolver: failed to read trust-repo current pointer: {}", ex.toString());
+            return Optional.empty();
+        }
+    }
+
+    private static String abbrev(String hash) {
+        return hash.length() > 12 ? hash.substring(0, 12) + "…" : hash;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -517,6 +517,12 @@ public class MainVerticle extends AbstractVerticle {
             // we already have.
             TrustStateLoader.bootstrap();
 
+            // Drop any npass:* graph that isn't the current-pointer target —
+            // leftovers from builds interrupted by a crash.
+            if (FeatureFlags.spacesEnabled()) {
+                AuthorityResolver.get().cleanOrphans();
+            }
+
             // Start periodic nanopub loading
             log.info("Starting periodic nanopub loading...");
             var executor = Executors.newSingleThreadScheduledExecutor();
@@ -526,6 +532,25 @@ public class MainVerticle extends AbstractVerticle {
                     JellyNanopubLoader.UPDATES_POLL_INTERVAL,
                     TimeUnit.MILLISECONDS
             );
+
+            // Periodic authority-resolver tick: detects trust-state flips and
+            // runs a full rebuild of the space-state graph when needed. Same
+            // cadence as the nanopub-loading poll.
+            if (FeatureFlags.spacesEnabled()) {
+                var spacesExecutor = Executors.newSingleThreadScheduledExecutor();
+                spacesExecutor.scheduleWithFixedDelay(
+                        () -> {
+                            try {
+                                AuthorityResolver.get().tick();
+                            } catch (Exception ex) {
+                                log.warn("AuthorityResolver tick failed", ex);
+                            }
+                        },
+                        JellyNanopubLoader.UPDATES_POLL_INTERVAL,
+                        JellyNanopubLoader.UPDATES_POLL_INTERVAL,
+                        TimeUnit.MILLISECONDS
+                );
+            }
         }).start();
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
@@ -112,6 +112,9 @@ public final class SpacesVocab {
     /** Repo-wide counter tracking the highest load number seen by the extractor. */
     public static final IRI CURRENT_LOAD_COUNTER = vf.createIRI(NPA.NAMESPACE, "currentLoadCounter");
 
+    /** Load-number horizon that a given space-state graph has been brought up to. */
+    public static final IRI PROCESSED_UP_TO = vf.createIRI(NPA.NAMESPACE, "processedUpTo");
+
     // -------- Subject-minting helpers --------
 
     /** Mints {@code npas:<spaceRef>} for an aggregate space-ref entry. */
@@ -142,6 +145,17 @@ public final class SpacesVocab {
     /** Mints {@code npainv:<artifactCode>} for an invalidation entry. */
     public static IRI forInvalidation(String artifactCode) {
         return vf.createIRI(NPAINV_NAMESPACE, artifactCode);
+    }
+
+    /**
+     * Mints {@code npass:<trustStateHash>_<loadCounterAtBuildStart>} for a space-state graph.
+     *
+     * @param trustStateHash       the source trust-state hash
+     * @param loadCounterAtBuildStart the value of {@code npa:currentLoadCounter} when the build kicked off
+     * @return the graph IRI
+     */
+    public static IRI forSpaceState(String trustStateHash, long loadCounterAtBuildStart) {
+        return vf.createIRI(NPASS_NAMESPACE, trustStateHash + "_" + loadCounterAtBuildStart);
     }
 
     private SpacesVocab() {

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -1,0 +1,56 @@
+package com.knowledgepixels.query;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-logic tests for {@link AuthorityResolver}. The full-cycle behaviour
+ * (mirror / runFullBuild / pointer swap / orphan cleanup) exercises real RDF4J
+ * connections; the project's current dependency versions mix
+ * {@code sail-base:5.3.0} with {@code sail-memory:5.1.5} / {@code common-concurrent:5.1.5}
+ * in a way that breaks pattern-delete and SPARQL UPDATE on both MemoryStore and
+ * NativeStore in tests. Those paths are covered by the integration smoke test
+ * against a live deployment (see {@code doc/plan-space-repositories.md} and the
+ * live-instance spot-checks accompanying this PR).
+ */
+class AuthorityResolverTest {
+
+    @BeforeEach
+    void resetSingletons() throws Exception {
+        // Prevent state bleeding across tests.
+        reset(AuthorityResolver.class, "instance");
+        reset(TrustStateRegistry.class, "instance");
+    }
+
+    private static void reset(Class<?> cls, String fieldName) throws Exception {
+        Field f = cls.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(null, null);
+    }
+
+    @Test
+    void get_returnsSameSingleton() {
+        AuthorityResolver a = AuthorityResolver.get();
+        AuthorityResolver b = AuthorityResolver.get();
+        assertNotNull(a);
+        assertSame(a, b, "get() must always return the same instance");
+    }
+
+    @Test
+    void tick_noCurrentTrustState_isNoOp() {
+        // Registry is fresh; getCurrentHash is empty.
+        assertFalse(TrustStateRegistry.get().getCurrentHash().isPresent());
+        // tick() should exit early and not throw.
+        AuthorityResolver.get().tick();
+        assertTrue(TrustStateRegistry.get().getCurrentHash().isEmpty(),
+                "tick() must not seed a hash when none is available");
+    }
+
+}


### PR DESCRIPTION
Refs #62.

First of three server-side materialization PRs (2a / 2b / 2c) implementing the v2 materialization pipeline from [`doc/plan-space-repositories.md`](https://github.com/knowledgepixels/nanopub-query/blob/main/doc/plan-space-repositories.md). Builds on the extraction layer merged as #79.

## Scope of this PR (2a)

This PR lands the pipeline's plumbing — trust-state flip detection, cross-repo mirror, pointer management, orphan cleanup — with the per-tier validation loops explicitly stubbed. Once this lands, a trust-state flip will cause a new `npass:<T>_<M>` graph to appear in the `spaces` repo containing only the mirrored approved trust rows; when PR 2b wires up the tier loops, those same graphs will also carry the validated `RoleInstantiation` / `RoleAssignment` closures.

### Added

- **`vocabulary/SpacesVocab`**: `npa:processedUpTo` predicate and `forSpaceState(trustStateHash, loadCounter)` helper minting `npass:<T>_<M>` IRIs per the plan.
- **`AuthorityResolver.java`** (~360 LoC):
  - `tick()` — polls `TrustStateRegistry`; on a flip (current hash ≠ active graph's `<T>_<M>` prefix), runs a full build. No-op otherwise. Safe to call on a schedule.
  - `runFullBuild(T)` — captures `M = currentLoadCounter`, mirrors, writes `processedUpTo = M`, flips pointer, drops old graph. `synchronized` for rebuild serialization.
  - `mirrorTrustState(T, newGraph)` — Java-level cross-repo copy of `AccountState` rows with `npa:trustStatus ∈ {npa:loaded, npa:toLoad}`. `npa:contested` and `npa:skipped` excluded automatically by the positive-list filter (per [design-trust-state-repos.md](https://github.com/knowledgepixels/nanopub-query/blob/main/doc/design-trust-state-repos.md)).
  - `flipPointer(newGraph)` — atomic `DELETE ... INSERT ... WHERE` so readers never see a zero-pointer window.
  - `cleanOrphans()` — on startup, drop any `npass:*` graph that `npa:hasCurrentSpaceState` doesn't point at. Handles crashes between build and pointer flip.
- **`MainVerticle`**: `AuthorityResolver.get().cleanOrphans()` on startup after `TrustStateLoader.bootstrap()`, plus a new single-thread scheduled executor calling `tick()` on the same cadence as nanopub loading. Both gated by `FeatureFlags.spacesEnabled()`.

### Deferred to PR 2b

- Per-tier SPARQL UPDATE loops (admin → `gen:hasRole` validation → maintainer → member → observer).
- Invalidation filter on reads from `npa:spacesGraph`.
- Incremental cycle (load-number-delta tier INSERTs + invalidation DELETE).
- Late-arrival handling (downstream re-run when structural changes happen in a cycle).

### Deferred to PR 2c

- `npa:needsFullRebuild` flag and periodic rebuild worker.

## Feature flag

Gated by the existing `NANOPUB_QUERY_ENABLE_SPACES` env var (default `true`). When disabled: cleanOrphans/tick are both no-ops and the scheduled executor isn't started.

## Testing

- `./mvnw clean test` — **153/153 pass** locally (2 new `AuthorityResolverTest` + 151 from PR #79 and before).
- **Deferred test coverage**: full-cycle behaviour (mirror, runFullBuild, pointer swap, cleanOrphans end-to-end) exercises real RDF4J I/O. The project's dependency tree currently mixes `rdf4j-sail-base:5.3.0` (transitively from `sail-nativerdf:5.3.0`) with `sail-memory:5.1.5` / `common-concurrent:5.1.5`, which breaks pattern-delete and SPARQL UPDATE in tests on both backing stores (`NoSuchMethodError` on `SailSourceConnection` internals). Naively bumping `sail-memory` to 5.3.0 pulls in more deps with the same kind of mismatch. I tried both paths and backed out in favour of unit tests covering the logic we can cleanly test. Full-cycle coverage can either land via the live integration smoke-test (per the approach used with PR #79) or as part of a parallel PR that untangles the rdf4j deps. Flagging for reviewers — happy to go either direction.

## Test plan

- [x] `./mvnw clean compile`
- [x] `./mvnw clean test` (153/153)
- [x] Start against a fresh local DB with `NANOPUB_QUERY_ENABLE_SPACES=true`; confirm a `npass:<T>_<M>` graph appears after the first trust-state tick; confirm `npa:hasCurrentSpaceState` points at it; confirm mirrored account-state rows match the approved set in the `trust` repo.
- [ ] Kill mid-build; confirm startup `cleanOrphans()` drops the half-built graph.