### PR TITLE
feat: add /spaces listing route with HTML and JSON output (#62)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -240,6 +240,10 @@ public class MainVerticle extends AbstractVerticle {
                      + "<li><a href=\"/pubkeys\">Pubkey Repos</a></li>"
                      + "<li><a href=\"/types\">Type Repos</a></li>"
                      + "</ul>"
+                     + (FeatureFlags.spacesEnabled()
+                             ? "<p>Spaces:</p>"
+                               + "<ul><li><a href=\"/spaces\">Spaces</a></li></ul>"
+                             : "")
                      + pinnedApiLinks
                      + "</body>\n"
                      + "</html>";
@@ -323,6 +327,31 @@ public class MainVerticle extends AbstractVerticle {
                 req.response().setStatusCode(500).end("Error: " + ex.getMessage());
             });
         });
+        io.vertx.core.Handler<RoutingContext> spacesHandler = req -> {
+            if (!FeatureFlags.spacesEnabled()) {
+                req.response().setStatusCode(404)
+                        .putHeader("content-type", "text/plain")
+                        .end("Spaces feature is disabled");
+                return;
+            }
+            // Path suffix wins over Accept header so /spaces.json is unambiguous.
+            boolean wantJson = req.normalizedPath().endsWith(".json")
+                    || "application/json".equalsIgnoreCase(req.request().getHeader("Accept"));
+            vertx.<String>executeBlocking(() -> {
+                var rows = SpacesListingRoute.fetchRows();
+                return wantJson
+                        ? SpacesListingRoute.renderJson(rows)
+                        : SpacesListingRoute.renderHtml(rows);
+            }, false).onSuccess(body -> {
+                req.response().putHeader(
+                        "content-type",
+                        wantJson ? "application/json" : "text/html").end(body);
+            }).onFailure(ex -> {
+                req.response().setStatusCode(500).end("Error: " + ex.getMessage());
+            });
+        };
+        proxyRouter.route(HttpMethod.GET, "/spaces").handler(spacesHandler);
+        proxyRouter.route(HttpMethod.GET, "/spaces.json").handler(spacesHandler);
         proxyRouter.route(HttpMethod.GET, "/style.css").handler(req -> {
             if (css == null) {
                 css = getResourceAsString("style.css");

--- a/src/main/java/com/knowledgepixels/query/SpacesListingRoute.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesListingRoute.java
@@ -1,0 +1,142 @@
+package com.knowledgepixels.query;
+
+import com.knowledgepixels.query.vocabulary.SpacesVocab;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.nanopub.vocabulary.NPA;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Backs the {@code GET /spaces} listing. Pure rendering helpers are
+ * static + side-effect-free so they can be unit-tested without RDF4J;
+ * the only repo-touching method is {@link #fetchRows()}.
+ */
+final class SpacesListingRoute {
+
+    private SpacesListingRoute() {}
+
+    /**
+     * One row per (SpaceRef, spaceIri, rootNanopub) tuple in
+     * {@code npa:spacesGraph}. The same Space IRI may appear under multiple
+     * SpaceRefs during the back-compat phase (one per declaration without
+     * {@code gen:hasRootDefinition}).
+     */
+    record Row(String spaceIri, String spaceRef, String rootNanopub) {}
+
+    private static final String QUERY = ""
+            + "PREFIX npa: <" + NPA.NAMESPACE + ">\n"
+            + "SELECT ?spaceIri ?spaceRef ?rootNanopub WHERE {\n"
+            + "  GRAPH npa:spacesGraph {\n"
+            + "    ?spaceRef a npa:SpaceRef ;\n"
+            + "              npa:spaceIri ?spaceIri ;\n"
+            + "              npa:rootNanopub ?rootNanopub .\n"
+            + "  }\n"
+            + "} ORDER BY ?spaceIri ?spaceRef";
+
+    static List<Row> fetchRows() {
+        List<Row> rows = new ArrayList<>();
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection("spaces");
+             TupleQueryResult r = conn.prepareTupleQuery(QueryLanguage.SPARQL, QUERY).evaluate()) {
+            while (r.hasNext()) {
+                BindingSet b = r.next();
+                rows.add(new Row(
+                        b.getBinding("spaceIri").getValue().stringValue(),
+                        b.getBinding("spaceRef").getValue().stringValue(),
+                        b.getBinding("rootNanopub").getValue().stringValue()));
+            }
+        }
+        return rows;
+    }
+
+    static String renderHtml(List<Row> rows) {
+        StringBuilder body = new StringBuilder();
+        if (rows.isEmpty()) {
+            body.append("<p><em>No spaces declared yet.</em></p>");
+        } else {
+            body.append("<ul>");
+            for (Row row : rows) {
+                String refLocal = stripPrefix(row.spaceRef(), SpacesVocab.NPAS_NAMESPACE);
+                body.append("<li><code>").append(escape(row.spaceIri())).append("</code>")
+                        .append(" — ref <code>").append(escape(refLocal)).append("</code>")
+                        .append(", root <a href=\"").append(escape(row.rootNanopub())).append("\"><code>")
+                        .append(escape(row.rootNanopub())).append("</code></a></li>");
+            }
+            body.append("</ul>");
+        }
+        return "<!DOCTYPE html>\n"
+                + "<html lang='en'>\n"
+                + "<head>\n"
+                + "<title>Nanopub Query: Spaces</title>\n"
+                + "<meta charset='utf-8'>\n"
+                + "<link rel=\"stylesheet\" href=\"/style.css\">\n"
+                + "</head>\n"
+                + "<body>\n"
+                + "<h3>Spaces</h3>"
+                + "<p><a href=\"/spaces.json\">JSON</a></p>"
+                + "<p>Declared spaces (from <code>npa:spacesGraph</code>):</p>"
+                + body
+                + "</body>\n"
+                + "</html>";
+    }
+
+    static String renderJson(List<Row> rows) {
+        StringBuilder out = new StringBuilder();
+        out.append("{\"spaces\":[");
+        boolean first = true;
+        for (Row row : rows) {
+            if (!first) out.append(',');
+            first = false;
+            out.append("{\"spaceIri\":\"").append(jsonEscape(row.spaceIri())).append('"')
+                    .append(",\"spaceRef\":\"").append(jsonEscape(row.spaceRef())).append('"')
+                    .append(",\"rootNanopub\":\"").append(jsonEscape(row.rootNanopub())).append("\"}");
+        }
+        out.append("]}");
+        return out.toString();
+    }
+
+    private static String stripPrefix(String s, String prefix) {
+        return s.startsWith(prefix) ? s.substring(prefix.length()) : s;
+    }
+
+    private static String escape(String s) {
+        StringBuilder out = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '&' -> out.append("&amp;");
+                case '<' -> out.append("&lt;");
+                case '>' -> out.append("&gt;");
+                case '"' -> out.append("&quot;");
+                case '\'' -> out.append("&#39;");
+                default -> out.append(c);
+            }
+        }
+        return out.toString();
+    }
+
+    private static String jsonEscape(String s) {
+        StringBuilder out = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> out.append("\\\"");
+                case '\\' -> out.append("\\\\");
+                case '\n' -> out.append("\\n");
+                case '\r' -> out.append("\\r");
+                case '\t' -> out.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        out.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        out.append(c);
+                    }
+                }
+            }
+        }
+        return out.toString();
+    }
+}

