### PR TITLE
feat: materialize canonical foaf:name per agent into trust + spaces graphs (#62)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -11,6 +11,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryLanguage;
@@ -1061,6 +1062,18 @@ public final class AuthorityResolver {
                     spacesConn.add(accountStateIri, NPA_PUBKEY, pubkey, newGraph);
                     spacesConn.add(accountStateIri, NPA_TRUST_STATUS, statusIri, newGraph);
                     count++;
+                }
+            }
+            // Mirror canonical foaf:name triples for approved agents. The trust
+            // loader emits one per agent (across approved keys, MAX(ratio) wins).
+            // Copying them into the space-state graph means consumers reading
+            // ?agent foaf:name ?n inside the state graph hit local data, with no
+            // cross-repo SERVICE.
+            try (RepositoryResult<Statement> nameRows = trustConn.getStatements(
+                    null, FOAF.NAME, null, trustStateIri)) {
+                while (nameRows.hasNext()) {
+                    Statement st = nameRows.next();
+                    spacesConn.add(st.getSubject(), st.getPredicate(), st.getObject(), newGraph);
                 }
             }
             spacesConn.commit();

--- a/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
@@ -4,8 +4,11 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -15,6 +18,7 @@ import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.QueryLanguage;
@@ -250,6 +254,17 @@ public class TrustStateLoader {
                 }
             }
 
