### PR TITLE
fix: flip backcompat role-predicate direction to match publisher convention (#62)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -320,7 +320,7 @@ public final class AuthorityResolver {
     /**
      * Admin tier: seed from {@code npadef:...hasRootAdmin} (trusted by construction)
      * plus closed-over admin grants; insert any {@code gen:RoleInstantiation} with
-     * {@code npa:regularProperty gen:hasAdmin} whose publisher (resolved via mirrored
+     * {@code npa:inverseProperty gen:hasAdmin} whose publisher (resolved via mirrored
      * trust-approved AccountState) is already in the admin set.
      */
     static String adminTierUpdate(IRI graph, long lastProcessed) {
@@ -338,7 +338,7 @@ public final class AuthorityResolver {
                 INSERT { GRAPH <%3$s> {
                   ?ri a gen:RoleInstantiation ;
                       npa:forSpace ?space ;
-                      npa:regularProperty gen:hasAdmin ;
+                      npa:inverseProperty gen:hasAdmin ;
                       npa:forAgent ?agent ;
                       npa:viaNanopub ?np .
                 } }
@@ -361,7 +361,7 @@ public final class AuthorityResolver {
                     GRAPH <%3$s> {
                       ?prev a gen:RoleInstantiation ;
                             npa:forSpace        ?space ;
-                            npa:regularProperty gen:hasAdmin ;
+                            npa:inverseProperty gen:hasAdmin ;
                             npa:forAgent        ?publisher .
                     }
                   }
@@ -375,7 +375,7 @@ public final class AuthorityResolver {
                   GRAPH <%4$s> {
                     ?ri a gen:RoleInstantiation ;
                         npa:forSpace        ?space ;
-                        npa:regularProperty gen:hasAdmin ;
+                        npa:inverseProperty gen:hasAdmin ;
                         npa:forAgent        ?agent ;
                         npa:pubkeyHash      ?pkh ;
                         npa:viaNanopub      ?np .
@@ -391,7 +391,7 @@ public final class AuthorityResolver {
                     ?existing a gen:RoleInstantiation ;
                               npa:forSpace ?space ;
                               npa:forAgent ?agent ;
-                              npa:regularProperty gen:hasAdmin .
+                              npa:inverseProperty gen:hasAdmin .
                   } }
                 }
                 """.formatted(
@@ -438,7 +438,7 @@ public final class AuthorityResolver {
                           npa:pubkey ?pkh .
                     ?adminRI a gen:RoleInstantiation ;
                              npa:forSpace ?space ;
-                             npa:regularProperty gen:hasAdmin ;
+                             npa:inverseProperty gen:hasAdmin ;
                              npa:forAgent ?publisher .
                   }
                   %6$s
@@ -473,7 +473,7 @@ public final class AuthorityResolver {
                   npa:agent  ?publisher .
             ?adminRI a gen:RoleInstantiation ;
                      npa:forSpace ?space ;
-                     npa:regularProperty gen:hasAdmin ;
+                     npa:inverseProperty gen:hasAdmin ;
                      npa:forAgent ?publisher .
             """;
 

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -212,7 +212,7 @@ public final class SpacesExtractor {
             IRI riIri = SpacesVocab.forRoleInstantiation(ctx.artifactCode());
             out.add(vf.createStatement(riIri, RDF.TYPE, GEN.ROLE_INSTANTIATION, GRAPH));
             out.add(vf.createStatement(riIri, SpacesVocab.FOR_SPACE, spaceIri, GRAPH));
-            out.add(vf.createStatement(riIri, SpacesVocab.REGULAR_PROPERTY, GEN.HAS_ADMIN, GRAPH));
+            out.add(vf.createStatement(riIri, SpacesVocab.INVERSE_PROPERTY, GEN.HAS_ADMIN, GRAPH));
             for (IRI adminAgent : adminAgents) {
                 out.add(vf.createStatement(riIri, SpacesVocab.FOR_AGENT, adminAgent, GRAPH));
             }
@@ -336,15 +336,18 @@ public final class SpacesExtractor {
     // ---------------- gen:RoleInstantiation (and backcompat) ----------------
 
     private static void extractRoleInstantiation(Nanopub np, Context ctx, List<Statement> out) {
-        // Find the assignment triple. Directionality:
-        //   REGULAR: <space> <predicate> <agent>  → npa:regularProperty.
-        //   INVERSE: <agent> <predicate> <space>  → npa:inverseProperty.
-        // gen:hasAdmin is hardcoded REGULAR. The 14 backwards-compat predicates are
-        // classified in {@link BackcompatRolePredicates#DIRECTIONS}. User-defined role
-        // predicates from gen:SpaceMemberRole nanopubs aren't resolvable here without
-        // the role-declaration registry; FIXME: the materializer in PR 2 should
-        // refine direction for the typed-but-unknown-predicate case. For now we emit
-        // only triples whose predicate we know the direction of.
+        // Find the assignment triple. Directionality (matches the publisher convention
+        // used by gen:hasRegularProperty / gen:hasInverseProperty in role-definition
+        // nanopubs):
+        //   REGULAR: <agent> <predicate> <space>  → npa:regularProperty.
+        //   INVERSE: <space> <predicate> <agent>  → npa:inverseProperty.
+        // gen:hasAdmin is hardcoded INVERSE (space-centric: <space> hasAdmin <agent>).
+        // The 14 backwards-compat predicates are classified in
+        // {@link BackcompatRolePredicates#DIRECTIONS}. User-defined role predicates from
+        // gen:SpaceMemberRole nanopubs aren't resolvable here without the role-declaration
+        // registry; FIXME: the materializer in PR 2 should refine direction for the
+        // typed-but-unknown-predicate case. For now we emit only triples whose predicate
+        // we know the direction of.
         for (Statement st : np.getAssertion()) {
             IRI predicate = st.getPredicate();
             BackcompatRolePredicates.Direction direction = directionFor(predicate);
@@ -355,11 +358,11 @@ public final class SpacesExtractor {
             IRI spaceSide;
             IRI agentSide;
             if (direction == BackcompatRolePredicates.Direction.REGULAR) {
+                agentSide = subjIri;
+                spaceSide = objIri;
+            } else {
                 spaceSide = subjIri;
                 agentSide = objIri;
-            } else {
-                spaceSide = objIri;
-                agentSide = subjIri;
             }
 
             // Deduplicate against the (possibly already emitted) admin instantiation
@@ -386,7 +389,7 @@ public final class SpacesExtractor {
     }
 
     private static BackcompatRolePredicates.Direction directionFor(IRI predicate) {
-        if (GEN.HAS_ADMIN.equals(predicate)) return BackcompatRolePredicates.Direction.REGULAR;
+        if (GEN.HAS_ADMIN.equals(predicate)) return BackcompatRolePredicates.Direction.INVERSE;
         return BackcompatRolePredicates.DIRECTIONS.get(predicate);
     }
 

--- a/src/main/java/com/knowledgepixels/query/vocabulary/BackcompatRolePredicates.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/BackcompatRolePredicates.java
@@ -19,18 +19,20 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
  * {@code doc/plan-space-repositories.md} for the current list.
  *
  * <p>Direction: each predicate is classified as either {@link Direction#REGULAR}
- * (space &rarr; agent) or {@link Direction#INVERSE} (agent &rarr; space),
- * which determines whether the extractor emits {@code npa:regularProperty} or
+ * (agent &rarr; space — the natural direction of a role from its bearer) or
+ * {@link Direction#INVERSE} (space &rarr; agent — the converse view), which
+ * determines whether the extractor emits {@code npa:regularProperty} or
  * {@code npa:inverseProperty} and which side of the assertion triple is the
- * space vs. the agent.
+ * space vs. the agent. Matches the convention used by published role-definition
+ * nanopubs ({@code gen:hasRegularProperty} / {@code gen:hasInverseProperty}).
  */
 public final class BackcompatRolePredicates {
 
     /** Triple-direction of an assignment predicate. */
     public enum Direction {
-        /** {@code <space> <predicate> <agent>}. */
+        /** {@code <agent> <predicate> <space>} — agent-centric, the role's natural direction. */
         REGULAR,
-        /** {@code <agent> <predicate> <space>}. */
+        /** {@code <space> <predicate> <agent>} — space-centric, the converse view. */
         INVERSE
     }
 
@@ -43,22 +45,22 @@ public final class BackcompatRolePredicates {
     /** Direction map for the backwards-compat predicates. */
     public static final Map<IRI, Direction> DIRECTIONS = Map.ofEntries(
             // Wikidata
-            Map.entry(iri("http://www.wikidata.org/entity/P1344"), Direction.INVERSE),   // "participant in"
-            Map.entry(iri("http://www.wikidata.org/entity/P463"),  Direction.INVERSE),   // "member of"
-            Map.entry(iri("http://www.wikidata.org/entity/P710"),  Direction.REGULAR),   // "participant"
-            Map.entry(iri("http://www.wikidata.org/entity/P823"),  Direction.REGULAR),   // "speaker"
+            Map.entry(iri("http://www.wikidata.org/entity/P1344"), Direction.REGULAR),   // "participant in" (agent → event)
+            Map.entry(iri("http://www.wikidata.org/entity/P463"),  Direction.REGULAR),   // "member of" (agent → space)
+            Map.entry(iri("http://www.wikidata.org/entity/P710"),  Direction.INVERSE),   // "participant" (event → agent)
+            Map.entry(iri("http://www.wikidata.org/entity/P823"),  Direction.INVERSE),   // "speaker" (event → agent)
             // FAIR 3pff
-            Map.entry(iri("https://w3id.org/fair/3pff/has-event-assistant"),                Direction.REGULAR),
-            Map.entry(iri("https://w3id.org/fair/3pff/has-event-facilitator"),              Direction.REGULAR),
-            Map.entry(iri("https://w3id.org/fair/3pff/participatedAsFacilitatorAssistantIn"), Direction.INVERSE),
-            Map.entry(iri("https://w3id.org/fair/3pff/participatedAsImplementerAspirantIn"),  Direction.INVERSE),
-            Map.entry(iri("https://w3id.org/fair/3pff/participatedAsParticipantIn"),          Direction.INVERSE),
+            Map.entry(iri("https://w3id.org/fair/3pff/has-event-assistant"),                Direction.INVERSE),
+            Map.entry(iri("https://w3id.org/fair/3pff/has-event-facilitator"),              Direction.INVERSE),
+            Map.entry(iri("https://w3id.org/fair/3pff/participatedAsFacilitatorAssistantIn"), Direction.REGULAR),
+            Map.entry(iri("https://w3id.org/fair/3pff/participatedAsImplementerAspirantIn"),  Direction.REGULAR),
+            Map.entry(iri("https://w3id.org/fair/3pff/participatedAsParticipantIn"),          Direction.REGULAR),
             // KPXL gen terms
-            Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasAdmin"),       Direction.REGULAR),
-            Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasObserver"),    Direction.REGULAR),
-            Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasProjectLead"), Direction.REGULAR),
-            Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasTeamMember"),  Direction.REGULAR),
-            Map.entry(iri("https://w3id.org/kpxl/gen/terms/plansToAttend"),  Direction.INVERSE));
+            Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasAdmin"),       Direction.INVERSE),
+            Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasObserver"),    Direction.INVERSE),
+            Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasProjectLead"), Direction.INVERSE),
+            Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasTeamMember"),  Direction.INVERSE),
+            Map.entry(iri("https://w3id.org/kpxl/gen/terms/plansToAttend"),  Direction.REGULAR));
 
     /** Convenience set of just the predicate IRIs — useful for type-lookup membership tests. */
     public static final Set<IRI> ALL = DIRECTIONS.keySet();

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -63,7 +63,7 @@ class AuthorityResolverTest {
     void adminTierUpdate_containsSeedAndClosedOverBranches() {
         String sparql = AuthorityResolver.adminTierUpdate(TEST_GRAPH, 17);
         assertTrue(sparql.contains("INSERT"), "INSERT clause");
-        assertTrue(sparql.contains("npa:regularProperty gen:hasAdmin"),
+        assertTrue(sparql.contains("npa:inverseProperty gen:hasAdmin"),
                 "pinned admin predicate");
         assertTrue(sparql.contains("npa:hasRootAdmin"),
                 "seed branch references hasRootAdmin");
@@ -83,7 +83,7 @@ class AuthorityResolverTest {
         assertTrue(sparql.contains("gen:RoleAssignment"),
                 "attachment-type inserted");
         assertTrue(sparql.contains("gen:hasRole"), "gen:hasRole predicate copied");
-        assertTrue(sparql.contains("npa:regularProperty gen:hasAdmin"),
+        assertTrue(sparql.contains("npa:inverseProperty gen:hasAdmin"),
                 "publisher-is-admin check");
         assertTrue(sparql.contains("FILTER (?ln > 5)"),
                 "delta filter on attachment nanopub");

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -160,10 +160,11 @@ class SpacesExtractorTest {
         assertContains(out, defIri, HAS_ROOT_ADMIN, ADMIN_AGENT_1);
         assertContains(out, defIri, HAS_ROOT_ADMIN, ADMIN_AGENT_2);
 
-        // Admin RoleInstantiation (space-scoped, both admins, regular direction)
+        // Admin RoleInstantiation (space-scoped, both admins, inverse direction —
+        // <space> hasAdmin <agent> is space-centric, INVERSE under the publisher convention)
         assertContains(out, riIri, RDF.TYPE, GEN.ROLE_INSTANTIATION);
         assertContains(out, riIri, FOR_SPACE, SPACE_IRI_1);
-        assertContains(out, riIri, REGULAR_PROPERTY, GEN.HAS_ADMIN);
+        assertContains(out, riIri, INVERSE_PROPERTY, GEN.HAS_ADMIN);
         assertContains(out, riIri, FOR_AGENT, ADMIN_AGENT_1);
         assertContains(out, riIri, FOR_AGENT, ADMIN_AGENT_2);
         assertContains(out, riIri, VIA_NANOPUB, NP_URI);
@@ -298,7 +299,9 @@ class SpacesExtractorTest {
     // ---------------- gen:RoleInstantiation via backcompat ----------------
 
     @Test
-    void extract_backcompatRegularDirection_emitsRoleInstantiation() throws Exception {
+    void extract_backcompatInverseDirection_emitsRoleInstantiation() throws Exception {
+        // Space-centric source: <space> <predicate> <agent>. INVERSE under the publisher
+        // convention. hasTeamMember is classified INVERSE in BackcompatRolePredicates.
         IRI hasTeamMember = vf.createIRI("https://w3id.org/kpxl/gen/terms/hasTeamMember");
         Nanopub np = creator()
                 // Single-triple assertion — this nanopub is detected as typed by the predicate
@@ -311,15 +314,16 @@ class SpacesExtractorTest {
 
         assertContains(out, subject, RDF.TYPE, GEN.ROLE_INSTANTIATION);
         assertContains(out, subject, FOR_SPACE, SPACE_IRI_1);        // subject of the assertion triple
-        assertContains(out, subject, REGULAR_PROPERTY, hasTeamMember);
+        assertContains(out, subject, INVERSE_PROPERTY, hasTeamMember);
         assertContains(out, subject, FOR_AGENT, MEMBER_AGENT);       // object of the assertion triple
-        assertDoesNotContain(out, subject, INVERSE_PROPERTY, hasTeamMember);
+        assertDoesNotContain(out, subject, REGULAR_PROPERTY, hasTeamMember);
     }
 
     @Test
-    void extract_backcompatInverseDirection_swapsSpaceAndAgent() throws Exception {
+    void extract_backcompatRegularDirection_swapsSpaceAndAgent() throws Exception {
+        // Agent-centric source: <agent> <predicate> <space>. REGULAR under the publisher
+        // convention. plansToAttend is classified REGULAR in BackcompatRolePredicates.
         IRI plansToAttend = vf.createIRI("https://w3id.org/kpxl/gen/terms/plansToAttend");
-        // For inverse direction the assertion is <agent> <predicate> <space>.
         Nanopub np = creator()
                 .assertion(MEMBER_AGENT, plansToAttend, SPACE_IRI_1)
                 .finalizeNanopub();
@@ -329,9 +333,9 @@ class SpacesExtractorTest {
 
         assertContains(out, subject, RDF.TYPE, GEN.ROLE_INSTANTIATION);
         assertContains(out, subject, FOR_SPACE, SPACE_IRI_1);        // object side
-        assertContains(out, subject, INVERSE_PROPERTY, plansToAttend);
+        assertContains(out, subject, REGULAR_PROPERTY, plansToAttend);
         assertContains(out, subject, FOR_AGENT, MEMBER_AGENT);       // subject side
-        assertDoesNotContain(out, subject, REGULAR_PROPERTY, plansToAttend);
+        assertDoesNotContain(out, subject, INVERSE_PROPERTY, plansToAttend);
     }
 
     // ---------------- Invalidation ----------------


### PR DESCRIPTION
## Summary

The `Direction` enum and `DIRECTIONS` map in `BackcompatRolePredicates` used the *opposite* convention from the one published role-definition nanopubs use:

- **code (before):** `REGULAR = <space> <pred> <agent>`, `INVERSE = <agent> <pred> <space>`
- **publishers (e.g. observer-role RD declares `gen:hasObserver` as `hasInverseProperty`):** regular = `<agent> <pred> <space>`, inverse = `<space> <pred> <agent>`

The mismatch silently filtered out otherwise-valid candidates: extracted RoleInstantiations carried `npa:regularProperty` for predicates the matching RoleDeclarations declared as inverse, so the non-admin tier UNION (which pairs regular-with-regular and inverse-with-inverse) never joined.

This PR aligns the convention everywhere in lockstep:

- **`BackcompatRolePredicates`** — enum/class Javadoc + every entry in `DIRECTIONS` flipped. `P1344`, `P463`, `plansToAttend`, the three `3pff:participatedAs*` predicates → `REGULAR`. `P710`, `P823`, `hasAdmin`, `hasObserver`, `hasProjectLead`, `hasTeamMember`, the two `3pff:has-event-*` predicates → `INVERSE`.
- **`SpacesExtractor`** — directionality comment updated; `spaceSide`/`agentSide` branch swapped so `REGULAR` binds `subject=agent`, `object=space`; `gen:hasAdmin` hardcode flipped to `INVERSE`; the `gen:Space`-path admin RoleInstantiation now emits `npa:inverseProperty gen:hasAdmin`.
- **`AuthorityResolver`** — every admin-tier SPARQL template that pinned `npa:regularProperty gen:hasAdmin` now pins `npa:inverseProperty gen:hasAdmin`. Admin tier is hardcoded for `gen:hasAdmin`, which is space-centric (`<space> hasAdmin <agent>`) and therefore INVERSE under the new convention.
- **Tests** — `SpacesExtractorTest` / `AuthorityResolverTest` updated; the two backcompat-direction tests renamed to reflect the new convention's terminology.

## Operational note

A live DB resync is required after merging. Existing extractions in `npa:spacesGraph` carry the *old* direction labels and won't match the new admin templates or the published role-definition RDs until re-extracted.

## Test plan

- [x] `mvn test` — 157/157 pass locally
- [x] CI green (Java 21/23/25, coveralls)
- [ ] Wipe spaces repo + resync from a fresh DB; verify the per-tier UPDATE loop completes without errors
- [ ] Confirm `admin` tier still produces non-zero counts after the flip (admin templates now pin `inverseProperty gen:hasAdmin`, matching the new extractor output)
- [ ] Confirm observer-tier candidates can now match the existing observer-role RDs (predicate-direction join no longer mismatched for `gen:hasObserver`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)