--- a/src/test/java/com/knowledgepixels/query/SpacesListingRouteTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesListingRouteTest.java
@@ -1,0 +1,90 @@
+package com.knowledgepixels.query;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpacesListingRouteTest {
+
+    private static final SpacesListingRoute.Row ROW_A = new SpacesListingRoute.Row(
+            "https://example.org/space/alpha",
+            "http://purl.org/nanopub/admin/space/RA_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_aaaaaaaa",
+            "https://w3id.org/np/RA_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    private static final SpacesListingRoute.Row ROW_B = new SpacesListingRoute.Row(
+            "https://example.org/space/beta",
+            "http://purl.org/nanopub/admin/space/RA_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb_bbbbbbbb",
+            "https://w3id.org/np/RA_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    @Test
+    void html_emptyRows_rendersPlaceholder() {
+        String html = SpacesListingRoute.renderHtml(List.of());
+        assertTrue(html.contains("No spaces declared yet"),
+                "empty listing should show explicit placeholder");
+        assertTrue(html.contains("<title>Nanopub Query: Spaces</title>"));
+    }
+
+    @Test
+    void html_rendersOneListItemPerRow() {
+        String html = SpacesListingRoute.renderHtml(List.of(ROW_A, ROW_B));
+        assertEquals(2, countOccurrences(html, "<li>"),
+                "expected one <li> per row");
+        assertTrue(html.contains("https://example.org/space/alpha"));
+        assertTrue(html.contains("https://example.org/space/beta"));
+        // The space-ref prefix should be stripped to its local name in the UI.
+        assertTrue(html.contains("RA_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_aaaaaaaa"));
+        assertTrue(!html.contains("http://purl.org/nanopub/admin/space/"),
+                "spaceref namespace should be stripped from the displayed local name");
+    }
+
+    @Test
+    void html_escapesHtmlSpecialCharacters() {
+        var hostile = new SpacesListingRoute.Row(
+                "https://example.org/<script>alert(1)</script>",
+                "http://purl.org/nanopub/admin/space/local",
+                "https://w3id.org/np/RA_safe");
+        String html = SpacesListingRoute.renderHtml(List.of(hostile));
+        assertTrue(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"),
+                "HTML special characters in spaceIri must be escaped");
+        assertTrue(!html.contains("<script>alert"),
+                "raw <script> must not survive the renderer");
+    }
+
+    @Test
+    void json_emptyRows_emptyArray() {
+        assertEquals("{\"spaces\":[]}", SpacesListingRoute.renderJson(List.of()));
+    }
+
+    @Test
+    void json_rendersAllFields() {
+        String json = SpacesListingRoute.renderJson(List.of(ROW_A));
+        assertTrue(json.startsWith("{\"spaces\":["));
+        assertTrue(json.endsWith("]}"));
+        assertTrue(json.contains("\"spaceIri\":\"https://example.org/space/alpha\""));
+        assertTrue(json.contains("\"spaceRef\":\"http://purl.org/nanopub/admin/space/RA_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_aaaaaaaa\""));
+        assertTrue(json.contains("\"rootNanopub\":\"https://w3id.org/np/RA_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""));
+    }
+
+    @Test
+    void json_escapesQuotesAndBackslashes() {
+        var hostile = new SpacesListingRoute.Row(
+                "iri-with-\"quote\"-and-\\back",
+                "ref",
+                "root");
+        String json = SpacesListingRoute.renderJson(List.of(hostile));
+        assertTrue(json.contains("iri-with-\\\"quote\\\"-and-\\\\back"));
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) != -1) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3b of the space-repositories plan ([`doc/plan-space-repositories.md:430`](doc/plan-space-repositories.md)). Adds a public listing of declared spaces so they are discoverable without an ad-hoc SPARQL query.

## Endpoints

- `GET /spaces` — HTML listing, with a `JSON` link at the top
- `GET /spaces.json` — JSON output
- `GET /spaces` with `Accept: application/json` — also JSON

All three honor `FeatureFlags.spacesEnabled()` (404 when off). Path suffix takes precedence over `Accept` so `/spaces.json` is unambiguous regardless of headers.

## Data model

The listing reads the add-only extraction graph `npa:spacesGraph` directly:

```sparql
PREFIX npa: <http://purl.org/nanopub/admin/>
SELECT ?spaceIri ?spaceRef ?rootNanopub WHERE {
  GRAPH npa:spacesGraph {
    ?spaceRef a npa:SpaceRef ;
              npa:spaceIri ?spaceIri ;
              npa:rootNanopub ?rootNanopub .
  }
} ORDER BY ?spaceIri ?spaceRef
```

One row per `(SpaceRef, spaceIri, rootNanopub)` tuple. The same Space IRI may appear under multiple SpaceRefs during the back-compat phase (declarations without `gen:hasRootDefinition` produce per-declaration refs); the listing surfaces this honestly rather than collapsing it.

## Home page integration

Adds a separate `Spaces:` section after the `Specific repos:` block (Pubkey/Type), gated on the spaces flag — so it disappears entirely when spaces are off. JSON link is on the spaces listing page itself, not the home page.

## Changes

- **New** `src/main/java/com/knowledgepixels/query/SpacesListingRoute.java` — pure helper class. `fetchRows()` is the only RDF4J-touching method; `renderHtml()` / `renderJson()` are static and side-effect-free, with inline HTML and JSON escaping.
- **`MainVerticle.java`** — `GET /spaces` and `GET /spaces.json` register one shared handler; flag gate; HTML/JSON content negotiation. Home-page handler gains the new section.
- **New** `src/test/java/com/knowledgepixels/query/SpacesListingRouteTest.java` — six tests over the renderers, covering empty input, multi-row HTML, HTML special-character escaping, JSON shape, and JSON quote/backslash escaping.

## Live verification

Against the local container with the existing data:

| check | result |
|---|---|
| `GET /spaces` (HTML) | 160 `<li>` rows |
| `GET /spaces.json` | 160 entries, valid JSON |
| `GET /spaces` with `Accept: application/json` | identical JSON to `/spaces.json` |
| Direct SPARQL `COUNT(*)` on `npa:spacesGraph` | 160 (matches) |
| Same-IRI duplication for non-rooted declarations | visible (e.g. `M4M.44.T.5` appears twice) — exactly the back-compat case the plan describes |

## Test plan

- [x] `mvn test` — 169/169 pass locally (was 163; +6 new tests in `SpacesListingRouteTest`)
- [x] Live verified: HTML / JSON / home-page link all render against the existing local DB
- [x] CI green

## Notes

- Phase 3c (`for-space` redirect) is the remaining slice and will land separately on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)