+            // 1b. Canonical foaf:name per agent. The registry stamps each account
+            // row with the foaf:name + dct:created of its declaring intro
+            // (see nanopub-registry#113). Per-agent canonical name is whichever
+            // approved row has the highest ratio (ties → MIN(name) lex). Emitted
+            // once per agent in the trust-state graph so consumers can read
+            // ?agent foaf:name ?n directly without a SERVICE join to /repo/full.
+            for (Map.Entry<String, String> e : resolveCanonicalNames(snapshot).entrySet()) {
+                conn.add(vf.createIRI(e.getKey()), FOAF.NAME,
+                        vf.createLiteral(e.getValue()), trustStateIri);
+            }
+
             // 2. Cross-state metadata in npa:graph
             conn.add(trustStateIri, RDF.TYPE, NPA_TRUST_STATE, NPA.GRAPH);
             conn.add(trustStateIri, NPA_HAS_TRUST_STATE_HASH,
@@ -330,6 +345,46 @@ public class TrustStateLoader {
     static String accountStateHash(String trustStateHash, TrustStateSnapshot.AccountEntry a) {
         String composite = trustStateHash + "|" + a.pubkey() + "|" + a.agent();
         return Hashing.sha256().hashString(composite, StandardCharsets.UTF_8).toString();
+    }
+
+    /** Trust-approved status set: rows with one of these {@code npa:trustStatus} values
+     *  are eligible to contribute the canonical agent name. Matches the set used by
+     *  {@code AuthorityResolver.mirrorTrustState}. */
+    private static final Set<String> APPROVED_STATUSES = Set.of("loaded", "toLoad");
+
+    /**
+     * Per-agent canonical name resolution. Returns a map from agent IRI to its
+     * canonical {@code foaf:name} literal, derived from the snapshot's per-account
+     * {@code name} field.
+     *
+     * <p>Policy: among an agent's account rows whose {@code status} is approved
+     * ({@code loaded} or {@code toLoad}) and whose {@code ratio} and {@code name}
+     * are both non-null, pick the row with the highest {@code ratio}. Ties break
+     * on lex-min {@code name} for determinism across rebuilds. Agents with no
+     * qualifying row are simply absent from the result map (no name emitted).
+     *
+     * <p>Per-{@code (agent, pubkey)} resolution (the latest declaring intro
+     * supplies that row's {@code name}) lives in the registry; this layer only
+     * folds across keys.
+     */
+    static Map<String, String> resolveCanonicalNames(TrustStateSnapshot snapshot) {
+        Map<String, TrustStateSnapshot.AccountEntry> chosen = new HashMap<>();
+        for (TrustStateSnapshot.AccountEntry a : snapshot.accounts()) {
+            if (!APPROVED_STATUSES.contains(a.status())) continue;
+            if (a.name() == null || a.ratio() == null) continue;
+            TrustStateSnapshot.AccountEntry incumbent = chosen.get(a.agent());
+            if (incumbent == null
+                    || a.ratio() > incumbent.ratio()
+                    || (a.ratio().equals(incumbent.ratio())
+                            && a.name().compareTo(incumbent.name()) < 0)) {
+                chosen.put(a.agent(), a);
+            }
+        }
+        Map<String, String> result = new HashMap<>(chosen.size());
+        for (Map.Entry<String, TrustStateSnapshot.AccountEntry> e : chosen.entrySet()) {
+            result.put(e.getKey(), e.getValue().name());
+        }
+        return result;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/query/TrustStateSnapshot.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateSnapshot.java
@@ -40,7 +40,11 @@ public record TrustStateSnapshot(
      *
      * <p>{@code pathCount}, {@code ratio}, and {@code quota} can be {@code null}
      * for accounts with {@code status == "skipped"} (trust calculation rejected
-     * them, so those stats aren't meaningful). Boxed types preserve that.
+     * them, so those stats aren't meaningful). {@code name} and {@code nameCreatedAt}
+     * are {@code null} when the declaring intro nanopub asserted no
+     * {@code foaf:name} on the agent (or when running against a registry that
+     * predates the field — additive non-breaking schema). Boxed types preserve
+     * the absence.
      *
      * @param pubkey hex-encoded public key
      * @param agent agent IRI (typically an ORCID, but any IRI is allowed)
@@ -50,6 +54,11 @@ public record TrustStateSnapshot(
      * @param pathCount number of independent trust paths, or {@code null} for skipped accounts
      * @param ratio aggregated trust score, or {@code null} for skipped accounts
      * @param quota allocated upload quota, or {@code null} for skipped accounts
+     * @param name {@code foaf:name} from the declaring intro nanopub, or {@code null} if absent
+     * @param nameCreatedAt {@code dct:created} of the declaring intro, or {@code null} if absent.
+     *                      Used to break ties when multiple intros declare the same {@code (agent, pubkey)};
+     *                      consumers picking one canonical name per agent across keys typically use
+     *                      {@code MAX(ratio)} with this as a secondary tiebreaker.
      */
     public record AccountEntry(
             String pubkey,
@@ -58,7 +67,9 @@ public record TrustStateSnapshot(
             Integer depth,
             Integer pathCount,
             Double ratio,
-            Long quota
+            Long quota,
+            String name,
+            Instant nameCreatedAt
     ) {}
 
     /**
@@ -110,7 +121,9 @@ public record TrustStateSnapshot(
                     a.getInteger("depth"),
                     a.getInteger("pathCount"),
                     a.getDouble("ratio"),
-                    unwrapLongNullable(a, "quota")
+                    unwrapLongNullable(a, "quota"),
+                    a.getString("name"),
+                    unwrapDateNullable(a, "nameCreatedAt")
             ));
         }
 
@@ -137,6 +150,44 @@ public record TrustStateSnapshot(
             throw new IllegalArgumentException("Trust state envelope is missing required field: " + key);
         }
         return v;
+    }
+
+    /**
+     * Reads an optional date-typed field. Handles MongoDB extended JSON
+     * ({@code {"$date": "..."}} or {@code {"$date": {"$numberLong": "..."}}}),
+     * plain ISO-8601 strings, and JSON {@code null}/missing. Returns {@code null}
+     * for any of those last cases so the field is fully optional — consumers
+     * working with snapshots from a registry that predates the {@code nameCreatedAt}
+     * field still parse cleanly.
+     */
+    private static Instant unwrapDateNullable(JsonObject obj, String key) {
+        Object v = obj.getValue(key);
+        if (v == null) return null;
+        if (v instanceof JsonObject j) {
+            Object dateVal = j.getValue("$date");
+            if (dateVal instanceof String s) {
+                try {
+                    return Instant.parse(s);
+                } catch (Exception ex) {
+                    throw new IllegalArgumentException("Cannot parse " + key + " as ISO-8601 instant: " + s, ex);
+                }
+            }
+            if (dateVal instanceof JsonObject inner) {
+                String numberLong = inner.getString("$numberLong");
+                if (numberLong != null) return Instant.ofEpochMilli(Long.parseLong(numberLong));
+            }
+            if (dateVal instanceof Number n) return Instant.ofEpochMilli(n.longValue());
+            throw new IllegalArgumentException("Cannot unwrap " + key + " from extended JSON $date: " + j);
+        }
+        if (v instanceof String s) {
+            try {
+                return Instant.parse(s);
+            } catch (Exception ex) {
+                throw new IllegalArgumentException("Cannot parse " + key + " as ISO-8601 instant: " + s, ex);
+            }
+        }
+        if (v instanceof Number n) return Instant.ofEpochMilli(n.longValue());
+        throw new IllegalArgumentException("Cannot unwrap " + key + " as date: " + v);
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/query/TrustStateLoaderTest.java
+++ b/src/test/java/com/knowledgepixels/query/TrustStateLoaderTest.java
@@ -2,8 +2,13 @@ package com.knowledgepixels.query;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,7 +58,7 @@ class TrustStateLoaderTest {
     void accountStateHash_isDeterministicOverSameInputs() {
         TrustStateSnapshot.AccountEntry a = new TrustStateSnapshot.AccountEntry(
                 "pk1", "https://orcid.org/0000-0001-5118-256X", "loaded",
-                1, 1, 0.008, 100000L);
+                1, 1, 0.008, 100000L, null, null);
         String h1 = TrustStateLoader.accountStateHash("trustA", a);
         String h2 = TrustStateLoader.accountStateHash("trustA", a);
         assertEquals(h1, h2);
@@ -65,7 +70,7 @@ class TrustStateLoaderTest {
     void accountStateHash_differsAcrossTrustStates() {
         // Same (pubkey, agent) under different trust states → different IRIs (by design).
         TrustStateSnapshot.AccountEntry a = new TrustStateSnapshot.AccountEntry(
-                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000L);
+                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000L, null, null);
         String h1 = TrustStateLoader.accountStateHash("trustA", a);
         String h2 = TrustStateLoader.accountStateHash("trustB", a);
         org.junit.jupiter.api.Assertions.assertNotEquals(h1, h2);
@@ -74,9 +79,9 @@ class TrustStateLoaderTest {
     @Test
     void accountStateHash_differsAcrossAgents() {
         TrustStateSnapshot.AccountEntry a1 = new TrustStateSnapshot.AccountEntry(
-                "pk1", "https://example.org/agentA", "loaded", 1, 1, 0.5, 1000L);
+                "pk1", "https://example.org/agentA", "loaded", 1, 1, 0.5, 1000L, null, null);
         TrustStateSnapshot.AccountEntry a2 = new TrustStateSnapshot.AccountEntry(
-                "pk1", "https://example.org/agentB", "loaded", 1, 1, 0.5, 1000L);
+                "pk1", "https://example.org/agentB", "loaded", 1, 1, 0.5, 1000L, null, null);
         org.junit.jupiter.api.Assertions.assertNotEquals(
                 TrustStateLoader.accountStateHash("trustA", a1),
                 TrustStateLoader.accountStateHash("trustA", a2));
@@ -88,12 +93,88 @@ class TrustStateLoaderTest {
         assertEquals(100, TrustStateLoader.effectiveRetention());
     }
 
+    // ---------------- Canonical name resolution (#62) ----------------
+
+    private static TrustStateSnapshot snapshotOf(TrustStateSnapshot.AccountEntry... accounts) {
+        return new TrustStateSnapshot("h", 1L, Instant.parse("2026-01-01T00:00:00Z"), List.of(accounts));
+    }
+
+    @Test
+    void resolveCanonicalNames_picksRowWithMaxRatio() {
+        // Same agent, two approved keys with different names. The MAX(ratio)
+        // policy chooses the more-trusted key's stamped name, which is
+        // semantically "the name from the agent's most-endorsed declaration".
+        TrustStateSnapshot.AccountEntry low = new TrustStateSnapshot.AccountEntry(
+                "pk1", "https://example.org/alice", "loaded", 1, 1, 0.10, 100L,
+                "Old Alice", Instant.parse("2025-01-01T00:00:00Z"));
+        TrustStateSnapshot.AccountEntry high = new TrustStateSnapshot.AccountEntry(
+                "pk2", "https://example.org/alice", "loaded", 1, 1, 0.90, 100L,
+                "Alice", Instant.parse("2024-01-01T00:00:00Z"));
+        Map<String, String> names =
+                TrustStateLoader.resolveCanonicalNames(snapshotOf(low, high));
+        assertEquals("Alice", names.get("https://example.org/alice"));
+    }
+
+    @Test
+    void resolveCanonicalNames_breaksTiesOnLexMinName() {
+        // Equal ratio → MIN(name) lex tiebreak so the resolution is
+        // deterministic across rebuilds and across MongoDB iteration order.
+        TrustStateSnapshot.AccountEntry charlie = new TrustStateSnapshot.AccountEntry(
+                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 100L,
+                "Charlie", Instant.parse("2025-06-01T00:00:00Z"));
+        TrustStateSnapshot.AccountEntry alice = new TrustStateSnapshot.AccountEntry(
+                "pk2", "https://example.org/agent", "loaded", 1, 1, 0.5, 100L,
+                "Alice", Instant.parse("2025-01-01T00:00:00Z"));
+        Map<String, String> names =
+                TrustStateLoader.resolveCanonicalNames(snapshotOf(charlie, alice));
+        assertEquals("Alice", names.get("https://example.org/agent"));
+    }
+
+    @Test
+    void resolveCanonicalNames_skipsUnapprovedRows() {
+        // A higher-ratio row with status=skipped or status=contested must not
+        // beat an approved-but-lower-ratio row, otherwise rejected agents could
+        // shadow the trust-graph's actual chosen name.
+        TrustStateSnapshot.AccountEntry approved = new TrustStateSnapshot.AccountEntry(
+                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.10, 100L,
+                "Approved Name", Instant.parse("2025-01-01T00:00:00Z"));
+        TrustStateSnapshot.AccountEntry skipped = new TrustStateSnapshot.AccountEntry(
+                "pk2", "https://example.org/agent", "skipped", 5, null, null, null,
+                "Skipped Name", Instant.parse("2025-06-01T00:00:00Z"));
+        Map<String, String> names =
+                TrustStateLoader.resolveCanonicalNames(snapshotOf(approved, skipped));
+        assertEquals("Approved Name", names.get("https://example.org/agent"));
+    }
+
+    @Test
+    void resolveCanonicalNames_omitsAgentsWithNoName() {
+        // Approved key, but the declaring intro had no foaf:name. No entry in
+        // the result map → consumer materializer emits no foaf:name triple.
+        TrustStateSnapshot.AccountEntry noName = new TrustStateSnapshot.AccountEntry(
+                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 100L,
+                null, null);
+        Map<String, String> names = TrustStateLoader.resolveCanonicalNames(snapshotOf(noName));
+        assertTrue(names.isEmpty(), "agent with no name across approved keys must not appear");
+        assertNull(names.get("https://example.org/agent"));
+    }
+
+    @Test
+    void resolveCanonicalNames_acceptsToLoadStatusToo() {
+        // toLoad is the second authority-approving status alongside loaded.
+        // Per APPROVED_STATUSES, both should contribute names.
+        TrustStateSnapshot.AccountEntry toLoad = new TrustStateSnapshot.AccountEntry(
+                "pk1", "https://example.org/agent", "toLoad", 1, 1, 0.5, 100L,
+                "ToLoad Name", Instant.parse("2025-01-01T00:00:00Z"));
+        Map<String, String> names = TrustStateLoader.resolveCanonicalNames(snapshotOf(toLoad));
+        assertEquals("ToLoad Name", names.get("https://example.org/agent"));
+    }
+
     @Test
     void accountStateHash_differsAcrossPubkeys() {
         TrustStateSnapshot.AccountEntry a1 = new TrustStateSnapshot.AccountEntry(
-                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000L);
+                "pk1", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000L, null, null);
         TrustStateSnapshot.AccountEntry a2 = new TrustStateSnapshot.AccountEntry(
-                "pk2", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000L);
+                "pk2", "https://example.org/agent", "loaded", 1, 1, 0.5, 1000L, null, null);
         org.junit.jupiter.api.Assertions.assertNotEquals(
                 TrustStateLoader.accountStateHash("trustA", a1),
                 TrustStateLoader.accountStateHash("trustA", a2));

--- a/src/test/java/com/knowledgepixels/query/TrustStateSnapshotTest.java
+++ b/src/test/java/com/knowledgepixels/query/TrustStateSnapshotTest.java
@@ -91,7 +91,7 @@ class TrustStateSnapshotTest {
         TrustStateSnapshot s = TrustStateSnapshot.parse(FIXTURE);
         assertThrows(UnsupportedOperationException.class,
                 () -> s.accounts().add(new TrustStateSnapshot.AccountEntry(
-                        "x", "y", "z", 0, 0, 0.0, 0L)));
+                        "x", "y", "z", 0, 0, 0.0, 0L, null, null)));
     }
 
     @Test
@@ -144,6 +144,77 @@ class TrustStateSnapshotTest {
                 "\"pubkey\": \"edf7482308e4e59fc3f658fbd1fe2a2a9a538de3adce2ec7ad6c5f804461d310\",",
                 "");
         assertThrows(IllegalArgumentException.class, () -> TrustStateSnapshot.parse(json));
+    }
+
+    @Test
+    void parse_extractsNameAndNameCreatedAtWhenPresent() {
+        // Registry-side change (#62): accounts may carry foaf:name + dct:created
+        // of the declaring intro. nameCreatedAt arrives as MongoDB extended JSON
+        // ({"$date": "..."}) when the registry serializes a Date; the parser
+        // must accept that shape as well as plain ISO-8601 strings.
+        String json = """
+                {
+                  "trustStateHash": "abc",
+                  "trustStateCounter": {"$numberLong": "1"},
+                  "createdAt": "2026-04-15T14:16:16Z[Etc/UTC]",
+                  "accounts": [
+                    {
+                      "pubkey": "abcdef",
+                      "agent": "https://orcid.org/0000-0002-1267-0234",
+                      "status": "loaded",
+                      "depth": 1,
+                      "pathCount": 1,
+                      "ratio": 0.5,
+                      "quota": 100,
+                      "name": "Tobias Kuhn",
+                      "nameCreatedAt": {"$date": "2025-11-12T10:30:00Z"}
+                    }
+                  ]
+                }
+                """;
+        TrustStateSnapshot s = TrustStateSnapshot.parse(json);
+        TrustStateSnapshot.AccountEntry a = s.accounts().get(0);
+        assertEquals("Tobias Kuhn", a.name());
+        assertEquals(Instant.parse("2025-11-12T10:30:00Z"), a.nameCreatedAt());
+    }
+
+    @Test
+    void parse_acceptsAccountWithoutNameFields() {
+        // Registry that predates the name field: no "name" / "nameCreatedAt"
+        // keys at all. Parser must treat them as null, not throw — the schema
+        // is additive and consumers must work against either registry version.
+        TrustStateSnapshot s = TrustStateSnapshot.parse(FIXTURE);
+        TrustStateSnapshot.AccountEntry a = s.accounts().get(0);
+        assertNull(a.name());
+        assertNull(a.nameCreatedAt());
+    }
+
+    @Test
+    void parse_acceptsPlainStringNameCreatedAt() {
+        // If the registry ever serializes nameCreatedAt as a plain ISO-8601
+        // string (no $date wrap), the parser must still accept it.
+        String json = """
+                {
+                  "trustStateHash": "abc",
+                  "trustStateCounter": {"$numberLong": "1"},
+                  "createdAt": "2026-04-15T14:16:16Z[Etc/UTC]",
+                  "accounts": [
+                    {
+                      "pubkey": "x",
+                      "agent": "https://example.org/agent",
+                      "status": "loaded",
+                      "depth": 1,
+                      "pathCount": 1,
+                      "ratio": 0.5,
+                      "quota": 100,
+                      "name": "Alice",
+                      "nameCreatedAt": "2025-06-15T09:00:00Z"
+                    }
+                  ]
+                }
+                """;
+        TrustStateSnapshot s = TrustStateSnapshot.parse(json);
+        assertEquals(Instant.parse("2025-06-15T09:00:00Z"), s.accounts().get(0).nameCreatedAt());
     }
 
     @Test


### PR DESCRIPTION
## Status

**Draft** — depends on [`nanopub-registry#113`](https://github.com/knowledgepixels/nanopub-registry/pull/113), which adds the per-account \`name\` + \`nameCreatedAt\` fields to the trust-state snapshot JSON. The schema parser is forward-compatible so this PR is safe to merge before the registry change ships (consumers running against an older registry simply produce no \`foaf:name\` triples), but the live effect only kicks in once both are deployed.

Pairs with [`nanopub-query#89`](https://github.com/knowledgepixels/nanopub-query/pull/89) (observer-tier permissive grants) — that PR's worked-example query in \`design-space-repositories.md\` will need a small follow-up doc update to drop the \`SERVICE <…/full>\` clause, which is intentionally **not** in this PR (the doc edit only makes sense after #89 lands).

## Summary

Consumes the per-account \`name\` + \`nameCreatedAt\` fields from the trust-state snapshot and folds them, at materialisation time, into one canonical \`foaf:name\` triple per approved agent — emitted in the trust-state named graph and mirrored into each new spaces state graph at full-build time.

Result: any consumer reading the trust or spaces state graph gets \`?agent foaf:name ?n\` directly, with no cross-repo \`SERVICE\` to \`/repo/full\`.

## Resolution policy

The two layers were decided up front (see PR #89's discussion) to keep the on-disk schema minimal:

- **Per-\`(agent, pubkey)\`** (registry, #113): keep the name from the intro with the latest \`dct:created\`. First write wins when no current timestamp exists; subsequent writes replace iff strictly newer. Multi-\`foaf:name\` on a single intro: \`MIN(?name)\` lex tiebreak for determinism.
- **Per-agent across keys** (this PR, \`TrustStateLoader.resolveCanonicalNames\`): pick the row with \`MAX(ratio)\` from the agent's *approved* (\`loaded\` / \`toLoad\`) account rows; ties → \`MIN(name)\` lex. Agents with no qualifying row are simply absent from the result map (no triple emitted).

Composed: \"the most-trusted key's freshest declaration\".

## Changes

### Parser — \`TrustStateSnapshot\`

- \`AccountEntry\` extends from 7 to 9 fields, adding optional \`name\` (\`String\`) and \`nameCreatedAt\` (\`Instant\`).
- New \`unwrapDateNullable\` handles MongoDB extended JSON (\`{\"\$date\": \"…\"}\` or \`{\"\$date\": {\"\$numberLong\": \"…\"}}\`), plain ISO-8601 strings, plain numeric epoch-ms, and JSON \`null\`/missing — so the parser works against any reasonable registry serialiser and against pre-#113 registries (where the fields are absent).

### Resolver — \`TrustStateLoader\`

- New static \`resolveCanonicalNames(snapshot)\` returning \`Map<agent, name>\`. Filters to \`APPROVED_STATUSES\` (\`loaded\` / \`toLoad\`), skips rows with null \`ratio\` or null \`name\`, picks \`MAX(ratio)\` per agent, breaks ties on lex-min name.
- \`materialize\` now emits one \`<agent> foaf:name \"…\"\` triple in the trust-state named graph per resolved agent, after the existing \`AccountState\` rows.

### Mirror — \`AuthorityResolver.mirrorTrustState\`

- After copying approved \`AccountState\` rows from the trust state graph into the new spaces state graph, additionally walks all \`?subj foaf:name ?obj\` triples in the trust-state graph and copies them too. The trust loader only emits names for approved agents, so no extra filter is needed here.

### Tests

- \`TrustStateLoaderTest\` (+5): \`resolveCanonicalNames_picksRowWithMaxRatio\`, \`_breaksTiesOnLexMinName\`, \`_skipsUnapprovedRows\`, \`_omitsAgentsWithNoName\`, \`_acceptsToLoadStatusToo\`. Pure-logic tests over the resolver function; no RDF4J / Mongo needed.
- \`TrustStateSnapshotTest\` (+3): \`parse_extractsNameAndNameCreatedAtWhenPresent\` (extended-JSON \`\$date\`), \`parse_acceptsAccountWithoutNameFields\` (forward-compat with pre-#113 registry), \`parse_acceptsPlainStringNameCreatedAt\` (alternative serialisation).
- Existing tests using the 7-arg \`AccountEntry\` constructor updated to 9-arg with \`null, null\` for the new fields.

## Test plan

- [x] \`mvn test\` — 177/177 pass locally (was 169; +8 new tests, 5 existing constructor sites updated)
- [ ] CI green
- [ ] Live verify after #113 + this both deploy:
  - \`/trust-state/<hash>.json\` includes \`name\` + \`nameCreatedAt\` per approved account row.
  - Trust state graph contains \`?agent foaf:name ?n\` triples for approved agents (one per agent, not per pubkey).
  - Spaces state graph (after a full build / pointer flip) mirrors those \`foaf:name\` triples.
  - Consumer query for session30 returns names without a \`SERVICE\` clause (drop \`SERVICE <http://query:9393/repo/full>\` from #89's worked-example query and verify same row count).

## Compatibility

- **Parser** is fully forward-compatible: pre-#113 registry → \`name\`/\`nameCreatedAt\` parsed as null → no \`foaf:name\` triples emitted. Same behaviour as today.
- **Mirror** is harmless when the trust graph has no \`foaf:name\` triples to copy.
- **No data-format change** for existing rows; the new triples are purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)