### PR TITLE
docs: drop for-space redirect, rename plan→design, document in-query pointer pattern (#62)

### DIFF
--- a/doc/plan-space-repositories.md
+++ b/doc/plan-space-repositories.md
@@ -427,8 +427,8 @@ Readers are never blocked: during the worker's build the pointer still reference
 
 1. **Raw loading** — `TripleStore` init, loader writes full nanopubs of predefined types into `spaces` and emits add-only extraction triples (including `npa:Invalidation` entries) into `npa:spacesGraph` with `npa:hasLoadNumber` stamps.
 2. **Materialization** — new `AuthorityResolver` drives per-tier SPARQL UPDATE loops on load-number deltas for incremental updates; runs full rebuilds on trust-state flips and on the periodic `npa:needsFullRebuild` signal; manages the `npa:hasCurrentSpaceState` pointer and old-graph cleanup.
-3. **Routes/metrics/invalidation** — `/spaces` listing, `for-space` redirect, gauges (rebuild duration, delta size, `processedUpTo` lag).
-4. **Nanodash migration** — publish with `gen:hasRootDefinition` and the predefined type IRIs; replace the 4-query chain with one query against the current `npass:*` graph; drop `isAdminPubkey` gate and pinned templates/queries.
+3. **Routes / metrics** — `/spaces` listing route (HTML + JSON), Prometheus gauges (rebuild duration, delta size, `processedUpTo` lag, distinct-subject totals).
+4. **Nanodash migration** — publish with `gen:hasRootDefinition` and the predefined type IRIs; replace the 4-query chain with one query that resolves the current `npass:*` graph from the pointer (see [Querying the current space-state graph](#querying-the-current-space-state-graph)); drop `isAdminPubkey` gate and pinned templates/queries.
 
 ## Bootstrap
 
@@ -440,9 +440,32 @@ On first deployment, scan `meta` / `full` for the predefined types, load each ma
 |------|------|
 | `NanopubLoader.java` | Type-match + full-nanopub write + extraction into `npa:spacesGraph` + load-number stamping + trigger the materializer |
 | `TripleStore.java` | `spaces` repo init |
-| `MainVerticle.java` | `/spaces` route, `for-space` redirect |
+| `MainVerticle.java` | `/spaces` listing route (HTML + JSON) |
 | `MetricsCollector.java` | Rebuild duration, delta size, `processedUpTo` lag |
 | **New:** `AuthorityResolver.java` | Mirror step, per-tier SPARQL UPDATE loops on load-number deltas, first-build on trust-state flips, pointer flip and old-graph drop |
+
+## Querying the current space-state graph
+
+Consumers (Nanodash, ad-hoc SPARQL users) resolve the live graph in-query by joining on the pointer in `npa:graph`:
+
+```sparql
+PREFIX npa: <http://purl.org/nanopub/admin/>
+SELECT ... WHERE {
+  GRAPH <http://purl.org/nanopub/admin/graph> {
+    <http://purl.org/nanopub/admin/thisRepo> npa:hasCurrentSpaceState ?g .
+  }
+  GRAPH ?g {
+    # actual space-state pattern here
+  }
+}
+```
+
+This is the *only* recommended pattern. Do **not** resolve the pointer in a separate request and then issue a second query against a frozen `npass:<hash>_<n>` IRI: a trust-state flip between the two requests will leave the second query reading an orphaned graph that is about to be dropped (or already gone). Resolving the pointer in the same SPARQL transaction as the actual read is atomic across flips.
+
+Two consequences of using this pattern:
+
+- A consumer never needs to know the trust-state hash or load counter — those are internal to the materializer.
+- There is no `for-space` HTTP redirect: it would have to resolve the pointer at request time and return a frozen graph IRI, reintroducing the same race the in-query pattern is designed to avoid.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

Two doc-only changes to close out issue #62 cleanly:

1. **Drop the `for-space` HTTP redirect** from the design. Walking through the actual semantics: such a redirect would have to resolve `npa:hasCurrentSpaceState` at request time and hand the consumer a frozen `npass:<hash>_<n>` graph IRI. If a trust-state flip lands between the redirect and the consumer's follow-up SPARQL query, the second query reads a graph that is being (or has been) dropped — a TOCTOU race the redirect itself created. Resolving the pointer **in-query**, in the same SPARQL transaction as the actual read, is both simpler and atomically consistent across flips. So `for-space` is not just unneeded — it would have been a regression.
2. **Rename `plan-space-repositories.md` → `design-space-repositories.md`**. The document started as a plan and has now been implemented end-to-end; its title and the six javadoc pointers around the codebase are updated to reflect that, matching the existing `doc/design-trust-state-repos.md` convention.

## Changes

- `doc/design-space-repositories.md` (renamed from `plan-space-repositories.md`):
  - Title and intro phrasing updated from "plan" to "design".
  - Phase 3 line: drop `for-space` redirect, refine the wording (`Routes / metrics` instead of `Routes/metrics/invalidation`, name the gauges that landed in #85, mention HTML + JSON for #86).
  - `Key files` table: drop the redirect from `MainVerticle.java`'s row.
  - New section `## Querying the current space-state graph`: shows the canonical SPARQL pattern (`GRAPH npa:graph { ... npa:hasCurrentSpaceState ?g } GRAPH ?g { ... }`) and explains why this is the only recommended pattern, including the consequence that consumers never need to know the trust-state hash or load counter.
- `AuthorityResolver.java`, `AuthorityResolverTest.java`, `SpacesExtractor.java`, `SpacesVocab.java`, `GEN.java`, `BackcompatRolePredicates.java` — javadoc references retargeted to the new filename.

## Test plan

- [x] `mvn test` — 169/169 pass locally
- [ ] CI green
- [x] No remaining `plan-space-repositories` references in the repo

## Notes

After this lands, **Phase 3 is done on the server side** (#85 gauges + #86 listing + #87 spec/cleanup). Issue #62 will be closed; Phase 4 (Nanodash query migration, dropping the 4-query chain + `isAdminPubkey` gate + pinned templates/queries) lives in the Nanodash repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)