### PR TITLE
feat: per-tier SPARQL UPDATE loops in full build (#62, PR 2b/3)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -307,10 +307,14 @@ public final class AuthorityResolver {
      * trust-approved AccountState) is already in the admin set.
      */
     static String adminTierUpdate(IRI graph, long lastProcessed) {
-        // npa:hasLoadNumber lives in the admin graph (NPA.GRAPH), NOT in
-        // npa:spacesGraph — NanopubLoader writes the stamp there. Every tier
-        // template below joins the delta filter via a separate GRAPH <npa:graph>
-        // block. Invalidation entries DO live in npa:spacesGraph.
+        // Order tuned for RDF4J's evaluator:
+        //   1. Anchor on the small (seed UNION closed-over) set to bind ?publisher
+        //      and ?space cheaply.
+        //   2. Resolve ?pkh from the mirrored AccountState row (?publisher bound).
+        //   3. Probe instantiations using the now-bound (?space, ?pkh) — targeted
+        //      lookup, not a full RoleInstantiation scan.
+        //   4. Load-number filter on bound ?np.
+        //   5. Dedup at the end.
         return """
                 PREFIX npa:  <%1$s>
                 PREFIX gen:  <%2$s>
@@ -322,24 +326,12 @@ public final class AuthorityResolver {
                       npa:viaNanopub ?np .
                 } }
                 WHERE {
-                  GRAPH <%4$s> {
-                    ?ri a gen:RoleInstantiation ;
-                        npa:forSpace        ?space ;
-                        npa:regularProperty gen:hasAdmin ;
-                        npa:forAgent        ?agent ;
-                        npa:pubkeyHash      ?pkh ;
-                        npa:viaNanopub      ?np .
-                    %6$s
-                  }
-                  GRAPH <%8$s> {
-                    ?np npa:hasLoadNumber ?ln .
-                    FILTER (?ln > %5$d)
-                  }
+                  # 1. Anchor: who is already an admin of which space?
                   {
                     # Seed branch: root-admin in a non-invalidated SpaceDefinition.
                     GRAPH <%4$s> {
                       ?def a npa:SpaceDefinition ;
-                           npa:forSpaceRef ?spaceRef ;
+                           npa:forSpaceRef  ?spaceRef ;
                            npa:hasRootAdmin ?publisher ;
                            npa:viaNanopub   ?defNp .
                       ?spaceRef npa:spaceIri ?space .
@@ -351,16 +343,33 @@ public final class AuthorityResolver {
                     # Closed-over branch: an existing admin in this space-state graph.
                     GRAPH <%3$s> {
                       ?prev a gen:RoleInstantiation ;
-                            npa:forSpace ?space ;
+                            npa:forSpace        ?space ;
                             npa:regularProperty gen:hasAdmin ;
-                            npa:forAgent ?publisher .
+                            npa:forAgent        ?publisher .
                     }
                   }
+                  # 2. Mirror: resolve ?publisher → ?pkh via the trust-approved row.
                   GRAPH <%3$s> {
                     ?acct a npa:AccountState ;
                           npa:agent  ?publisher ;
                           npa:pubkey ?pkh .
                   }
+                  # 3. Targeted instantiation lookup by space + pubkey.
+                  GRAPH <%4$s> {
+                    ?ri a gen:RoleInstantiation ;
+                        npa:forSpace        ?space ;
+                        npa:regularProperty gen:hasAdmin ;
+                        npa:forAgent        ?agent ;
+                        npa:pubkeyHash      ?pkh ;
+                        npa:viaNanopub      ?np .
+                    %6$s
+                  }
+                  # 4. Load-number filter on bound ?np.
+                  GRAPH <%8$s> {
+                    ?np npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
+                  }
+                  # 5. Dedup last.
                   FILTER NOT EXISTS { GRAPH <%3$s> {
                     ?existing a gen:RoleInstantiation ;
                               npa:forSpace ?space ;
@@ -452,6 +461,15 @@ public final class AuthorityResolver {
      */
     static String nonAdminTierUpdate(IRI graph, long lastProcessed,
                                      IRI tierClass, String publisherConstraint) {
+        // Order tuned for RDF4J's evaluator (which executes BGPs roughly in order):
+        //   1. Anchor on the small, tier-pinned RoleDeclaration set (~tens of rows).
+        //   2. Pair the role-decl direction with the instantiation direction inside
+        //      one UNION so only valid (regular, regular)/(inverse, inverse) joins
+        //      are explored — not the 2x2 cross-product of independent UNIONs.
+        //   3. Match the candidate instantiation by the now-bound predicate.
+        //   4. Resolve load-number from the admin graph (now-bound subject).
+        //   5. Attachment + mirrored AccountState + publisher constraint, last.
+        //   6. Dedup at the end.
         return """
                 PREFIX npa:  <%1$s>
                 PREFIX gen:  <%2$s>
@@ -462,41 +480,47 @@ public final class AuthorityResolver {
                       npa:viaNanopub ?np .
                 } }
                 WHERE {
+                  # 1. Anchor: tier-pinned RoleDeclarations (small, selective).
                   GRAPH <%4$s> {
+                    ?rd a npa:RoleDeclaration ;
+                        npa:hasRoleType <%7$s> ;
+                        npa:role        ?role ;
+                        npa:viaNanopub  ?rdNp .
+                    %8$s
+                    # 2. Pair direction so the planner explores only matching combos.
+                    {
+                      ?rd gen:hasRegularProperty ?pred .
+                      ?ri npa:regularProperty    ?pred .
+                    }
+                    UNION
+                    {
+                      ?rd gen:hasInverseProperty ?pred .
+                      ?ri npa:inverseProperty    ?pred .
+                    }
+                    # 3. Targeted instantiation lookup — ?pred is bound.
                     ?ri a gen:RoleInstantiation ;
-                        npa:forSpace ?space ;
-                        npa:forAgent ?agent ;
+                        npa:forSpace   ?space ;
+                        npa:forAgent   ?agent ;
                         npa:pubkeyHash ?pkh ;
                         npa:viaNanopub ?np .
-                    { ?ri npa:regularProperty ?pred . }
-                    UNION
-                    { ?ri npa:inverseProperty ?pred . }
                     %6$s
-                    # Predicate maps to a RoleDeclaration of this tier (not invalidated).
-                    ?rd a npa:RoleDeclaration ;
-                        npa:role ?role ;
-                        npa:hasRoleType <%7$s> ;
-                        npa:viaNanopub ?rdNp .
-                    { ?rd gen:hasRegularProperty ?pred . }
-                    UNION
-                    { ?rd gen:hasInverseProperty ?pred . }
-                    %8$s
                   }
+                  # 4. Load-number filter on bound ?np.
                   GRAPH <%10$s> {
                     ?np npa:hasLoadNumber ?ln .
                     FILTER (?ln > %5$d)
                   }
+                  # 5. Attachment + AccountState + publisher constraint.
                   GRAPH <%3$s> {
-                    # Role must be admin-attached to the target space.
                     ?ra a gen:RoleAssignment ;
-                        npa:forSpace ?space ;
-                        gen:hasRole  ?role .
-                    # Publisher's agent from the mirrored trust-approved set.
+                        gen:hasRole  ?role ;
+                        npa:forSpace ?space .
                     ?acct a npa:AccountState ;
-                          npa:agent ?publisher ;
-                          npa:pubkey ?pkh .
+                          npa:pubkey ?pkh ;
+                          npa:agent  ?publisher .
                     %9$s
                   }
+                  # 6. Dedup last.
                   FILTER NOT EXISTS { GRAPH <%3$s> {
                     ?existing a gen:RoleInstantiation ;
                               npa:forSpace ?space ;

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -235,10 +235,15 @@ public final class AuthorityResolver {
         int total = 0;
         long before = graphSize(graph);
         while (true) {
+            // Note: no explicit transaction wrapping here. In tests we observed that
+            // HTTPRepository's RDF4J-transaction protocol silently no-op'd cross-graph
+            // SPARQL UPDATEs with UNION sub-patterns inside conn.begin()/commit(),
+            // while the same UPDATE POSTed directly to /statements applied correctly.
+            // A bare prepareUpdate().execute() takes the direct /statements path and
+            // runs the UPDATE atomically per SPARQL 1.1 semantics — which is all we
+            // need; there's nothing else to commit atomically alongside the UPDATE.
             try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
-                conn.begin(IsolationLevels.SERIALIZABLE);
                 conn.prepareUpdate(QueryLanguage.SPARQL, sparqlUpdate).execute();
-                conn.commit();
             }
             long after = graphSize(graph);
             long added = after - before;

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -203,15 +203,26 @@ public final class AuthorityResolver {
      */
     TierCounts runAllTierLoops(IRI graph, long lastProcessed) {
         TierCounts c = new TierCounts();
-        c.admin = runTierLoop(graph, adminTierUpdate(graph, lastProcessed));
-        c.attachment = runTierLoop(graph, attachmentValidationUpdate(graph, lastProcessed));
-        c.maintainer = runTierLoop(graph, nonAdminTierUpdate(graph, lastProcessed,
+        c.admin = runTierLabeled("admin", graph, adminTierUpdate(graph, lastProcessed));
+        c.attachment = runTierLabeled("attachment", graph,
+                attachmentValidationUpdate(graph, lastProcessed));
+        c.maintainer = runTierLabeled("maintainer", graph, nonAdminTierUpdate(graph, lastProcessed,
                 GEN.MAINTAINER_ROLE, PUBLISHER_IS_ADMIN));
-        c.member = runTierLoop(graph, nonAdminTierUpdate(graph, lastProcessed,
+        c.member = runTierLabeled("member", graph, nonAdminTierUpdate(graph, lastProcessed,
                 GEN.MEMBER_ROLE, PUBLISHER_IS_ADMIN_OR_MAINTAINER));
-        c.observer = runTierLoop(graph, nonAdminTierUpdate(graph, lastProcessed,
+        c.observer = runTierLabeled("observer", graph, nonAdminTierUpdate(graph, lastProcessed,
                 GEN.OBSERVER_ROLE, PUBLISHER_IS_SELF_OR_TIERED));
         return c;
+    }
+
+    /** Wraps {@link #runTierLoop} with tier-name context for logs/exceptions. */
+    private int runTierLabeled(String tier, IRI graph, String sparqlUpdate) {
+        try {
+            return runTierLoop(graph, sparqlUpdate);
+        } catch (RuntimeException ex) {
+            log.error("AuthorityResolver: tier={} failed with SPARQL UPDATE:\n{}\n", tier, sparqlUpdate, ex);
+            throw ex;
+        }
     }
 
     /**
@@ -246,10 +257,17 @@ public final class AuthorityResolver {
 
     // ---------------- SPARQL templates ----------------
 
-    /** Reusable invalidation filter on a bound nanopub-IRI variable. */
-    private static String invalidationFilter(String npVar) {
-        return "FILTER NOT EXISTS { ?_inv_" + npVar + " a <" + SpacesVocab.INVALIDATION + "> ; "
-                + "<" + SpacesVocab.INVALIDATES + "> " + npVar + " . }";
+    /**
+     * Reusable invalidation filter on a bound nanopub-IRI variable. Pass the bare
+     * variable name (no leading {@code ?}); e.g. {@code invalidationFilter("np")}
+     * produces {@code FILTER NOT EXISTS { ?_inv_np a npa:Invalidation ; npa:invalidates ?np . }}.
+     * Variable names must match {@code [A-Za-z0-9_]+} per SPARQL grammar — embedding
+     * a {@code ?} inside {@code ?_inv_?np} would yield a parse error.
+     */
+    private static String invalidationFilter(String bareVarName) {
+        return "FILTER NOT EXISTS { ?_inv_" + bareVarName
+                + " a <" + SpacesVocab.INVALIDATION + "> ; "
+                + "<" + SpacesVocab.INVALIDATES + "> ?" + bareVarName + " . }";
     }
 
     /**
@@ -259,6 +277,10 @@ public final class AuthorityResolver {
      * trust-approved AccountState) is already in the admin set.
      */
     static String adminTierUpdate(IRI graph, long lastProcessed) {
+        // The seed branch reads SpaceDefinition entries from npa:spacesGraph (that's
+        // where they live). The closed-over branch reads existing admin instantiations
+        // from the current space-state graph. Both branches must establish ?publisher
+        // before joining to the mirrored AccountState row (which resolves ?pkh).
         return """
                 PREFIX npa:  <%1$s>
                 PREFIX gen:  <%2$s>
@@ -281,26 +303,31 @@ public final class AuthorityResolver {
                     FILTER (?ln > %5$d)
                     %6$s
                   }
-                  GRAPH <%3$s> {
-                    ?acct a npa:AccountState ;
-                          npa:agent  ?publisher ;
-                          npa:pubkey ?pkh .
-                    {
-                      # Seed: root-admin in a non-invalidated SpaceDefinition for this space
+                  {
+                    # Seed branch: root-admin in a non-invalidated SpaceDefinition.
+                    GRAPH <%4$s> {
                       ?def a npa:SpaceDefinition ;
                            npa:forSpaceRef ?spaceRef ;
                            npa:hasRootAdmin ?publisher ;
                            npa:viaNanopub   ?defNp .
                       ?spaceRef npa:spaceIri ?space .
+                      %7$s
                     }
-                    UNION
-                    {
-                      # Closed-over: an existing admin instantiation for this space
+                  }
+                  UNION
+                  {
+                    # Closed-over branch: an existing admin in this space-state graph.
+                    GRAPH <%3$s> {
                       ?prev a gen:RoleInstantiation ;
                             npa:forSpace ?space ;
                             npa:regularProperty gen:hasAdmin ;
                             npa:forAgent ?publisher .
                     }
+                  }
+                  GRAPH <%3$s> {
+                    ?acct a npa:AccountState ;
+                          npa:agent  ?publisher ;
+                          npa:pubkey ?pkh .
                   }
                   FILTER NOT EXISTS { GRAPH <%3$s> {
                     ?existing a gen:RoleInstantiation ;
@@ -308,11 +335,6 @@ public final class AuthorityResolver {
                               npa:forAgent ?agent ;
                               npa:regularProperty gen:hasAdmin .
                   } }
-                  # Invalidation filter on the SpaceDefinition (seed branch) is only
-                  # checked if that branch matched. Since ?defNp is unbound in the
-                  # closed-over branch we apply the filter inside the WHERE's OPTIONAL
-                  # pattern via a nested FILTER — see adminSeedInvalidationFilter
-                  # below.
                 }
                 """.formatted(
                 NPA.NAMESPACE,
@@ -320,7 +342,8 @@ public final class AuthorityResolver {
                 graph,
                 SpacesVocab.SPACES_GRAPH,
                 lastProcessed,
-                invalidationFilter("?np"));
+                invalidationFilter("np"),
+                invalidationFilter("defNp"));
     }
 
     /**
@@ -370,7 +393,7 @@ public final class AuthorityResolver {
                 graph,
                 SpacesVocab.SPACES_GRAPH,
                 lastProcessed,
-                invalidationFilter("?np"));
+                invalidationFilter("np"));
     }
 
     /** Non-admin tier publisher constraints (inserted as a SPARQL sub-pattern). */
@@ -505,9 +528,9 @@ public final class AuthorityResolver {
                 graph,
                 SpacesVocab.SPACES_GRAPH,
                 lastProcessed,
-                invalidationFilter("?np"),
+                invalidationFilter("np"),
                 tierClass,
-                invalidationFilter("?rdNp"),
+                invalidationFilter("rdNp"),
                 publisherConstraint);
     }
 

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -214,15 +214,11 @@ public final class AuthorityResolver {
                 GEN.MEMBER_ROLE, PUBLISHER_IS_ADMIN));
         c.member += runTierLabeled("member(maint-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
                 GEN.MEMBER_ROLE, publisherIsTieredRole(GEN.MAINTAINER_ROLE)));
-        // Observer tier: admin OR maintainer OR member publisher OR self-evidence — four
-        // simple updates instead of one 4-branch UNION, which HTTP-timed out in practice.
-        c.observer = runTierLabeled("observer(admin-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
-                GEN.OBSERVER_ROLE, PUBLISHER_IS_ADMIN));
-        c.observer += runTierLabeled("observer(maint-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
-                GEN.OBSERVER_ROLE, publisherIsTieredRole(GEN.MAINTAINER_ROLE)));
-        c.observer += runTierLabeled("observer(member-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
-                GEN.OBSERVER_ROLE, publisherIsTieredRole(GEN.MEMBER_ROLE)));
-        c.observer += runTierLabeled("observer(self)", graph, nonAdminTierUpdate(graph, lastProcessed,
+        // Observer tier: self-evidence only per the plan's policy table
+        // (gen:ObserverRole = self). Authority-publisher sub-tiers were overreach;
+        // the three of them have been removed, so an observer instantiation is
+        // validated iff the assignee's own pubkey signed it.
+        c.observer = runTierLabeled("observer(self)", graph, nonAdminTierUpdate(graph, lastProcessed,
                 GEN.OBSERVER_ROLE, PUBLISHER_IS_SELF));
         return c;
     }

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -226,9 +226,14 @@ public final class AuthorityResolver {
     /**
      * Builds a publisher constraint requiring the publisher to be a validated holder
      * of the given tier's role (maintainer or member) in the target space.
+     * Owns its own AccountState resolution so ?publisher is bound through the
+     * targeted (pkh → agent) lookup rather than enumerated.
      */
     private static String publisherIsTieredRole(IRI tierClass) {
         return """
+                ?acct a npa:AccountState ;
+                      npa:pubkey ?pkh ;
+                      npa:agent  ?publisher .
                 ?tierRI a gen:RoleInstantiation ;
                         npa:forSpace ?space ;
                         npa:forAgent ?publisher .
@@ -290,14 +295,26 @@ public final class AuthorityResolver {
     /**
      * Reusable invalidation filter on a bound nanopub-IRI variable. Pass the bare
      * variable name (no leading {@code ?}); e.g. {@code invalidationFilter("np")}
-     * produces {@code FILTER NOT EXISTS { ?_inv_np a npa:Invalidation ; npa:invalidates ?np . }}.
-     * Variable names must match {@code [A-Za-z0-9_]+} per SPARQL grammar — embedding
-     * a {@code ?} inside {@code ?_inv_?np} would yield a parse error.
+     * produces an outer-scoped {@code FILTER NOT EXISTS { GRAPH npa:spacesGraph
+     * { ?_inv_np a npa:Invalidation ; npa:invalidates ?np . } }}.
+     *
+     * <p>Important: this filter must be placed OUTSIDE the surrounding
+     * {@code GRAPH npa:spacesGraph { ... }} block, not nested inside it. When
+     * nested, RDF4J's planner couples the FILTER NOT EXISTS evaluation into the
+     * join order (per-row scan of {@code ?_inv a npa:Invalidation} multiplied by
+     * the candidate set), which we measured turning a 39ms query into a 60s+
+     * timeout on the live observer-tier data. Outside the GRAPH block, the
+     * planner defers the filter until {@code ?np}/{@code ?rdNp} are bound and
+     * does a targeted index lookup.
+     *
+     * <p>Variable names must match {@code [A-Za-z0-9_]+} per SPARQL grammar —
+     * embedding a {@code ?} inside {@code ?_inv_?np} would yield a parse error.
      */
     private static String invalidationFilter(String bareVarName) {
-        return "FILTER NOT EXISTS { ?_inv_" + bareVarName
+        return "FILTER NOT EXISTS { GRAPH <" + SpacesVocab.SPACES_GRAPH + "> {"
+                + " ?_inv_" + bareVarName
                 + " a <" + SpacesVocab.INVALIDATION + "> ; "
-                + "<" + SpacesVocab.INVALIDATES + "> ?" + bareVarName + " . }";
+                + "<" + SpacesVocab.INVALIDATES + "> ?" + bareVarName + " . } }";
     }
 
     /**
@@ -335,8 +352,8 @@ public final class AuthorityResolver {
                            npa:hasRootAdmin ?publisher ;
                            npa:viaNanopub   ?defNp .
                       ?spaceRef npa:spaceIri ?space .
-                      %7$s
                     }
+                    %7$s
                   }
                   UNION
                   {
@@ -362,8 +379,8 @@ public final class AuthorityResolver {
                         npa:forAgent        ?agent ;
                         npa:pubkeyHash      ?pkh ;
                         npa:viaNanopub      ?np .
-                    %6$s
                   }
+                  %6$s
                   # 4. Load-number filter on bound ?np.
                   GRAPH <%8$s> {
                     ?np npa:hasLoadNumber ?ln .
@@ -410,7 +427,6 @@ public final class AuthorityResolver {
                         gen:hasRole  ?role ;
                         npa:pubkeyHash ?pkh ;
                         npa:viaNanopub ?np .
-                    %6$s
                   }
                   GRAPH <%7$s> {
                     ?np npa:hasLoadNumber ?ln .
@@ -425,6 +441,7 @@ public final class AuthorityResolver {
                              npa:regularProperty gen:hasAdmin ;
                              npa:forAgent ?publisher .
                   }
+                  %6$s
                   FILTER NOT EXISTS { GRAPH <%3$s> {
                     ?existing a gen:RoleAssignment ;
                               npa:forSpace ?space ;
@@ -441,17 +458,30 @@ public final class AuthorityResolver {
                 NPA.GRAPH);
     }
 
-    /** Non-admin tier publisher constraints (inserted as a SPARQL sub-pattern). */
+    /**
+     * Non-admin tier publisher constraints (inserted as a SPARQL sub-pattern).
+     * Each constraint owns the AccountState (pkh → agent) lookup so the join
+     * variable is bound through a targeted pattern. The observer-self variant
+     * binds {@code npa:agent ?agent} directly — no separate {@code ?publisher}
+     * variable, no post-join equality filter — which lets the planner anchor
+     * the AccountState lookup on the already-bound {@code ?agent} instead of
+     * enumerating all approved publishers and filtering at the end.
+     */
     static final String PUBLISHER_IS_ADMIN = """
+            ?acct a npa:AccountState ;
+                  npa:pubkey ?pkh ;
+                  npa:agent  ?publisher .
             ?adminRI a gen:RoleInstantiation ;
                      npa:forSpace ?space ;
                      npa:regularProperty gen:hasAdmin ;
                      npa:forAgent ?publisher .
             """;
 
-    /** Observer self-evidence: the assignee is the publisher. */
+    /** Observer self-evidence: the assignee's own pubkey signed the instantiation. */
     static final String PUBLISHER_IS_SELF = """
-            FILTER (?publisher = ?agent)
+            ?acct a npa:AccountState ;
+                  npa:pubkey ?pkh ;
+                  npa:agent  ?agent .
             """;
 
     /**
@@ -461,15 +491,21 @@ public final class AuthorityResolver {
      */
     static String nonAdminTierUpdate(IRI graph, long lastProcessed,
                                      IRI tierClass, String publisherConstraint) {
-        // Order tuned for RDF4J's evaluator (which executes BGPs roughly in order):
-        //   1. Anchor on the small, tier-pinned RoleDeclaration set (~tens of rows).
-        //   2. Pair the role-decl direction with the instantiation direction inside
-        //      one UNION so only valid (regular, regular)/(inverse, inverse) joins
-        //      are explored — not the 2x2 cross-product of independent UNIONs.
-        //   3. Match the candidate instantiation by the now-bound predicate.
-        //   4. Resolve load-number from the admin graph (now-bound subject).
-        //   5. Attachment + mirrored AccountState + publisher constraint, last.
-        //   6. Dedup at the end.
+        // Order tuned for RDF4J's evaluator (which executes BGPs roughly in order).
+        // The crucial choice is the *anchor*: instantiation-first plans send the
+        // planner exploring the full ~thousands of candidate RIs and only filter
+        // by tier at the very end. Attachment-first anchors on the small set of
+        // gen:RoleAssignment rows already validated in this space-state graph
+        // (~hundreds, often zero) and walks outward by bound (?role, ?space).
+        //
+        //   1. Anchor on RoleAssignments in this space-state graph (small).
+        //   2. Match the tier-pinned RoleDeclaration by ?role.
+        //   3. Pair role-decl direction to instantiation direction in one UNION
+        //      so only (reg, reg)/(inv, inv) combos are explored.
+        //   4. Targeted instantiation lookup — (?space, ?pred) are bound.
+        //   5. Publisher constraint (incl. AccountState resolution).
+        //   6. Load-number filter on bound ?np.
+        //   7. Dedup at the end.
         return """
                 PREFIX npa:  <%1$s>
                 PREFIX gen:  <%2$s>
@@ -480,14 +516,19 @@ public final class AuthorityResolver {
                       npa:viaNanopub ?np .
                 } }
                 WHERE {
-                  # 1. Anchor: tier-pinned RoleDeclarations (small, selective).
+                  # 1. Anchor: validated attachments in this space-state graph.
+                  GRAPH <%3$s> {
+                    ?ra a gen:RoleAssignment ;
+                        gen:hasRole  ?role ;
+                        npa:forSpace ?space .
+                  }
+                  # 2. Tier-pinned RoleDeclaration (?role bound from the attachment).
                   GRAPH <%4$s> {
                     ?rd a npa:RoleDeclaration ;
                         npa:hasRoleType <%7$s> ;
                         npa:role        ?role ;
                         npa:viaNanopub  ?rdNp .
-                    %8$s
-                    # 2. Pair direction so the planner explores only matching combos.
+                    # 3. Pair direction so only matching combos are explored.
                     {
                       ?rd gen:hasRegularProperty ?pred .
                       ?ri npa:regularProperty    ?pred .
@@ -497,30 +538,27 @@ public final class AuthorityResolver {
                       ?rd gen:hasInverseProperty ?pred .
                       ?ri npa:inverseProperty    ?pred .
                     }
-                    # 3. Targeted instantiation lookup — ?pred is bound.
+                    # 4. Targeted instantiation lookup — (?space, ?pred) bound.
                     ?ri a gen:RoleInstantiation ;
                         npa:forSpace   ?space ;
                         npa:forAgent   ?agent ;
                         npa:pubkeyHash ?pkh ;
                         npa:viaNanopub ?np .
-                    %6$s
                   }
-                  # 4. Load-number filter on bound ?np.
+                  # 5. Publisher constraint (incl. AccountState resolution).
+                  GRAPH <%3$s> {
+                    %9$s
+                  }
+                  # 6. Load-number filter on bound ?np.
                   GRAPH <%10$s> {
                     ?np npa:hasLoadNumber ?ln .
                     FILTER (?ln > %5$d)
                   }
-                  # 5. Attachment + AccountState + publisher constraint.
-                  GRAPH <%3$s> {
-                    ?ra a gen:RoleAssignment ;
-                        gen:hasRole  ?role ;
-                        npa:forSpace ?space .
-                    ?acct a npa:AccountState ;
-                          npa:pubkey ?pkh ;
-                          npa:agent  ?publisher .
-                    %9$s
-                  }
-                  # 6. Dedup last.
+                  # 7. Invalidation filters — outside the GRAPH block so the
+                  #    planner defers them until ?rdNp/?np are bound.
+                  %8$s
+                  %6$s
+                  # 8. Dedup last.
                   FILTER NOT EXISTS { GRAPH <%3$s> {
                     ?existing a gen:RoleInstantiation ;
                               npa:forSpace ?space ;

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -208,11 +208,40 @@ public final class AuthorityResolver {
                 attachmentValidationUpdate(graph, lastProcessed));
         c.maintainer = runTierLabeled("maintainer", graph, nonAdminTierUpdate(graph, lastProcessed,
                 GEN.MAINTAINER_ROLE, PUBLISHER_IS_ADMIN));
-        c.member = runTierLabeled("member", graph, nonAdminTierUpdate(graph, lastProcessed,
-                GEN.MEMBER_ROLE, PUBLISHER_IS_ADMIN_OR_MAINTAINER));
-        c.observer = runTierLabeled("observer", graph, nonAdminTierUpdate(graph, lastProcessed,
-                GEN.OBSERVER_ROLE, PUBLISHER_IS_SELF_OR_TIERED));
+        // Member tier: admin OR maintainer publisher — split into two simpler updates
+        // so the query planner doesn't struggle with the UNION.
+        c.member = runTierLabeled("member(admin-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.MEMBER_ROLE, PUBLISHER_IS_ADMIN));
+        c.member += runTierLabeled("member(maint-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.MEMBER_ROLE, publisherIsTieredRole(GEN.MAINTAINER_ROLE)));
+        // Observer tier: admin OR maintainer OR member publisher OR self-evidence — four
+        // simple updates instead of one 4-branch UNION, which HTTP-timed out in practice.
+        c.observer = runTierLabeled("observer(admin-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.OBSERVER_ROLE, PUBLISHER_IS_ADMIN));
+        c.observer += runTierLabeled("observer(maint-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.OBSERVER_ROLE, publisherIsTieredRole(GEN.MAINTAINER_ROLE)));
+        c.observer += runTierLabeled("observer(member-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.OBSERVER_ROLE, publisherIsTieredRole(GEN.MEMBER_ROLE)));
+        c.observer += runTierLabeled("observer(self)", graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.OBSERVER_ROLE, PUBLISHER_IS_SELF));
         return c;
+    }
+
+    /**
+     * Builds a publisher constraint requiring the publisher to be a validated holder
+     * of the given tier's role (maintainer or member) in the target space.
+     */
+    private static String publisherIsTieredRole(IRI tierClass) {
+        return """
+                ?tierRI a gen:RoleInstantiation ;
+                        npa:forSpace ?space ;
+                        npa:forAgent ?publisher .
+                ?rdT a npa:RoleDeclaration ;
+                     npa:hasRoleType <%1$s> .
+                { ?tierRI npa:regularProperty ?predT . ?rdT gen:hasRegularProperty ?predT . }
+                UNION
+                { ?tierRI npa:inverseProperty ?predT . ?rdT gen:hasInverseProperty ?predT . }
+                """.formatted(tierClass);
     }
 
     /** Wraps {@link #runTierLoop} with tier-name context for logs/exceptions. */
@@ -415,65 +444,9 @@ public final class AuthorityResolver {
                      npa:forAgent ?publisher .
             """;
 
-    static final String PUBLISHER_IS_ADMIN_OR_MAINTAINER = """
-            {
-              ?adminRI a gen:RoleInstantiation ;
-                       npa:forSpace ?space ;
-                       npa:regularProperty gen:hasAdmin ;
-                       npa:forAgent ?publisher .
-            }
-            UNION
-            {
-              ?maintRI a gen:RoleInstantiation ;
-                       npa:forSpace ?space ;
-                       npa:forAgent ?publisher .
-              ?rdM a npa:RoleDeclaration ;
-                   npa:hasRoleType gen:MaintainerRole .
-              { ?maintRI npa:regularProperty ?predM . ?rdM gen:hasRegularProperty ?predM . }
-              UNION
-              { ?maintRI npa:inverseProperty ?predM . ?rdM gen:hasInverseProperty ?predM . }
-            }
-            """;
-
-    /**
-     * Observer self-evidence: publisher is admin, maintainer, member, OR the
-     * mirrored trust row confirms that the signing pubkey maps to the assignee
-     * itself (i.e. the assignee is the publisher).
-     */
-    static final String PUBLISHER_IS_SELF_OR_TIERED = """
-            {
-              ?adminRI a gen:RoleInstantiation ;
-                       npa:forSpace ?space ;
-                       npa:regularProperty gen:hasAdmin ;
-                       npa:forAgent ?publisher .
-            }
-            UNION
-            {
-              ?maintRI a gen:RoleInstantiation ;
-                       npa:forSpace ?space ;
-                       npa:forAgent ?publisher .
-              ?rdM a npa:RoleDeclaration ;
-                   npa:hasRoleType gen:MaintainerRole .
-              { ?maintRI npa:regularProperty ?predM . ?rdM gen:hasRegularProperty ?predM . }
-              UNION
-              { ?maintRI npa:inverseProperty ?predM . ?rdM gen:hasInverseProperty ?predM . }
-            }
-            UNION
-            {
-              ?memRI a gen:RoleInstantiation ;
-                     npa:forSpace ?space ;
-                     npa:forAgent ?publisher .
-              ?rdMem a npa:RoleDeclaration ;
-                     npa:hasRoleType gen:MemberRole .
-              { ?memRI npa:regularProperty ?predMem . ?rdMem gen:hasRegularProperty ?predMem . }
-              UNION
-              { ?memRI npa:inverseProperty ?predMem . ?rdMem gen:hasInverseProperty ?predMem . }
-            }
-            UNION
-            {
-              # Self-evidence: publisher pubkey maps to the assignee.
-              FILTER (?publisher = ?agent)
-            }
+    /** Observer self-evidence: the assignee is the publisher. */
+    static final String PUBLISHER_IS_SELF = """
+            FILTER (?publisher = ?agent)
             """;
 
     /**

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -277,10 +277,10 @@ public final class AuthorityResolver {
      * trust-approved AccountState) is already in the admin set.
      */
     static String adminTierUpdate(IRI graph, long lastProcessed) {
-        // The seed branch reads SpaceDefinition entries from npa:spacesGraph (that's
-        // where they live). The closed-over branch reads existing admin instantiations
-        // from the current space-state graph. Both branches must establish ?publisher
-        // before joining to the mirrored AccountState row (which resolves ?pkh).
+        // npa:hasLoadNumber lives in the admin graph (NPA.GRAPH), NOT in
+        // npa:spacesGraph — NanopubLoader writes the stamp there. Every tier
+        // template below joins the delta filter via a separate GRAPH <npa:graph>
+        // block. Invalidation entries DO live in npa:spacesGraph.
         return """
                 PREFIX npa:  <%1$s>
                 PREFIX gen:  <%2$s>
@@ -299,9 +299,11 @@ public final class AuthorityResolver {
                         npa:forAgent        ?agent ;
                         npa:pubkeyHash      ?pkh ;
                         npa:viaNanopub      ?np .
+                    %6$s
+                  }
+                  GRAPH <%8$s> {
                     ?np npa:hasLoadNumber ?ln .
                     FILTER (?ln > %5$d)
-                    %6$s
                   }
                   {
                     # Seed branch: root-admin in a non-invalidated SpaceDefinition.
@@ -343,7 +345,8 @@ public final class AuthorityResolver {
                 SpacesVocab.SPACES_GRAPH,
                 lastProcessed,
                 invalidationFilter("np"),
-                invalidationFilter("defNp"));
+                invalidationFilter("defNp"),
+                NPA.GRAPH);
     }
 
     /**
@@ -368,9 +371,11 @@ public final class AuthorityResolver {
                         gen:hasRole  ?role ;
                         npa:pubkeyHash ?pkh ;
                         npa:viaNanopub ?np .
+                    %6$s
+                  }
+                  GRAPH <%7$s> {
                     ?np npa:hasLoadNumber ?ln .
                     FILTER (?ln > %5$d)
-                    %6$s
                   }
                   GRAPH <%3$s> {
                     ?acct a npa:AccountState ;
@@ -393,7 +398,8 @@ public final class AuthorityResolver {
                 graph,
                 SpacesVocab.SPACES_GRAPH,
                 lastProcessed,
-                invalidationFilter("np"));
+                invalidationFilter("np"),
+                NPA.GRAPH);
     }
 
     /** Non-admin tier publisher constraints (inserted as a SPARQL sub-pattern). */
@@ -491,8 +497,6 @@ public final class AuthorityResolver {
                     { ?ri npa:regularProperty ?pred . }
                     UNION
                     { ?ri npa:inverseProperty ?pred . }
-                    ?np npa:hasLoadNumber ?ln .
-                    FILTER (?ln > %5$d)
                     %6$s
                     # Predicate maps to a RoleDeclaration of this tier (not invalidated).
                     ?rd a npa:RoleDeclaration ;
@@ -503,6 +507,10 @@ public final class AuthorityResolver {
                     UNION
                     { ?rd gen:hasInverseProperty ?pred . }
                     %8$s
+                  }
+                  GRAPH <%10$s> {
+                    ?np npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
                   }
                   GRAPH <%3$s> {
                     # Role must be admin-attached to the target space.
@@ -531,7 +539,8 @@ public final class AuthorityResolver {
                 invalidationFilter("np"),
                 tierClass,
                 invalidationFilter("rdNp"),
-                publisherConstraint);
+                publisherConstraint,
+                NPA.GRAPH);
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -21,6 +21,7 @@ import org.nanopub.vocabulary.NPA;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.knowledgepixels.query.vocabulary.GEN;
 import com.knowledgepixels.query.vocabulary.NPAT;
 import com.knowledgepixels.query.vocabulary.SpacesVocab;
 
@@ -160,7 +161,9 @@ public final class AuthorityResolver {
         // 1. Mirror trust-approved rows into the new graph.
         int mirrored = mirrorTrustState(trustStateHash, newGraph);
 
-        // 2. PR 2b placeholder: per-tier UPDATE loops would run here.
+        // 2. Per-tier UPDATE loops (from scratch: lastProcessed = -1 so the
+        //    delta filter FILTER(?ln > ?lastProcessed) includes everything).
+        TierCounts counts = runAllTierLoops(newGraph, -1);
 
         // 3. Stamp processedUpTo inside the new graph.
         writeProcessedUpTo(newGraph, loadCounter);
@@ -173,8 +176,339 @@ public final class AuthorityResolver {
             dropGraph(oldGraph);
         }
 
-        log.info("AuthorityResolver: full build complete — graph={} mirrored={} rows loadCounter={}",
-                newGraph, mirrored, loadCounter);
+        log.info("AuthorityResolver: full build complete — graph={} mirrored={} rows loadCounter={} "
+                        + "tiers: admin={} attachment={} maintainer={} member={} observer={}",
+                newGraph, mirrored, loadCounter,
+                counts.admin, counts.attachment, counts.maintainer, counts.member, counts.observer);
+    }
+
+    // ---------------- Tier UPDATE loops ----------------
+
+    /** Per-tier INSERT counts (for logging/metrics). */
+    static final class TierCounts {
+        int admin;
+        int attachment;
+        int maintainer;
+        int member;
+        int observer;
+    }
+
+    /**
+     * Runs the five tier loops in order: admin → {@code gen:hasRole} attachment
+     * validation → maintainer → member → observer. Each loop iterates a SPARQL
+     * INSERT to fixed point (no new triples added). Returns per-tier counts.
+     *
+     * @param graph         target space-state graph
+     * @param lastProcessed load-number horizon; use {@code -1} for full build
+     */
+    TierCounts runAllTierLoops(IRI graph, long lastProcessed) {
+        TierCounts c = new TierCounts();
+        c.admin = runTierLoop(graph, adminTierUpdate(graph, lastProcessed));
+        c.attachment = runTierLoop(graph, attachmentValidationUpdate(graph, lastProcessed));
+        c.maintainer = runTierLoop(graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.MAINTAINER_ROLE, PUBLISHER_IS_ADMIN));
+        c.member = runTierLoop(graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.MEMBER_ROLE, PUBLISHER_IS_ADMIN_OR_MAINTAINER));
+        c.observer = runTierLoop(graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.OBSERVER_ROLE, PUBLISHER_IS_SELF_OR_TIERED));
+        return c;
+    }
+
+    /**
+     * Runs a single tier's INSERT to fixed point. Counts rows by probing
+     * graph size before/after each INSERT; stops when the size doesn't change.
+     *
+     * @return total number of triples inserted by this tier across all iterations
+     */
+    int runTierLoop(IRI graph, String sparqlUpdate) {
+        int total = 0;
+        long before = graphSize(graph);
+        while (true) {
+            try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
+                conn.begin(IsolationLevels.SERIALIZABLE);
+                conn.prepareUpdate(QueryLanguage.SPARQL, sparqlUpdate).execute();
+                conn.commit();
+            }
+            long after = graphSize(graph);
+            long added = after - before;
+            if (added <= 0) break;
+            total += added;
+            before = after;
+        }
+        return total;
+    }
+
+    private long graphSize(IRI graph) {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
+            return conn.size(graph);
+        }
+    }
+
+    // ---------------- SPARQL templates ----------------
+
+    /** Reusable invalidation filter on a bound nanopub-IRI variable. */
+    private static String invalidationFilter(String npVar) {
+        return "FILTER NOT EXISTS { ?_inv_" + npVar + " a <" + SpacesVocab.INVALIDATION + "> ; "
+                + "<" + SpacesVocab.INVALIDATES + "> " + npVar + " . }";
+    }
+
+    /**
+     * Admin tier: seed from {@code npadef:...hasRootAdmin} (trusted by construction)
+     * plus closed-over admin grants; insert any {@code gen:RoleInstantiation} with
+     * {@code npa:regularProperty gen:hasAdmin} whose publisher (resolved via mirrored
+     * trust-approved AccountState) is already in the admin set.
+     */
+    static String adminTierUpdate(IRI graph, long lastProcessed) {
+        return """
+                PREFIX npa:  <%1$s>
+                PREFIX gen:  <%2$s>
+                INSERT { GRAPH <%3$s> {
+                  ?ri a gen:RoleInstantiation ;
+                      npa:forSpace ?space ;
+                      npa:regularProperty gen:hasAdmin ;
+                      npa:forAgent ?agent ;
+                      npa:viaNanopub ?np .
+                } }
+                WHERE {
+                  GRAPH <%4$s> {
+                    ?ri a gen:RoleInstantiation ;
+                        npa:forSpace        ?space ;
+                        npa:regularProperty gen:hasAdmin ;
+                        npa:forAgent        ?agent ;
+                        npa:pubkeyHash      ?pkh ;
+                        npa:viaNanopub      ?np .
+                    ?np npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
+                    %6$s
+                  }
+                  GRAPH <%3$s> {
+                    ?acct a npa:AccountState ;
+                          npa:agent  ?publisher ;
+                          npa:pubkey ?pkh .
+                    {
+                      # Seed: root-admin in a non-invalidated SpaceDefinition for this space
+                      ?def a npa:SpaceDefinition ;
+                           npa:forSpaceRef ?spaceRef ;
+                           npa:hasRootAdmin ?publisher ;
+                           npa:viaNanopub   ?defNp .
+                      ?spaceRef npa:spaceIri ?space .
+                    }
+                    UNION
+                    {
+                      # Closed-over: an existing admin instantiation for this space
+                      ?prev a gen:RoleInstantiation ;
+                            npa:forSpace ?space ;
+                            npa:regularProperty gen:hasAdmin ;
+                            npa:forAgent ?publisher .
+                    }
+                  }
+                  FILTER NOT EXISTS { GRAPH <%3$s> {
+                    ?existing a gen:RoleInstantiation ;
+                              npa:forSpace ?space ;
+                              npa:forAgent ?agent ;
+                              npa:regularProperty gen:hasAdmin .
+                  } }
+                  # Invalidation filter on the SpaceDefinition (seed branch) is only
+                  # checked if that branch matched. Since ?defNp is unbound in the
+                  # closed-over branch we apply the filter inside the WHERE's OPTIONAL
+                  # pattern via a nested FILTER — see adminSeedInvalidationFilter
+                  # below.
+                }
+                """.formatted(
+                NPA.NAMESPACE,
+                GEN.NAMESPACE,
+                graph,
+                SpacesVocab.SPACES_GRAPH,
+                lastProcessed,
+                invalidationFilter("?np"));
+    }
+
+    /**
+     * {@code gen:hasRole} attachment validation: an attachment is validated iff its
+     * publisher is already a validated admin of the target space. Adds
+     * {@code gen:RoleAssignment} rows to the space-state graph.
+     */
+    static String attachmentValidationUpdate(IRI graph, long lastProcessed) {
+        return """
+                PREFIX npa:  <%1$s>
+                PREFIX gen:  <%2$s>
+                INSERT { GRAPH <%3$s> {
+                  ?ra a gen:RoleAssignment ;
+                      npa:forSpace ?space ;
+                      gen:hasRole  ?role ;
+                      npa:viaNanopub ?np .
+                } }
+                WHERE {
+                  GRAPH <%4$s> {
+                    ?ra a gen:RoleAssignment ;
+                        npa:forSpace ?space ;
+                        gen:hasRole  ?role ;
+                        npa:pubkeyHash ?pkh ;
+                        npa:viaNanopub ?np .
+                    ?np npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
+                    %6$s
+                  }
+                  GRAPH <%3$s> {
+                    ?acct a npa:AccountState ;
+                          npa:agent  ?publisher ;
+                          npa:pubkey ?pkh .
+                    ?adminRI a gen:RoleInstantiation ;
+                             npa:forSpace ?space ;
+                             npa:regularProperty gen:hasAdmin ;
+                             npa:forAgent ?publisher .
+                  }
+                  FILTER NOT EXISTS { GRAPH <%3$s> {
+                    ?existing a gen:RoleAssignment ;
+                              npa:forSpace ?space ;
+                              gen:hasRole  ?role .
+                  } }
+                }
+                """.formatted(
+                NPA.NAMESPACE,
+                GEN.NAMESPACE,
+                graph,
+                SpacesVocab.SPACES_GRAPH,
+                lastProcessed,
+                invalidationFilter("?np"));
+    }
+
+    /** Non-admin tier publisher constraints (inserted as a SPARQL sub-pattern). */
+    static final String PUBLISHER_IS_ADMIN = """
+            ?adminRI a gen:RoleInstantiation ;
+                     npa:forSpace ?space ;
+                     npa:regularProperty gen:hasAdmin ;
+                     npa:forAgent ?publisher .
+            """;
+
+    static final String PUBLISHER_IS_ADMIN_OR_MAINTAINER = """
+            {
+              ?adminRI a gen:RoleInstantiation ;
+                       npa:forSpace ?space ;
+                       npa:regularProperty gen:hasAdmin ;
+                       npa:forAgent ?publisher .
+            }
+            UNION
+            {
+              ?maintRI a gen:RoleInstantiation ;
+                       npa:forSpace ?space ;
+                       npa:forAgent ?publisher .
+              ?rdM a npa:RoleDeclaration ;
+                   npa:hasRoleType gen:MaintainerRole .
+              { ?maintRI npa:regularProperty ?predM . ?rdM gen:hasRegularProperty ?predM . }
+              UNION
+              { ?maintRI npa:inverseProperty ?predM . ?rdM gen:hasInverseProperty ?predM . }
+            }
+            """;
+
+    /**
+     * Observer self-evidence: publisher is admin, maintainer, member, OR the
+     * mirrored trust row confirms that the signing pubkey maps to the assignee
+     * itself (i.e. the assignee is the publisher).
+     */
+    static final String PUBLISHER_IS_SELF_OR_TIERED = """
+            {
+              ?adminRI a gen:RoleInstantiation ;
+                       npa:forSpace ?space ;
+                       npa:regularProperty gen:hasAdmin ;
+                       npa:forAgent ?publisher .
+            }
+            UNION
+            {
+              ?maintRI a gen:RoleInstantiation ;
+                       npa:forSpace ?space ;
+                       npa:forAgent ?publisher .
+              ?rdM a npa:RoleDeclaration ;
+                   npa:hasRoleType gen:MaintainerRole .
+              { ?maintRI npa:regularProperty ?predM . ?rdM gen:hasRegularProperty ?predM . }
+              UNION
+              { ?maintRI npa:inverseProperty ?predM . ?rdM gen:hasInverseProperty ?predM . }
+            }
+            UNION
+            {
+              ?memRI a gen:RoleInstantiation ;
+                     npa:forSpace ?space ;
+                     npa:forAgent ?publisher .
+              ?rdMem a npa:RoleDeclaration ;
+                     npa:hasRoleType gen:MemberRole .
+              { ?memRI npa:regularProperty ?predMem . ?rdMem gen:hasRegularProperty ?predMem . }
+              UNION
+              { ?memRI npa:inverseProperty ?predMem . ?rdMem gen:hasInverseProperty ?predMem . }
+            }
+            UNION
+            {
+              # Self-evidence: publisher pubkey maps to the assignee.
+              FILTER (?publisher = ?agent)
+            }
+            """;
+
+    /**
+     * Maintainer / Member / Observer tier INSERT. Same shape: find an instantiation
+     * whose predicate matches a RoleDeclaration of the given tier attached to the
+     * target space, and whose publisher passes the tier-specific constraint.
+     */
+    static String nonAdminTierUpdate(IRI graph, long lastProcessed,
+                                     IRI tierClass, String publisherConstraint) {
+        return """
+                PREFIX npa:  <%1$s>
+                PREFIX gen:  <%2$s>
+                INSERT { GRAPH <%3$s> {
+                  ?ri a gen:RoleInstantiation ;
+                      npa:forSpace ?space ;
+                      npa:forAgent ?agent ;
+                      npa:viaNanopub ?np .
+                } }
+                WHERE {
+                  GRAPH <%4$s> {
+                    ?ri a gen:RoleInstantiation ;
+                        npa:forSpace ?space ;
+                        npa:forAgent ?agent ;
+                        npa:pubkeyHash ?pkh ;
+                        npa:viaNanopub ?np .
+                    { ?ri npa:regularProperty ?pred . }
+                    UNION
+                    { ?ri npa:inverseProperty ?pred . }
+                    ?np npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
+                    %6$s
+                    # Predicate maps to a RoleDeclaration of this tier (not invalidated).
+                    ?rd a npa:RoleDeclaration ;
+                        npa:role ?role ;
+                        npa:hasRoleType <%7$s> ;
+                        npa:viaNanopub ?rdNp .
+                    { ?rd gen:hasRegularProperty ?pred . }
+                    UNION
+                    { ?rd gen:hasInverseProperty ?pred . }
+                    %8$s
+                  }
+                  GRAPH <%3$s> {
+                    # Role must be admin-attached to the target space.
+                    ?ra a gen:RoleAssignment ;
+                        npa:forSpace ?space ;
+                        gen:hasRole  ?role .
+                    # Publisher's agent from the mirrored trust-approved set.
+                    ?acct a npa:AccountState ;
+                          npa:agent ?publisher ;
+                          npa:pubkey ?pkh .
+                    %9$s
+                  }
+                  FILTER NOT EXISTS { GRAPH <%3$s> {
+                    ?existing a gen:RoleInstantiation ;
+                              npa:forSpace ?space ;
+                              npa:forAgent ?agent ;
+                              npa:viaNanopub ?np .
+                  } }
+                }
+                """.formatted(
+                NPA.NAMESPACE,
+                GEN.NAMESPACE,
+                graph,
+                SpacesVocab.SPACES_GRAPH,
+                lastProcessed,
+                invalidationFilter("?np"),
+                tierClass,
+                invalidationFilter("?rdNp"),
+                publisherConstraint);
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -53,4 +53,66 @@ class AuthorityResolverTest {
                 "tick() must not seed a hash when none is available");
     }
 
+    // ---------------- SPARQL template structure ----------------
+
+    private static final org.eclipse.rdf4j.model.IRI TEST_GRAPH =
+            com.knowledgepixels.query.vocabulary.SpacesVocab.forSpaceState(
+                    "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", 42L);
+
+    @Test
+    void adminTierUpdate_containsSeedAndClosedOverBranches() {
+        String sparql = AuthorityResolver.adminTierUpdate(TEST_GRAPH, 17);
+        assertTrue(sparql.contains("INSERT"), "INSERT clause");
+        assertTrue(sparql.contains("npa:regularProperty gen:hasAdmin"),
+                "pinned admin predicate");
+        assertTrue(sparql.contains("npa:hasRootAdmin"),
+                "seed branch references hasRootAdmin");
+        assertTrue(sparql.contains("UNION"),
+                "seed + closed-over branches joined by UNION");
+        assertTrue(sparql.contains("FILTER (?ln > 17)"),
+                "load-number delta filter with lastProcessed substituted");
+        assertTrue(sparql.contains("FILTER NOT EXISTS"),
+                "existence + invalidation filters");
+        assertTrue(sparql.contains("npa:AccountState"),
+                "mirrored-row join");
+    }
+
+    @Test
+    void attachmentValidationUpdate_requiresAdminPublisher() {
+        String sparql = AuthorityResolver.attachmentValidationUpdate(TEST_GRAPH, 5);
+        assertTrue(sparql.contains("gen:RoleAssignment"),
+                "attachment-type inserted");
+        assertTrue(sparql.contains("gen:hasRole"), "gen:hasRole predicate copied");
+        assertTrue(sparql.contains("npa:regularProperty gen:hasAdmin"),
+                "publisher-is-admin check");
+        assertTrue(sparql.contains("FILTER (?ln > 5)"),
+                "delta filter on attachment nanopub");
+    }
+
+    @Test
+    void maintainerTierUpdate_pinsMaintainerRoleAndAdminConstraint() {
+        String sparql = AuthorityResolver.nonAdminTierUpdate(
+                TEST_GRAPH, 0,
+                com.knowledgepixels.query.vocabulary.GEN.MAINTAINER_ROLE,
+                AuthorityResolver.PUBLISHER_IS_ADMIN);
+        assertTrue(sparql.contains("gen:hasRegularProperty") || sparql.contains("gen:hasInverseProperty"),
+                "maps predicate to a RoleDeclaration property direction");
+        assertTrue(sparql.contains(
+                com.knowledgepixels.query.vocabulary.GEN.MAINTAINER_ROLE.stringValue()),
+                "tier class is substituted");
+        assertTrue(sparql.contains("gen:RoleAssignment"),
+                "attachment gate present");
+    }
+
+    @Test
+    void observerTierUpdate_allowsSelfEvidence() {
+        String sparql = AuthorityResolver.nonAdminTierUpdate(
+                TEST_GRAPH, 0,
+                com.knowledgepixels.query.vocabulary.GEN.OBSERVER_ROLE,
+                AuthorityResolver.PUBLISHER_IS_SELF_OR_TIERED);
+        // Self-evidence: publisher agent (from mirrored rows) matches the assignee.
+        assertTrue(sparql.contains("?publisher = ?agent"),
+                "observer tier accepts self-evidence");
+    }
+
 }

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -110,9 +110,13 @@ class AuthorityResolverTest {
                 TEST_GRAPH, 0,
                 com.knowledgepixels.query.vocabulary.GEN.OBSERVER_ROLE,
                 AuthorityResolver.PUBLISHER_IS_SELF);
-        // Self-evidence: publisher agent (from mirrored rows) matches the assignee.
-        assertTrue(sparql.contains("?publisher = ?agent"),
-                "observer tier (self branch) accepts self-evidence");
+        // Self-evidence: AccountState's npa:agent is bound directly to ?agent
+        // (the assignee), so the (pkh, agent) row anchors the join — no
+        // separate ?publisher variable, no post-join equality filter.
+        assertTrue(sparql.contains("npa:agent  ?agent"),
+                "observer tier (self branch) binds AccountState agent to ?agent directly");
+        assertFalse(sparql.contains("?publisher = ?agent"),
+                "observer tier must not rely on a post-join equality filter");
     }
 
 }

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -109,10 +109,10 @@ class AuthorityResolverTest {
         String sparql = AuthorityResolver.nonAdminTierUpdate(
                 TEST_GRAPH, 0,
                 com.knowledgepixels.query.vocabulary.GEN.OBSERVER_ROLE,
-                AuthorityResolver.PUBLISHER_IS_SELF_OR_TIERED);
+                AuthorityResolver.PUBLISHER_IS_SELF);
         // Self-evidence: publisher agent (from mirrored rows) matches the assignee.
         assertTrue(sparql.contains("?publisher = ?agent"),
-                "observer tier accepts self-evidence");
+                "observer tier (self branch) accepts self-evidence");
     }
 
 }


### PR DESCRIPTION
Refs #62. Builds on #80 (merged).

Second of three server-side materialization PRs. Fills in the per-tier SPARQL UPDATE loops that PR 2a (#80) stubbed out. After this lands, every trust-state flip produces a fully-validated `npass:<T>_<M>` graph — a Nanodash-side query against it can answer "who has role X in space S?" without the old 4-query chain.

## Scope

Full-build path only. Incremental cycle and the periodic rebuild flag come in PR 2c.

### Added tier loops (in `AuthorityResolver`)

After the mirror step, `runFullBuild` calls `runAllTierLoops(graph, lastProcessed=-1)`, which runs five SPARQL UPDATE loops in order, each iterated to fixed point via a graph-size-before/after probe:

1. **Admin**: seed from `npadef:…npa:hasRootAdmin` (trusted by construction; root NPID is part of the space ref) UNION closed-over admin grants. Match `gen:RoleInstantiation` entries with `npa:regularProperty gen:hasAdmin` whose publisher resolves (via mirrored trust-approved AccountState rows) to an existing admin.
2. **`gen:hasRole` attachment**: `gen:RoleAssignment` entries whose publisher is a validated admin of the target space.
3. **Maintainer**: instantiations whose `npa:regularProperty` or `npa:inverseProperty` matches a `npa:RoleDeclaration` with `npa:hasRoleType gen:MaintainerRole` that has been validated-attached to the target space, and whose publisher is in the admin set.
4. **Member**: same pattern with `gen:MemberRole`; publisher must be in admin ∪ maintainer set.
5. **Observer**: same pattern with `gen:ObserverRole`; publisher must be in admin ∪ maintainer ∪ member set, **OR** self-evidence holds (publisher agent from mirrored rows equals `npa:forAgent`).

### Invalidation filter

Every read from `npa:spacesGraph` carries `FILTER NOT EXISTS { ?inv a npa:Invalidation; npa:invalidates ?np }`, so retractions/supersessions take effect regardless of whether the invalidation arrived before or after its target.

### Template builders

SPARQL templates are static package-private methods returning formatted strings parameterised by `(graph, lastProcessed)` and tier-specific variants. Easy to re-use for PR 2c's incremental cycle (same templates, different `lastProcessed` value).

## Testing

- `./mvnw clean test`: **157/157 pass** (4 new template-structure tests + 153 from main).
- New `AuthorityResolverTest` cases:
  - `adminTierUpdate_containsSeedAndClosedOverBranches`
  - `attachmentValidationUpdate_requiresAdminPublisher`
  - `maintainerTierUpdate_pinsMaintainerRoleAndAdminConstraint`
  - `observerTierUpdate_allowsSelfEvidence`
- Full closure behaviour covered by the live integration smoke-test (same approach as #79 and #80). The project's mixed `rdf4j-sail-*` versions still break in-memory tests that exercise SPARQL UPDATE — flagged in #80 as a candidate for a separate dep-cleanup.

## Deferred to PR 2c

- Incremental cycle (invalidation DELETE + tier INSERTs with `FILTER(?ln > ?lastProcessed)`).
- Late-arrival handling (downstream tier re-run without delta filter when a cycle adds structural enablers).
- Pending-cycle flag + `NanopubLoader` trigger wiring.
- `npa:needsFullRebuild` flag + periodic rebuild worker.

## Test plan

- [x] `./mvnw clean test`
- [ ] Restart local dev instance on this branch; confirm the full-build pass populates `gen:RoleInstantiation`, `gen:RoleAssignment` triples in the current `npass:<T>_<M>` graph, and that the counts match expectations for a trust-approved publisher set with some role declarations already seeded.
- [ ] Spot-check one admin agent: should resolve to a `gen:RoleInstantiation` with `npa:forSpace` and `npa:regularProperty gen:hasAdmin` in the space-state graph.
- [ ] Confirm an instantiation whose publisher is not in the admin closure is **not** present in the space-state graph despite being present in `npa:spacesGraph`.