### PR TITLE
docs: rename plan-space-repositories.md to design-space-repositories.md

### DIFF
--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -1,8 +1,8 @@
-# Plan: Space Repositories in Nanopub Query
+# Design: Space Repositories in Nanopub Query
 
 ## Context
 
-Today Nanodash computes Space membership client-side via a chain of API queries (`GET_ADMINS` → `GET_SPACE_MEMBER_ROLES` → `GET_SPACE_MEMBERS` → `GET_VIEW_DISPLAYS`) against `full`/`meta`. It's slow and puts the membership logic in the wrong place. This plan moves that calculation server-side, into a new `spaces` repo.
+Today Nanodash computes Space membership client-side via a chain of API queries (`GET_ADMINS` → `GET_SPACE_MEMBER_ROLES` → `GET_SPACE_MEMBERS` → `GET_VIEW_DISPLAYS`) against `full`/`meta`. It's slow and puts the membership logic in the wrong place. This design moves that calculation server-side, into a new `spaces` repo.
 
 ## Space Identity
 

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -47,7 +47,7 @@ import com.knowledgepixels.query.vocabulary.SpacesVocab;
  * when an admin RI / RoleAssignment / RoleDeclaration was invalidated; periodic
  * worker turns the flag into a from-scratch rebuild.
  *
- * <p>See {@code doc/plan-space-repositories.md} — this implements the "Full
+ * <p>See {@code doc/design-space-repositories.md} — this implements the "Full
  * build", "Incremental cycle", and "Periodic full rebuild" procedures.
  */
 public final class AuthorityResolver {

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -32,7 +32,7 @@ import net.trustyuri.TrustyUriUtils;
 /**
  * Pure-logic extractor from a loaded {@link Nanopub} to the add-only summary
  * triples destined for {@code npa:spacesGraph}. Implements the per-type schema
- * from {@code doc/plan-space-repositories.md}.
+ * from {@code doc/design-space-repositories.md}.
  *
  * <p>Dispatch is by nanopub type — {@link NanopubUtils#getTypes(Nanopub)} returns
  * both {@code rdf:type} / {@code npx:hasNanopubType} declarations and, for

--- a/src/main/java/com/knowledgepixels/query/vocabulary/BackcompatRolePredicates.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/BackcompatRolePredicates.java
@@ -16,7 +16,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
  *
  * <p>Temporary — these should be dropped once existing deployments have moved
  * to publishing with {@link GEN#ROLE_INSTANTIATION}. See
- * {@code doc/plan-space-repositories.md} for the current list.
+ * {@code doc/design-space-repositories.md} for the current list.
  *
  * <p>Direction: each predicate is classified as either {@link Direction#REGULAR}
  * (agent &rarr; space — the natural direction of a role from its bearer) or

--- a/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
@@ -9,7 +9,7 @@ import org.nanopub.vocabulary.VocabUtils;
  * (<a href="https://w3id.org/kpxl/gen/terms/">https://w3id.org/kpxl/gen/terms/</a>).
  *
  * <p>Defines the subset needed by the space-extraction layer
- * (see {@code doc/plan-space-repositories.md}):
+ * (see {@code doc/design-space-repositories.md}):
  * the {@link #SPACE} type and {@link #HAS_ROOT_DEFINITION} predicate for space
  * declarations; {@link #SPACE_MEMBER_ROLE} and its tier subclasses
  * ({@link #MAINTAINER_ROLE}, {@link #MEMBER_ROLE}, {@link #OBSERVER_ROLE}) for

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
@@ -7,7 +7,7 @@ import org.nanopub.vocabulary.NPA;
 
 /**
  * IRIs, prefixes and subject-minting helpers used by the space-extraction layer
- * (see {@code doc/plan-space-repositories.md}).
+ * (see {@code doc/design-space-repositories.md}).
  *
  * <p>Every extraction entry in {@code npa:spacesGraph} has a dedicated subject IRI
  * derived from the originating nanopub's trusty-URI artifact code, so subjects

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
  * {@code sail-base:5.3.0} with {@code sail-memory:5.1.5} / {@code common-concurrent:5.1.5}
  * in a way that breaks pattern-delete and SPARQL UPDATE on both MemoryStore and
  * NativeStore in tests. Those paths are covered by the integration smoke test
- * against a live deployment (see {@code doc/plan-space-repositories.md} and the
+ * against a live deployment (see {@code doc/design-space-repositories.md} and the
  * live-instance spot-checks accompanying this PR).
  */
 class AuthorityResolverTest {


### PR DESCRIPTION
## Summary

Follow-up to #87. That branch carried two commits — the `for-space` drop + in-query pointer pattern, **and** a rename of `doc/plan-space-repositories.md` → `doc/design-space-repositories.md` plus the corresponding javadoc updates. The merge took only the first commit, so the rename is still owed.

Now that the design has been implemented and validated end-to-end across #74–#87, "plan" no longer reflects what the document is. The repo's existing convention (e.g. `doc/design-trust-state-repos.md`) is "design".

## Changes

- `doc/plan-space-repositories.md` → `doc/design-space-repositories.md` (`git mv`, 99% similarity)
- Document title updated from `# Plan: Space Repositories in Nanopub Query` to `# Design: Space Repositories in Nanopub Query`; intro phrasing "This plan moves..." → "This design moves..."
- Six javadoc references retargeted to the new filename:
  - `AuthorityResolver.java`
  - `SpacesExtractor.java`
  - `vocabulary/SpacesVocab.java`
  - `vocabulary/GEN.java`
  - `vocabulary/BackcompatRolePredicates.java`
  - `test/.../AuthorityResolverTest.java`

## Test plan

- [x] `mvn test` — 169/169 pass locally (no behavioural change; verifies the test-class javadoc edit didn't break the file)
- [x] `grep -r 'plan-space-repositories'` returns nothing across `src/` and `doc/`
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)