### PR TITLE
chore(deps): bump nanopub 1.86.2→1.87.1 and rdf4j 5.3.0→5.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,12 +123,12 @@
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-repository-http</artifactId>
-      <version>5.3.0</version>
+      <version>5.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-sail-nativerdf</artifactId>
-      <version>5.3.0</version>
+      <version>5.3.1</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.nanopub</groupId>
       <artifactId>nanopub</artifactId>
-      <version>1.86.2</version>
+      <version>1.87.1</version>
     </dependency>
     <!-- Temporary: dependency on Jitpack for snapshot builds -->
     <!-- <dependency>


### PR DESCRIPTION
## Summary
- `org.nanopub:nanopub` 1.86.2 → 1.87.1 (patch)
- `org.eclipse.rdf4j:rdf4j-repository-http` and `rdf4j-sail-nativerdf` 5.3.0 → 5.3.1 (patch)

Each bump in its own commit. Skipping the `micrometer-registry-prometheus` and major Vert.x / JUnit upgrades for now (separate, more involved work).

## Test plan
- [x] `mvn test` after each bump — 178/178 pass on both