### PR TITLE
feat: validate downward observer-tier grants from admin/maintainer/member (#62)

### DIFF
--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -471,6 +471,105 @@ Two consequences of using this pattern:
 - A consumer never needs to know the trust-state hash or load counter — those are internal to the materializer.
 - There is no `for-space` HTTP redirect: it would have to resolve the pointer at request time and return a frozen graph IRI, reintroducing the same race the in-query pattern is designed to avoid.
 
+### What the state graph does and does not carry per RoleInstantiation
+
+Every validated `gen:RoleInstantiation` in the state graph carries:
+
+- `npa:forSpace` — the Space IRI
+- `npa:forAgent` — the agent IRI
+- `npa:viaNanopub` — the source nanopub
+- `npa:inverseProperty gen:hasAdmin` — *only* on admin-tier RIs (pinned)
+
+Non-admin RIs intentionally do not carry their role predicate or tier class in the state graph: those are dropped after validation, since the same RI subject can validate against multiple tier rules and only one row is written per nanopub.
+
+To recover the role predicate per-RI, join back to `npa:spacesGraph` on the same `?ri` IRI (the `npari:<artifactCode>` is shared across both graphs):
+
+```sparql
+GRAPH ?g { ?ri a gen:RoleInstantiation ; npa:forAgent ?agent . }    # state graph
+GRAPH npa:spacesGraph {
+  { ?ri npa:regularProperty ?pred } UNION { ?ri npa:inverseProperty ?pred }
+}
+```
+
+### Worked example — agents in a space, with names and approval status
+
+The materializer only writes *validated* RIs into the state graph. Some space-relevant nanopubs are extracted but never validate — typically because the publisher (or, for `PUBLISHER_IS_SELF`, the agent) has no `npa:AccountState` in the trust state. Consumers that want to surface those rows alongside the validated set (e.g. for a "people who self-declared but aren't approved yet" UI section) read the **universe** from `npa:spacesGraph` and tag rows by checking against the state graph.
+
+The recommended one-query pattern combines:
+
+1. Universe enumeration from the extraction graph (drives row generation).
+2. `EXISTS` checks against the state graph for `(space, agent)` validation and against the mirrored `AccountState` rows for trust visibility — `EXISTS` is critical here so per-agent flags don't multiply rows.
+3. A three-way status: `approved` / `tier-mismatch` / `agent-unknown`.
+4. Cross-repo `SERVICE` to `/repo/full` for `foaf:name` (the trust repo carries pubkey / status only, no human-readable names).
+
+```sparql
+PREFIX npa:  <http://purl.org/nanopub/admin/>
+PREFIX gen:  <https://w3id.org/kpxl/gen/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+SELECT ?agent ?name ?status
+       (GROUP_CONCAT(DISTINCT ?role; separator=", ") AS ?roles)
+WHERE {
+  GRAPH <http://purl.org/nanopub/admin/graph> {
+    <http://purl.org/nanopub/admin/thisRepo> npa:hasCurrentSpaceState ?g .
+  }
+
+  # Universe: every extracted RoleInstantiation for the space, validated or not.
+  GRAPH npa:spacesGraph {
+    ?ri a gen:RoleInstantiation ;
+        npa:forSpace <SPACE_IRI> ;
+        npa:forAgent ?agent .
+    OPTIONAL {
+      { ?ri npa:regularProperty ?pred } UNION { ?ri npa:inverseProperty ?pred }
+    }
+  }
+  BIND(IF(BOUND(?pred), STR(?pred), "?") AS ?role)
+
+  # Per-agent flags via EXISTS so they don't multiply rows.
+  BIND(EXISTS {
+    GRAPH ?g {
+      ?riV a gen:RoleInstantiation ;
+           npa:forSpace <SPACE_IRI> ;
+           npa:forAgent ?agent .
+    }
+  } AS ?hasValidatedRI)
+  BIND(EXISTS {
+    GRAPH ?g { ?acct a npa:AccountState ; npa:agent ?agent . }
+  } AS ?hasAccountState)
+
+  BIND(IF(?hasValidatedRI, "approved",
+       IF(?hasAccountState, "tier-mismatch", "agent-unknown")) AS ?status)
+
+  SERVICE <http://query:9393/repo/full> {
+    OPTIONAL { ?agent foaf:name ?name }
+  }
+}
+GROUP BY ?agent ?name ?status
+ORDER BY ?status ?agent
+```
+
+Three-way status semantics:
+
+| status | meaning |
+|---|---|
+| `approved` | At least one of the agent's RIs in this space passed tier validation; the agent is a recognised member at some tier. |
+| `tier-mismatch` | The agent has an `AccountState` in the trust state (so they're a known account) but no RI for this space validated at any tier. Typical cause: a role was granted to them but the granting publisher's tier didn't qualify under the role's declared `hasRoleType`. |
+| `agent-unknown` | The agent has no `AccountState` at all — they're outside the trust state's reach. Self-declarations from such agents extract correctly but never validate. |
+
+Common UI filters as one-line additions before `GROUP BY`:
+
+| filter | clause |
+|---|---|
+| Validated only | `FILTER(?status = "approved")` |
+| Hide outside-the-trust-radius agents | `FILTER(?status != "agent-unknown")` |
+| Unapproved only | `FILTER(?status != "approved")` |
+
+### Operational notes for the query above
+
+- **Names live in `/repo/full`, not `/repo/trust`.** The trust repo only carries `npa:agent`, `npa:pubkey`, `npa:trustStatus`, `npa:depth`, `npa:ratio`, and similar admin metadata — there is no `foaf:name` there. Agent introduction nanopubs (which carry `foaf:name`) are indexed in `full` (and `meta`).
+- **`SERVICE` host: use the docker-compose service name, not `localhost`.** The `SERVICE` clause executes inside the RDF4J container, where `localhost` resolves to RDF4J itself — not to the nanopub-query proxy. Use `http://query:9393/repo/full` so the SERVICE call comes back through the proxy. Outside the docker network, replace with whatever DNS name reaches the proxy from RDF4J's perspective.
+- **Multi-name agents**: the `full` repo can hold multiple `foaf:name` claims for the same agent (variant capitalisations, name changes). The query above produces one row per `(agent, name, status)` triple; if you want exactly one row per `(agent, status)`, drop `?name` from `GROUP BY` and replace its projection with `(SAMPLE(?name) AS ?name)` or `(GROUP_CONCAT(DISTINCT ?name; separator=" / ") AS ?names)`.
+
 ## Verification
 
 - Unit: closures, incremental delta correctness (same result as a full rebuild), invalidation cleanup (sticky, non-cascading), rebuild idempotence.

--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -18,16 +18,18 @@ For backwards compatibility during the transition phase, a `gen:Space`-typed nan
 
 ## Role types
 
-Four `gen:SpaceMemberRole` subclasses:
+Four `gen:SpaceMemberRole` subclasses, each with a distinct grant rule. The grant rule names which publishers' role-instantiation nanopubs the materializer accepts as evidence for that tier:
 
-| Type | Predicate / how it's granted |
-|------|------------------------------|
-| `gen:AdminRole`      | Single hardcoded instance `<https://w3id.org/np/RA_eEJjQbxzSqYSwPzfjzOZi5sMPpUmHskFNsgJYSws8I/adminRole>`, defining `gen:hasAdmin`. No other admin roles. |
-| `gen:MaintainerRole` | User-defined predicates declared `rdf:type gen:MaintainerRole`. Nothing is hardcoded at this tier. |
-| `gen:MemberRole`     | User-defined predicates declared `rdf:type gen:MemberRole`. |
-| `gen:ObserverRole`   | User-defined predicates declared `rdf:type gen:ObserverRole`. **Default** when a role definition doesn't declare a type. |
+| Type | How it's granted (publisher of the RoleInstantiation) |
+|------|-------------------------------------------------------|
+| `gen:AdminRole`      | Single hardcoded instance `<https://w3id.org/np/RA_eEJjQbxzSqYSwPzfjzOZi5sMPpUmHskFNsgJYSws8I/adminRole>`, defining `gen:hasAdmin`. Granted by an existing admin (transitive admin chain seeded from the trust state's space-root admin list). No other admin roles. |
+| `gen:MaintainerRole` | Granted by an admin. |
+| `gen:MemberRole`     | Granted by an admin or a maintainer. |
+| `gen:ObserverRole`   | Granted by an admin, maintainer, or member; or self-attested by the agent. **Default** when a role definition doesn't declare a tier subclass. |
 
-Per-tier privilege enforcement is Nanodash's concern, out of scope here.
+Downward-only chain: each tier accepts grants from itself and any tier above it (admin > maintainer > member > observer). Self-attestation is unique to observer — it's the only tier where "publisher == agent" is a valid evidence path. This keeps observer accessible enough to be the safe default, while still admitting top-down grants so an admin's "X is the speaker" nanopub validates even when the speaker role didn't explicitly declare its tier.
+
+Per-tier privilege enforcement (what each tier may do *inside* a space) is Nanodash's concern, out of scope here. This table only describes grant-time evidence rules.
 
 ## What's In the `spaces` Repo
 
@@ -253,7 +255,9 @@ GRAPH npass:<trustStateHash>_<loadCounterAtBuildStart> {
 
 ### Validation rule
 
-All tier checks (authority evidence for admin/maintainer/member; self-evidence for observer) resolve the publisher via `(agent, pubkey)` pairs in the mirrored rows — i.e. the signing key on the extraction (`npa:pubkeyHash`) must match an `npa:AccountState` whose `npa:agent` is the agent being checked. `npx:signedBy` is informational only (self-declared from pubinfo) and never decides validity.
+All tier checks resolve the publisher via `(agent, pubkey)` pairs in the mirrored rows — i.e. the signing key on the extraction (`npa:pubkeyHash`) must match an `npa:AccountState` whose `npa:agent` is the publishing agent. `npx:signedBy` is informational only (self-declared from pubinfo) and never decides validity.
+
+A RoleInstantiation is admitted into the validated state graph iff *any* of the per-tier evidence paths in [Role types](#role-types) is satisfied. The materializer iterates the candidate paths from highest tier downward — admin first, then maintainer / member sub-tiers, then observer sub-tiers (admin / maintainer / member / self) — to fixed point. Dedup filters in each tier's INSERT prevent the same RI being inserted twice when multiple paths would have qualified it.
 
 Since the registry's trust calculation flags any pubkey that claims multiple agents as `npa:contested` (and contested rows are not in the mirrored set), a trust-approved pubkey in `npass:<ts>` resolves to exactly one agent. No multi-agent ambiguity to handle at validation time.
 

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -376,7 +376,15 @@ public final class AuthorityResolver {
         c.member += runTierLabeled("member(maint-pub,late)", graph,
                 nonAdminTierUpdate(graph, -1,
                         GEN.MEMBER_ROLE, publisherIsTieredRole(GEN.MAINTAINER_ROLE)));
-        c.observer = runTierLabeled("observer(self,late)", graph,
+        c.observer = runTierLabeled("observer(admin-pub,late)", graph,
+                nonAdminTierUpdate(graph, -1, GEN.OBSERVER_ROLE, PUBLISHER_IS_ADMIN));
+        c.observer += runTierLabeled("observer(maint-pub,late)", graph,
+                nonAdminTierUpdate(graph, -1,
+                        GEN.OBSERVER_ROLE, publisherIsTieredRole(GEN.MAINTAINER_ROLE)));
+        c.observer += runTierLabeled("observer(member-pub,late)", graph,
+                nonAdminTierUpdate(graph, -1,
+                        GEN.OBSERVER_ROLE, publisherIsTieredRole(GEN.MEMBER_ROLE)));
+        c.observer += runTierLabeled("observer(self,late)", graph,
                 nonAdminTierUpdate(graph, -1, GEN.OBSERVER_ROLE, PUBLISHER_IS_SELF));
         return c;
     }
@@ -453,11 +461,21 @@ public final class AuthorityResolver {
                 GEN.MEMBER_ROLE, PUBLISHER_IS_ADMIN));
         c.member += runTierLabeled("member(maint-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
                 GEN.MEMBER_ROLE, publisherIsTieredRole(GEN.MAINTAINER_ROLE)));
-        // Observer tier: self-evidence only per the plan's policy table
-        // (gen:ObserverRole = self). Authority-publisher sub-tiers were overreach;
-        // the three of them have been removed, so an observer instantiation is
-        // validated iff the assignee's own pubkey signed it.
-        c.observer = runTierLabeled("observer(self)", graph, nonAdminTierUpdate(graph, lastProcessed,
+        // Observer tier: self-evidence OR a downward grant from any higher tier.
+        // ObserverRole is the default tier when a role definition omits an
+        // explicit subclass (see "Role types" in design-space-repositories.md), so
+        // most "X assigned Y this role" nanopubs land here. Restricting the tier
+        // to PUBLISHER_IS_SELF would silently drop those grants. The four
+        // sub-loops mirror the trust-state's downward-only chain: admin grants
+        // anything; maintainers and members grant observer; everyone may
+        // self-attest.
+        c.observer = runTierLabeled("observer(admin-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.OBSERVER_ROLE, PUBLISHER_IS_ADMIN));
+        c.observer += runTierLabeled("observer(maint-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.OBSERVER_ROLE, publisherIsTieredRole(GEN.MAINTAINER_ROLE)));
+        c.observer += runTierLabeled("observer(member-pub)", graph, nonAdminTierUpdate(graph, lastProcessed,
+                GEN.OBSERVER_ROLE, publisherIsTieredRole(GEN.MEMBER_ROLE)));
+        c.observer += runTierLabeled("observer(self)", graph, nonAdminTierUpdate(graph, lastProcessed,
                 GEN.OBSERVER_ROLE, PUBLISHER_IS_SELF));
         return c;
     }

--- a/src/main/java/com/knowledgepixels/query/vocabulary/BackcompatRolePredicates.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/BackcompatRolePredicates.java
@@ -53,8 +53,12 @@ public final class BackcompatRolePredicates {
             Map.entry(iri("https://w3id.org/fair/3pff/has-event-assistant"),                Direction.INVERSE),
             Map.entry(iri("https://w3id.org/fair/3pff/has-event-facilitator"),              Direction.INVERSE),
             Map.entry(iri("https://w3id.org/fair/3pff/participatedAsFacilitatorAssistantIn"), Direction.REGULAR),
+            Map.entry(iri("https://w3id.org/fair/3pff/participatedAsFacilitatorIn"),          Direction.REGULAR),
             Map.entry(iri("https://w3id.org/fair/3pff/participatedAsImplementerAspirantIn"),  Direction.REGULAR),
+            Map.entry(iri("https://w3id.org/fair/3pff/participatedAsImplementerIn"),          Direction.REGULAR),
             Map.entry(iri("https://w3id.org/fair/3pff/participatedAsParticipantIn"),          Direction.REGULAR),
+            Map.entry(iri("https://w3id.org/fair/3pff/participatedAsTrainerAssistantIn"),     Direction.REGULAR),
+            Map.entry(iri("https://w3id.org/fair/3pff/participatedAsTrainerIn"),              Direction.REGULAR),
             // KPXL gen terms
             Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasAdmin"),       Direction.INVERSE),
             Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasObserver"),    Direction.INVERSE),

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -122,6 +122,24 @@ class AuthorityResolverTest {
     }
 
     @Test
+    void observerTierUpdate_acceptsAdminPublishedGrant() {
+        // Permissive observer: admin-published grants of an ObserverRole-typed
+        // role validate at this tier without needing a separate self-attestation.
+        // Without this path, "admin assigned X the speaker role" silently no-ops
+        // when the speaker role didn't declare an explicit tier subclass and
+        // therefore defaulted to ObserverRole.
+        String sparql = AuthorityResolver.nonAdminTierUpdate(
+                TEST_GRAPH, 0,
+                com.knowledgepixels.query.vocabulary.GEN.OBSERVER_ROLE,
+                AuthorityResolver.PUBLISHER_IS_ADMIN);
+        assertTrue(sparql.contains(
+                com.knowledgepixels.query.vocabulary.GEN.OBSERVER_ROLE.stringValue()),
+                "tier class is substituted to ObserverRole");
+        assertTrue(sparql.contains("npa:inverseProperty gen:hasAdmin"),
+                "admin publisher constraint pinned via gen:hasAdmin");
+    }
+
+    @Test
     void observerTierUpdate_allowsSelfEvidence() {
         String sparql = AuthorityResolver.nonAdminTierUpdate(
                 TEST_GRAPH, 0,


### PR DESCRIPTION
## Status

**Draft** — open for additional changes before review. Core change is the observer-grant fix described below; expect this PR to grow.

## Summary

`gen:ObserverRole` is the default tier when a role definition omits an explicit subclass (per the Role types table in [`doc/design-space-repositories.md`](doc/design-space-repositories.md)). The previous validation rule restricted observer-tier grants to `PUBLISHER_IS_SELF`, which made admin-driven grants of such roles silently no-op.

### Concrete case that motivated this

The space `<https://w3id.org/spaces/nanopub/nanosessions/session30>` has a *speaker role* nanopub (`RA7Ly-qDdWz049Wf0v2SEMbBqD98gwCWFV9oTOHxzb7lU`) that declares only `:speakerRole a gen:SpaceMemberRole` — no tier subclass. The extractor correctly synthesizes a RoleDeclaration with `npa:hasRoleType = gen:ObserverRole` (the documented default).

An admin (Virginia Balseiro, `0009-0009-0118-9195`) then published `RAvAXk5BaI8KxCAvvqFH4BsfS1IrvdS1mLDDPAGpou0FI`, granting Roberto Pizzolotto (`0000-0002-4587-3476`) the speaker role for that session. Live trace (against current `main`):

| step | result |
|---|---|
| Extracted into `npa:spacesGraph` | ✅ 8 triples |
| Recipient agent trust-approved | ✅ depth=2, `npa:loaded`, mirrored in state graph |
| Publisher (admin) | ✅ |
| RoleDeclaration for `wd:P823` | ✅ `hasRoleType = gen:ObserverRole` |
| **Promoted to validated state graph** | **❌ 0 triples** |

The grant fell into a no-validation gap: observer's `PUBLISHER_IS_SELF` rejected it (publisher ≠ agent), and member/maintainer tiers ignored it (RoleDeclaration tier ≠ Member/Maintainer).

## Changes

### Code

`AuthorityResolver.runAllTierLoops` and `runDownstreamWithoutLoadFilter` (late-arrival sweep): the single `observer(self)` loop is replaced by four sub-tiers — `observer(admin-pub)`, `observer(maint-pub)`, `observer(member-pub)`, `observer(self)` — mirroring the existing maintainer/member fan-out and the trust-state's downward-only chain. Dedup filters in `nonAdminTierUpdate`'s template prevent double-insert when multiple paths qualify the same RI.

The comment block above the observer loops is rewritten to explain *why*: ObserverRole is the default tier so silently dropping admin grants would surprise users.

### Doc

- `## Role types` table rewritten to describe the per-tier grant rule explicitly. Admin > maintainer > member > observer downward-only chain, with self-attestation unique to observer.
- `### Validation rule` reworded to describe the materializer's iterate-paths-to-fixed-point semantics: an RI is admitted iff *any* tier evidence path qualifies it.

### Tests

- `observerTierUpdate_acceptsAdminPublishedGrant` (new) — verifies SPARQL template substitution for the admin-published-observer case.
- `observerTierUpdate_allowsSelfEvidence` (existing) — still passes; self path is preserved.

## Test plan

- [x] `mvn test` — 170/170 pass locally (+1 new test)
- [ ] CI green
- [ ] Live verify after redeploy: clear `npa:hasCurrentSpaceState` pointer to force a full rebuild, then re-run the consolidated `(agent, name, roles)` query for session30 and confirm Roberto Pizzolotto + any other previously-blocked admin-grant recipients now appear with their granted roles
- [ ] Spot-check delta gauges (`registry_spaces_delta_last_inserted_triples`, `registry_spaces_subjects_*`) on the live instance after rebuild

## Compatibility / migration

- **No data-format change.** Same `npa:spacesGraph` extractions, same state-graph schema. Existing rebuilds will simply admit a strict superset of the previous output on the next pass.
- **Effect on existing deployments:** the next full rebuild (trust-state flip, periodic rebuild, or manual pointer clear) will retroactively pick up admin-/maintainer-/member-published observer grants that were silently rejected before. No DELETE path: nothing currently in the state graph becomes invalid.
- **Reverts an earlier intentional simplification** (commit `e77dd02` *"drop observer authority sub-tiers per policy table"*) once the user-facing implication of the strict reading was identified. Restores the three sub-tiers the earlier commit removed and adds the comment explaining why.

## Possible additional changes for this PR

(Listing here so we can decide what else to bundle before un-drafting.)

- TBD — leaving room for follow-on changes the maintainer wants to fold in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)