### PR TITLE
Extract gen:isSubSpaceOf declarations and id-prefix triples (#93, PR 1/3)

### DIFF
--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -69,6 +69,8 @@ Every extraction uses a dedicated subject IRI per entry — derived from the ori
 - `npard:` = `<http://purl.org/nanopub/admin/roledecl/>` — subject for `npa:RoleDeclaration` entries (extracted from `gen:SpaceMemberRole` nanopubs)
 - `npadef:` = `<http://purl.org/nanopub/admin/spacedef/>` — subject for `npa:SpaceDefinition` entries (per contributing `gen:Space` nanopub)
 - `npainv:` = `<http://purl.org/nanopub/admin/invalidation/>` — subject for `npa:Invalidation` entries
+- `npasub:` = `<http://purl.org/nanopub/admin/subspace/>` — subject for `npa:SubSpaceDeclaration` entries (one per `(child, parent)` pair from a sub-space-relevant nanopub)
+- `npasl:`  = `<http://purl.org/nanopub/admin/subspacelink/>` — subject for `npa:SubSpaceLink` entries materialised in `npass:<…>`
 
 Each entry carries `npa:viaNanopub <originatingNP>` to link back to the source; the stamped load number goes on that nanopub IRI so all of a nanopub's emitted entries share one stamp:
 
@@ -91,7 +93,8 @@ GRAPH npa:spacesGraph {
   # Aggregate — space-identity; multiple contributing nanopubs reinforce the same triples
   npas:<spaceRef> a npa:SpaceRef ;
                   npa:spaceIri    <spaceIRI> ;
-                  npa:rootNanopub <rootNP> .    # object of gen:hasRootDefinition; <thisNP> if the triple is absent
+                  npa:rootNanopub <rootNP> ;    # object of gen:hasRootDefinition; <thisNP> if the triple is absent
+                  npa:hasIdPrefix <prefix1>, <prefix2>, … .  # all path-prefixes of <spaceIRI> down to host-only; see Sub-space relations
 
   # Per-contributor — one per loaded gen:Space nanopub for this space ref
   npadef:<artifactCode> a npa:SpaceDefinition ;
@@ -133,6 +136,8 @@ If the loaded nanopub is additionally the space's root — detectable by `npa:ro
 ```
 
 These are the trust seed for the admin closure — trusted by construction because the root's NPID is part of the space ref, so no publisher-agent validation is needed. In the rootless transition case the nanopub is its own root, so the same rule applies and its admins seed the per-declaration space ref. Invalidating the root gen:Space nanopub DELETEs the `npadef:` entry (via `npa:viaNanopub`), taking the `npa:hasRootAdmin` seeds with it.
+
+If the assertion contains one or more `<spaceIri> gen:isSubSpaceOf <parentIri>` triples for any declared `<spaceIri>` (rooted or transitional), additionally emit one `npa:SubSpaceDeclaration` per `(spaceIri, parentIri)` pair into `npa:spacesGraph`. See [Sub-space relations](#sub-space-relations).
 
 ### Triples added per `gen:hasRole` nanopub
 
@@ -200,6 +205,10 @@ GRAPH npa:spacesGraph {
 ```
 
 Exactly one of `npa:regularProperty` or `npa:inverseProperty` is emitted per instantiation, matching the predicate direction used in the source nanopub's assertion. Consumers JOIN through the corresponding `npa:RoleDeclaration` (via `gen:hasRegularProperty` / `gen:hasInverseProperty`) to resolve the role IRI and tier.
+
+### Triples added per `gen:isSubSpaceOf` nanopub
+
+Single-triple-assertion dispatch picks up nanopubs whose assertion uses `gen:isSubSpaceOf` as the predicate (the predicate IRI surfaces in the nanopub's type set, the same trick that catches the 14 backcompat role predicates). Every `<childIri> gen:isSubSpaceOf <parentIri>` triple in the assertion emits one `npa:SubSpaceDeclaration` entry — same shape as the embedded path in `gen:Space` extraction. Multi-triple assertions are allowed; one entry per `(child, parent)` pair. Full schema and validation rule live in [Sub-space relations](#sub-space-relations).
 
 ### Triples added per invalidation
 
@@ -427,12 +436,198 @@ Readers are never blocked: during the worker's build the pointer still reference
 
 **Trust-state flip detection.** The materializer reads `npa:thisRepo npa:hasCurrentTrustState` in the `trust` repo at each rebuild-worker wakeup. A changed hash triggers the full-build path; no dedicated notification channel is needed.
 
+## Sub-space relations
+
+A sub-space link is an n-to-n parent/child relation between two spaces, declared via `gen:isSubSpaceOf` (child → parent direction). A space may have multiple super-spaces and multiple sub-spaces.
+
+### Declaration paths
+
+Predicate: `gen:isSubSpaceOf` (in the `gen:` namespace alongside other space terms). Two paths produce the same `npa:SubSpaceDeclaration` extraction entry; downstream rules don't distinguish them:
+
+1. **Embedded** in a `gen:Space` nanopub — `<thisSpaceIri> gen:isSubSpaceOf <parentSpaceIri>` triple in the assertion. One declaration per parent.
+2. **Standalone** `gen:isSubSpaceOf` nanopub — `<childIri> gen:isSubSpaceOf <parentIri>` triple(s) in the assertion. The single-triple-assertion type dispatch catches the predicate; multi-triple assertions are allowed and each pair emits its own declaration.
+
+### Extraction entry (in `npa:spacesGraph`)
+
+```turtle
+GRAPH npa:spacesGraph {
+  npasub:<artifactCode>_<parentHash> a npa:SubSpaceDeclaration ;
+                                     npa:childSpace  <childSpaceIri> ;
+                                     npa:parentSpace <parentSpaceIri> ;
+                                     npa:viaNanopub  <thisNP> ;
+                                     npx:signedBy    <publishingAgent> ;
+                                     npa:pubkeyHash  "<pubkeyHash>" ;
+                                     dct:created     "<timestamp>"^^xsd:dateTime .
+}
+```
+
+`<parentHash> = Utils.createHash(<parentSpaceIri>)` so a single nanopub declaring multiple parents (or, in the standalone path, multiple `(child, parent)` pairs) mints distinct subjects without collision.
+
+### Authority rule
+
+A `(child, parent)` link enters `npass:<…>` iff *an admin of the child* and *an admin of the parent* have together attested to it. Two satisfaction modes:
+
+- **Mode A — single declaration** by a publisher who is admin of both child and parent at materialization time: one `npa:SubSpaceDeclaration` whose `npa:pubkeyHash` resolves (via the mirrored `AccountState` rows) to an agent in both admin closures.
+- **Mode B — two declarations** for the same `(child, parent)` pair, in any combination of paths and any order: a child-side admin's declaration plus a parent-side admin's declaration. Each declaration is inert on its own; the link is admitted when both exist and neither is invalidated.
+
+Admit-pass UPDATE (sketch, runs after the admin closure has settled in the per-tier loop):
+
+```sparql
+INSERT { GRAPH npass:<ts> {
+  ?linkIri a npa:SubSpaceLink ;
+           npa:childSpace  ?child ;
+           npa:parentSpace ?parent ;
+           npa:viaNanopub  ?d_np .
+} }
+WHERE {
+  GRAPH npa:spacesGraph {
+    ?d a npa:SubSpaceDeclaration ;
+       npa:childSpace ?child ;
+       npa:parentSpace ?parent ;
+       npa:pubkeyHash ?pkh ;
+       npa:viaNanopub ?d_np .
+    FILTER NOT EXISTS { ?inv a npa:Invalidation ; npa:invalidates ?d_np . }
+  }
+  GRAPH npass:<ts> {
+    ?acct a npa:AccountState ; npa:agent ?publisher ; npa:pubkey ?pkh .
+  }
+
+  {  # Mode A — publisher is admin of both child and parent
+    FILTER EXISTS { GRAPH npass:<ts> {
+      ?riC a gen:RoleInstantiation ; npa:inverseProperty gen:hasAdmin ;
+           npa:forSpace ?child  ; npa:forAgent ?publisher .
+    } }
+    FILTER EXISTS { GRAPH npass:<ts> {
+      ?riP a gen:RoleInstantiation ; npa:inverseProperty gen:hasAdmin ;
+           npa:forSpace ?parent ; npa:forAgent ?publisher .
+    } }
+  } UNION {  # Mode B — second declaration for the same pair, jointly covering both admin sides
+    GRAPH npa:spacesGraph {
+      ?d2 a npa:SubSpaceDeclaration ;
+          npa:childSpace ?child ;
+          npa:parentSpace ?parent ;
+          npa:pubkeyHash ?pkh2 ;
+          npa:viaNanopub ?d_np2 .
+      FILTER (?d_np2 != ?d_np)
+      FILTER NOT EXISTS { ?inv a npa:Invalidation ; npa:invalidates ?d_np2 . }
+    }
+    GRAPH npass:<ts> {
+      ?acct2 a npa:AccountState ; npa:agent ?publisher2 ; npa:pubkey ?pkh2 .
+    }
+    # Between {publisher, publisher2}, both admin sides are covered.
+    FILTER EXISTS { GRAPH npass:<ts> {
+      ?riA a gen:RoleInstantiation ; npa:inverseProperty gen:hasAdmin ;
+           npa:forSpace ?child .
+      { ?riA npa:forAgent ?publisher . } UNION { ?riA npa:forAgent ?publisher2 . }
+    } }
+    FILTER EXISTS { GRAPH npass:<ts> {
+      ?riB a gen:RoleInstantiation ; npa:inverseProperty gen:hasAdmin ;
+           npa:forSpace ?parent .
+      { ?riB npa:forAgent ?publisher . } UNION { ?riB npa:forAgent ?publisher2 . }
+    } }
+  }
+
+  BIND(IRI(CONCAT(STR(npasl:), MD5(CONCAT(STR(?child), "|", STR(?parent))))) AS ?linkIri)
+  FILTER NOT EXISTS { GRAPH npass:<ts> {
+    ?linkIri a npa:SubSpaceLink .
+  } }
+}
+```
+
+`?linkIri` is minted from `(child, parent)` so the UNION dedups naturally regardless of which declaration is chosen as the `npa:viaNanopub` witness. Mode-A and Mode-B candidates for the same pair collapse to one row.
+
+For consumer convenience the admit pass also emits both directions on the Space IRIs themselves:
+
+```turtle
+GRAPH npass:<ts> {
+  <child>  npa:isSubSpaceOf <parent> .
+  <parent> npa:hasSubSpace  <child>  .
+}
+```
+
+### URL-prefix fallback (for spaces with no explicit declaration)
+
+For every loaded `gen:Space` nanopub, the extractor emits `npa:hasIdPrefix` triples on the `npa:SpaceRef` aggregate, one per intermediate path-prefix of the Space IRI. For `<https://example.org/a/b/c/space>`:
+
+```turtle
+npas:<spaceRef> npa:hasIdPrefix <https://example.org/a/b/c> ,
+                                <https://example.org/a/b> ,
+                                <https://example.org/a> ,
+                                <https://example.org> .
+```
+
+Computation: normalise the Space IRI (strip query, fragment, trailing `/`), then strip path segments one at a time after the `://`, down to host-only. Identity-derived, so reinforced (RDF set semantics) by every contributor.
+
+The fallback admit pass runs in `npass:<…>` *after* the explicit-declaration admit pass:
+
+```sparql
+INSERT { GRAPH npass:<ts> {
+  ?linkIri a npa:SubSpaceLink ;
+           npa:childSpace ?child ;
+           npa:parentSpace ?parent ;
+           npa:derivationKind npa:byUrlPrefix .
+} }
+WHERE {
+  GRAPH npa:spacesGraph {
+    ?childRef  npa:spaceIri ?child ;
+               npa:hasIdPrefix ?parent .
+    ?parentRef npa:spaceIri ?parent .
+  }
+  # Suppress fallback for any child that has any non-invalidated explicit declaration.
+  FILTER NOT EXISTS {
+    GRAPH npa:spacesGraph {
+      ?d a npa:SubSpaceDeclaration ;
+         npa:childSpace ?child ;
+         npa:viaNanopub ?d_np .
+      FILTER NOT EXISTS { ?inv a npa:Invalidation ; npa:invalidates ?d_np . }
+    }
+  }
+  BIND(IRI(CONCAT(STR(npasl:), MD5(CONCAT(STR(?child), "|", STR(?parent))))) AS ?linkIri)
+  FILTER NOT EXISTS { GRAPH npass:<ts> {
+    ?linkIri a npa:SubSpaceLink .
+  } }
+}
+```
+
+Suppression is **per child, all-or-nothing**: any single non-invalidated declaration on a child suppresses every fallback edge for that child. No partial mixing of declared and derived parents — once a space has spoken explicitly, its declarations are canonical.
+
+Tagged with `npa:derivationKind npa:byUrlPrefix` so consumers can render derived links differently or hide them. No authority check — the URL prefix is heuristic, the tag is the warning label.
+
+Fallback edges live **only in `npass:<…>`**, never in `npa:spacesGraph`. Each rebuild regenerates them; no separate cleanup path.
+
+### Invalidation
+
+Standard `npa:viaNanopub` DELETE on the originating declaration. The incremental-update admit query is re-run for affected `(child, parent)` pairs: in Mode B, removing one of two co-declarations causes the existence checks to fail and the link row to come down; in Mode A, removing the sole declaration drops the link directly.
+
+`npa:SubSpaceLink` DELETEs are **structural** — set `npa:needsFullRebuild` per [Operational details](#operational-details). Downstream consumers may have cached parent/child views, and once a child loses its only explicit declaration the URL-prefix fallback should re-engage on rebuild.
+
+### Consumer pattern
+
+Single SPARQL replaces Nanodash's `SpaceRepository.findSubspaces(...)` URL regex + map JOIN:
+
+```sparql
+PREFIX npa: <http://purl.org/nanopub/admin/>
+SELECT ?subspace ?derivation WHERE {
+  GRAPH <http://purl.org/nanopub/admin/graph> {
+    <http://purl.org/nanopub/admin/thisRepo> npa:hasCurrentSpaceState ?g .
+  }
+  GRAPH ?g {
+    ?link a npa:SubSpaceLink ;
+          npa:parentSpace <PARENT_IRI> ;
+          npa:childSpace  ?subspace .
+    OPTIONAL { ?link npa:derivationKind ?derivation . }
+  }
+}
+```
+
+Add `FILTER(!BOUND(?derivation))` to exclude URL-prefix-derived edges; omit it to include them. Querying the inverse direction (find all super-spaces of a given child) uses the same shape with `npa:childSpace <CHILD_IRI>` and `npa:parentSpace ?superspace`.
+
 ## Implementation phases
 
-1. **Raw loading** — `TripleStore` init, loader writes full nanopubs of predefined types into `spaces` and emits add-only extraction triples (including `npa:Invalidation` entries) into `npa:spacesGraph` with `npa:hasLoadNumber` stamps.
-2. **Materialization** — new `AuthorityResolver` drives per-tier SPARQL UPDATE loops on load-number deltas for incremental updates; runs full rebuilds on trust-state flips and on the periodic `npa:needsFullRebuild` signal; manages the `npa:hasCurrentSpaceState` pointer and old-graph cleanup.
+1. **Raw loading** — `TripleStore` init, loader writes full nanopubs of predefined types into `spaces` and emits add-only extraction triples (including `npa:Invalidation` entries) into `npa:spacesGraph` with `npa:hasLoadNumber` stamps. Includes `npa:SubSpaceDeclaration` extraction (both embedded-in-`gen:Space` and standalone `gen:isSubSpaceOf` paths) and `npa:hasIdPrefix` triples on `npa:SpaceRef` aggregates (see [Sub-space relations](#sub-space-relations)).
+2. **Materialization** — new `AuthorityResolver` drives per-tier SPARQL UPDATE loops on load-number deltas for incremental updates; runs full rebuilds on trust-state flips and on the periodic `npa:needsFullRebuild` signal; manages the `npa:hasCurrentSpaceState` pointer and old-graph cleanup. Includes the explicit-declaration sub-space admit pass (Mode A + Mode B), the URL-prefix fallback admit pass (suppressed per child by any non-invalidated declaration), and the structural-rebuild flag on `npa:SubSpaceLink` DELETE.
 3. **Routes / metrics** — `/spaces` listing route (HTML + JSON), Prometheus gauges (rebuild duration, delta size, `processedUpTo` lag, distinct-subject totals).
-4. **Nanodash migration** — publish with `gen:hasRootDefinition` and the predefined type IRIs; replace the 4-query chain with one query that resolves the current `npass:*` graph from the pointer (see [Querying the current space-state graph](#querying-the-current-space-state-graph)); drop `isAdminPubkey` gate and pinned templates/queries.
+4. **Nanodash migration** — publish with `gen:hasRootDefinition` and the predefined type IRIs; replace the 4-query chain with one query that resolves the current `npass:*` graph from the pointer (see [Querying the current space-state graph](#querying-the-current-space-state-graph)); drop `isAdminPubkey` gate and pinned templates/queries. Replace `SpaceRepository.findSubspaces(...)` URL regex with the single-query consumer pattern in [Sub-space relations](#sub-space-relations).
 
 ## Bootstrap
 
@@ -569,6 +764,6 @@ Common UI filters as one-line additions before `GROUP BY`:
 
 ## Verification
 
-- Unit: closures, incremental delta correctness (same result as a full rebuild), invalidation cleanup (sticky, non-cascading), rebuild idempotence.
-- Integration: space definition, admin chain depth ≥ 2, role definition + attachment + instantiation, supersession, trust-state flip (full rebuild + pointer flip + old-graph drop), root retraction.
-- End-to-end: Space page renders from `spaces` alone; steady-state reads do not `SERVICE`-join to `trust` (the mirror step runs at trust-state-flip time via Java-level cross-repo copy, not at read time).
+- Unit: closures, incremental delta correctness (same result as a full rebuild), invalidation cleanup (sticky, non-cascading), rebuild idempotence. Sub-space-specific: `npa:hasIdPrefix` enumeration matches the IRI normalisation (no trailing slash, no host-only-with-extra-segment edge cases).
+- Integration: space definition, admin chain depth ≥ 2, role definition + attachment + instantiation, supersession, trust-state flip (full rebuild + pointer flip + old-graph drop), root retraction. Sub-space-specific: Mode-A admit (single dual-admin publisher); Mode-B admit (two single-side admin publishers, both orderings tested); URL-prefix fallback appears for declaration-less child and is suppressed once any non-invalidated declaration on that child exists; invalidating one of two co-declarations drops the link; invalidating the sole Mode-A declaration drops the link and re-engages the URL-prefix fallback on rebuild.
+- End-to-end: Space page renders from `spaces` alone; steady-state reads do not `SERVICE`-join to `trust` (the mirror step runs at trust-state-flip time via Java-level cross-repo copy, not at read time). Nanodash sub-space panel renders entirely from one query against `npass:<…>` instead of the URL-regex map.

--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -69,8 +69,7 @@ Every extraction uses a dedicated subject IRI per entry — derived from the ori
 - `npard:` = `<http://purl.org/nanopub/admin/roledecl/>` — subject for `npa:RoleDeclaration` entries (extracted from `gen:SpaceMemberRole` nanopubs)
 - `npadef:` = `<http://purl.org/nanopub/admin/spacedef/>` — subject for `npa:SpaceDefinition` entries (per contributing `gen:Space` nanopub)
 - `npainv:` = `<http://purl.org/nanopub/admin/invalidation/>` — subject for `npa:Invalidation` entries
-- `npasub:` = `<http://purl.org/nanopub/admin/subspace/>` — subject for `npa:SubSpaceDeclaration` entries (one per `(child, parent)` pair from a sub-space-relevant nanopub)
-- `npasl:`  = `<http://purl.org/nanopub/admin/subspacelink/>` — subject for `npa:SubSpaceLink` entries materialised in `npass:<…>`
+- `npasub:` = `<http://purl.org/nanopub/admin/subspace/>` — subject for `npa:SubSpaceDeclaration` entries (one per `(child, parent)` pair from a sub-space-relevant nanopub); validated copies retain the same subject in `npass:<…>`
 
 Each entry carries `npa:viaNanopub <originatingNP>` to link back to the source; the stamped load number goes on that nanopub IRI so all of a nanopub's emitted entries share one stamp:
 
@@ -470,14 +469,14 @@ A `(child, parent)` link enters `npass:<…>` iff *an admin of the child* and *a
 - **Mode A — single declaration** by a publisher who is admin of both child and parent at materialization time: one `npa:SubSpaceDeclaration` whose `npa:pubkeyHash` resolves (via the mirrored `AccountState` rows) to an agent in both admin closures.
 - **Mode B — two declarations** for the same `(child, parent)` pair, in any combination of paths and any order: a child-side admin's declaration plus a parent-side admin's declaration. Each declaration is inert on its own; the link is admitted when both exist and neither is invalidated.
 
-Admit-pass UPDATE (sketch, runs after the admin closure has settled in the per-tier loop):
+Admit-pass UPDATE (sketch, runs after the admin closure has settled in the per-tier loop). Validated declarations are copied into `npass:<…>` keeping their `npasub:` subject, matching how `RoleAssignment` and `RoleInstantiation` entries are handled — one row per source declaration, no separate link type:
 
 ```sparql
 INSERT { GRAPH npass:<ts> {
-  ?linkIri a npa:SubSpaceLink ;
-           npa:childSpace  ?child ;
-           npa:parentSpace ?parent ;
-           npa:viaNanopub  ?d_np .
+  ?d a npa:SubSpaceDeclaration ;
+     npa:childSpace  ?child ;
+     npa:parentSpace ?parent ;
+     npa:viaNanopub  ?d_np .
 } }
 WHERE {
   GRAPH npa:spacesGraph {
@@ -527,16 +526,17 @@ WHERE {
     } }
   }
 
-  BIND(IRI(CONCAT(STR(npasl:), MD5(CONCAT(STR(?child), "|", STR(?parent))))) AS ?linkIri)
   FILTER NOT EXISTS { GRAPH npass:<ts> {
-    ?linkIri a npa:SubSpaceLink .
+    ?d a npa:SubSpaceDeclaration .
   } }
 }
 ```
 
-`?linkIri` is minted from `(child, parent)` so the UNION dedups naturally regardless of which declaration is chosen as the `npa:viaNanopub` witness. Mode-A and Mode-B candidates for the same pair collapse to one row.
+Mode B produces *two* rows in the state graph (one per declaration); both share the same `(child, parent)` and mutually validated each other. Consumers use `EXISTS` / `DISTINCT` to ask "does any validated declaration for this pair exist?" — the same shape they already use for role tiers.
 
-For consumer convenience the admit pass also emits both directions on the Space IRIs themselves:
+Per-`viaNanopub` DELETE during invalidation works uniformly: dropping one Mode-B declaration leaves the other in place, but the admit-pass re-runs on the remaining one and finds it no longer has a co-declaration to validate against, so the surviving row's existence check fails and it comes down too.
+
+For consumer convenience the admit pass also emits both directions on the Space IRIs themselves, with `FILTER NOT EXISTS` dedup so Mode B doesn't produce duplicate triples:
 
 ```turtle
 GRAPH npass:<ts> {
@@ -558,14 +558,16 @@ npas:<spaceRef> npa:hasIdPrefix <https://example.org/a/b/c> ,
 
 Computation: normalise the Space IRI (strip query, fragment, trailing `/`), then strip path segments one at a time after the `://`, down to host-only. Identity-derived, so reinforced (RDF set semantics) by every contributor.
 
-The fallback admit pass runs in `npass:<…>` *after* the explicit-declaration admit pass:
+The fallback admit pass runs in `npass:<…>` *after* the explicit-declaration admit pass. Fallback edges are emitted directly as `<child> npa:isSubSpaceOf <parent>` / `<parent> npa:hasSubSpace <child>` triples on the Space IRIs, tagged on the relationship via a reified `npa:derivedSubSpaceLink` row so consumers can hide them:
 
 ```sparql
 INSERT { GRAPH npass:<ts> {
-  ?linkIri a npa:SubSpaceLink ;
-           npa:childSpace ?child ;
-           npa:parentSpace ?parent ;
-           npa:derivationKind npa:byUrlPrefix .
+  <child>  npa:isSubSpaceOf <parent> .
+  <parent> npa:hasSubSpace  <child>  .
+  ?tagIri a npa:DerivedSubSpaceLink ;
+          npa:childSpace ?child ;
+          npa:parentSpace ?parent ;
+          npa:derivationKind npa:byUrlPrefix .
 } }
 WHERE {
   GRAPH npa:spacesGraph {
@@ -582,16 +584,14 @@ WHERE {
       FILTER NOT EXISTS { ?inv a npa:Invalidation ; npa:invalidates ?d_np . }
     }
   }
-  BIND(IRI(CONCAT(STR(npasl:), MD5(CONCAT(STR(?child), "|", STR(?parent))))) AS ?linkIri)
-  FILTER NOT EXISTS { GRAPH npass:<ts> {
-    ?linkIri a npa:SubSpaceLink .
-  } }
+  BIND(IRI(CONCAT("http://purl.org/nanopub/admin/derivedlink/",
+                  MD5(CONCAT(STR(?child), "|", STR(?parent))))) AS ?tagIri)
 }
 ```
 
 Suppression is **per child, all-or-nothing**: any single non-invalidated declaration on a child suppresses every fallback edge for that child. No partial mixing of declared and derived parents — once a space has spoken explicitly, its declarations are canonical.
 
-Tagged with `npa:derivationKind npa:byUrlPrefix` so consumers can render derived links differently or hide them. No authority check — the URL prefix is heuristic, the tag is the warning label.
+The `npa:DerivedSubSpaceLink` tag carries `npa:derivationKind npa:byUrlPrefix` so consumers that want to exclude derived links can `FILTER NOT EXISTS { ?tag npa:childSpace ?child ; npa:parentSpace ?parent ; npa:derivationKind npa:byUrlPrefix }`. No authority check on the underlying derivation — the URL prefix is heuristic, the tag is the warning label.
 
 Fallback edges live **only in `npass:<…>`**, never in `npa:spacesGraph`. Each rebuild regenerates them; no separate cleanup path.
 
@@ -599,33 +599,42 @@ Fallback edges live **only in `npass:<…>`**, never in `npa:spacesGraph`. Each 
 
 Standard `npa:viaNanopub` DELETE on the originating declaration. The incremental-update admit query is re-run for affected `(child, parent)` pairs: in Mode B, removing one of two co-declarations causes the existence checks to fail and the link row to come down; in Mode A, removing the sole declaration drops the link directly.
 
-`npa:SubSpaceLink` DELETEs are **structural** — set `npa:needsFullRebuild` per [Operational details](#operational-details). Downstream consumers may have cached parent/child views, and once a child loses its only explicit declaration the URL-prefix fallback should re-engage on rebuild.
+Validated `npa:SubSpaceDeclaration` DELETEs in `npass:<…>` are **structural** — set `npa:needsFullRebuild` per [Operational details](#operational-details). Downstream consumers may have cached parent/child views, and once a child loses its only explicit declaration the URL-prefix fallback should re-engage on rebuild.
 
 ### Consumer pattern
 
-Single SPARQL replaces Nanodash's `SpaceRepository.findSubspaces(...)` URL regex + map JOIN:
+Single SPARQL replaces Nanodash's `SpaceRepository.findSubspaces(...)` URL regex + map JOIN. The convenience direct triples cover both validated declarations and URL-prefix derivations, so the basic query shape is:
 
 ```sparql
 PREFIX npa: <http://purl.org/nanopub/admin/>
-SELECT ?subspace ?derivation WHERE {
+SELECT DISTINCT ?subspace WHERE {
   GRAPH <http://purl.org/nanopub/admin/graph> {
     <http://purl.org/nanopub/admin/thisRepo> npa:hasCurrentSpaceState ?g .
   }
-  GRAPH ?g {
-    ?link a npa:SubSpaceLink ;
-          npa:parentSpace <PARENT_IRI> ;
-          npa:childSpace  ?subspace .
-    OPTIONAL { ?link npa:derivationKind ?derivation . }
+  GRAPH ?g { <PARENT_IRI> npa:hasSubSpace ?subspace . }
+}
+```
+
+To exclude URL-prefix-derived edges, filter against the `npa:DerivedSubSpaceLink` tag:
+
+```sparql
+GRAPH ?g {
+  <PARENT_IRI> npa:hasSubSpace ?subspace .
+  FILTER NOT EXISTS {
+    ?tag a npa:DerivedSubSpaceLink ;
+         npa:parentSpace <PARENT_IRI> ;
+         npa:childSpace ?subspace ;
+         npa:derivationKind npa:byUrlPrefix .
   }
 }
 ```
 
-Add `FILTER(!BOUND(?derivation))` to exclude URL-prefix-derived edges; omit it to include them. Querying the inverse direction (find all super-spaces of a given child) uses the same shape with `npa:childSpace <CHILD_IRI>` and `npa:parentSpace ?superspace`.
+Querying the inverse direction (find all super-spaces of a given child) uses `<CHILD_IRI> npa:isSubSpaceOf ?superspace` with the same dedup / tag-filter shape.
 
 ## Implementation phases
 
 1. **Raw loading** — `TripleStore` init, loader writes full nanopubs of predefined types into `spaces` and emits add-only extraction triples (including `npa:Invalidation` entries) into `npa:spacesGraph` with `npa:hasLoadNumber` stamps. Includes `npa:SubSpaceDeclaration` extraction (both embedded-in-`gen:Space` and standalone `gen:isSubSpaceOf` paths) and `npa:hasIdPrefix` triples on `npa:SpaceRef` aggregates (see [Sub-space relations](#sub-space-relations)).
-2. **Materialization** — new `AuthorityResolver` drives per-tier SPARQL UPDATE loops on load-number deltas for incremental updates; runs full rebuilds on trust-state flips and on the periodic `npa:needsFullRebuild` signal; manages the `npa:hasCurrentSpaceState` pointer and old-graph cleanup. Includes the explicit-declaration sub-space admit pass (Mode A + Mode B), the URL-prefix fallback admit pass (suppressed per child by any non-invalidated declaration), and the structural-rebuild flag on `npa:SubSpaceLink` DELETE.
+2. **Materialization** — new `AuthorityResolver` drives per-tier SPARQL UPDATE loops on load-number deltas for incremental updates; runs full rebuilds on trust-state flips and on the periodic `npa:needsFullRebuild` signal; manages the `npa:hasCurrentSpaceState` pointer and old-graph cleanup. Includes the explicit-declaration sub-space admit pass (Mode A + Mode B, copying validated `npa:SubSpaceDeclaration` rows into `npass:<…>`), the URL-prefix fallback admit pass (suppressed per child by any non-invalidated declaration), and the structural-rebuild flag on validated-declaration DELETE.
 3. **Routes / metrics** — `/spaces` listing route (HTML + JSON), Prometheus gauges (rebuild duration, delta size, `processedUpTo` lag, distinct-subject totals).
 4. **Nanodash migration** — publish with `gen:hasRootDefinition` and the predefined type IRIs; replace the 4-query chain with one query that resolves the current `npass:*` graph from the pointer (see [Querying the current space-state graph](#querying-the-current-space-state-graph)); drop `isAdminPubkey` gate and pinned templates/queries. Replace `SpaceRepository.findSubspaces(...)` URL regex with the single-query consumer pattern in [Sub-space relations](#sub-space-relations).
 

--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -575,13 +575,15 @@ WHERE {
                npa:hasIdPrefix ?parent .
     ?parentRef npa:spaceIri ?parent .
   }
-  # Suppress fallback for any child that has any non-invalidated explicit declaration.
+  # Suppress fallback for any child that already has a validated declaration in
+  # npass:<…>. We check against the validated rows (not raw extraction-graph
+  # declarations) so an unapproved or in-flight Mode B declaration doesn't
+  # silently hide both the URL-prefix fallback and the (still-invalid) explicit
+  # relation. Run order matters: the explicit-declaration admit pass must commit
+  # first so this NOT EXISTS sees the validated set.
   FILTER NOT EXISTS {
-    GRAPH npa:spacesGraph {
-      ?d a npa:SubSpaceDeclaration ;
-         npa:childSpace ?child ;
-         npa:viaNanopub ?d_np .
-      FILTER NOT EXISTS { ?inv a npa:Invalidation ; npa:invalidates ?d_np . }
+    GRAPH npass:<ts> {
+      ?d a npa:SubSpaceDeclaration ; npa:childSpace ?child .
     }
   }
   BIND(IRI(CONCAT("http://purl.org/nanopub/admin/derivedlink/",
@@ -589,7 +591,7 @@ WHERE {
 }
 ```
 
-Suppression is **per child, all-or-nothing**: any single non-invalidated declaration on a child suppresses every fallback edge for that child. No partial mixing of declared and derived parents — once a space has spoken explicitly, its declarations are canonical.
+Suppression is **per child, all-or-nothing**: any single validated declaration on a child suppresses every fallback edge for that child. No partial mixing of approved and derived parents — once a space has *successfully* spoken (admin-of-both gate passed), its declarations are canonical. A child whose only declarations are unapproved or in-flight Mode B still gets URL-prefix fallback, so it isn't silently dropped.
 
 The `npa:DerivedSubSpaceLink` tag carries `npa:derivationKind npa:byUrlPrefix` so consumers that want to exclude derived links can `FILTER NOT EXISTS { ?tag npa:childSpace ?child ; npa:parentSpace ?parent ; npa:derivationKind npa:byUrlPrefix }`. No authority check on the underlying derivation — the URL prefix is heuristic, the tag is the warning label.
 

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -88,8 +88,9 @@ public final class SpacesExtractor {
         boolean isSpaceMemberRole = types.contains(GEN.SPACE_MEMBER_ROLE);
         boolean isRoleInstantiation = types.contains(GEN.ROLE_INSTANTIATION)
                 || anyMatch(types, BackcompatRolePredicates.ALL);
+        boolean isSubSpaceOf = types.contains(GEN.IS_SUB_SPACE_OF);
 
-        if (!isSpace && !isHasRole && !isSpaceMemberRole && !isRoleInstantiation) {
+        if (!isSpace && !isHasRole && !isSpaceMemberRole && !isRoleInstantiation && !isSubSpaceOf) {
             return Collections.emptyList();
         }
 
@@ -97,6 +98,7 @@ public final class SpacesExtractor {
         if (isHasRole) extractHasRole(np, ctx, out);
         if (isSpaceMemberRole) extractSpaceMemberRole(np, ctx, out);
         if (isRoleInstantiation) extractRoleInstantiation(np, ctx, out);
+        if (isSubSpaceOf) extractSubSpaceOf(np, ctx, out);
 
         return out;
     }
@@ -131,6 +133,7 @@ public final class SpacesExtractor {
                 || types.contains(GEN.HAS_ROLE)
                 || types.contains(GEN.SPACE_MEMBER_ROLE)
                 || types.contains(GEN.ROLE_INSTANTIATION)
+                || types.contains(GEN.IS_SUB_SPACE_OF)
                 || anyMatch(types, BackcompatRolePredicates.ALL);
     }
 
@@ -191,6 +194,18 @@ public final class SpacesExtractor {
         out.add(vf.createStatement(refIri, RDF.TYPE, SpacesVocab.SPACE_REF, GRAPH));
         out.add(vf.createStatement(refIri, SpacesVocab.SPACE_IRI, spaceIri, GRAPH));
         out.add(vf.createStatement(refIri, SpacesVocab.ROOT_NANOPUB, rootUri, GRAPH));
+
+        // Identity-derived path-prefix enumeration powering the URL-prefix sub-space
+        // fallback in the materializer. Same triples on every contributor (RDF set
+        // semantics dedups them).
+        for (IRI prefix : enumerateIdPrefixes(spaceIri)) {
+            out.add(vf.createStatement(refIri, SpacesVocab.HAS_ID_PREFIX, prefix, GRAPH));
+        }
+
+        // Embedded gen:isSubSpaceOf triples in this gen:Space nanopub: emit one
+        // SubSpaceDeclaration per (spaceIri, parentIri) pair. Same shape as the
+        // standalone path; downstream rules don't distinguish them.
+        emitSubSpaceDeclarations(np, ctx, spaceIri, out);
 
         // Per-contributor entry: signer, pubkey, created-at, link back to nanopub.
         out.add(vf.createStatement(defIri, RDF.TYPE, SpacesVocab.SPACE_DEFINITION, GRAPH));
@@ -391,6 +406,115 @@ public final class SpacesExtractor {
     private static BackcompatRolePredicates.Direction directionFor(IRI predicate) {
         if (GEN.HAS_ADMIN.equals(predicate)) return BackcompatRolePredicates.Direction.INVERSE;
         return BackcompatRolePredicates.DIRECTIONS.get(predicate);
+    }
+
+    // ---------------- gen:isSubSpaceOf (standalone path) ----------------
+
+    /**
+     * Standalone {@code gen:isSubSpaceOf} nanopub: every
+     * {@code <childIri> gen:isSubSpaceOf <parentIri>} triple in the assertion emits one
+     * {@code npa:SubSpaceDeclaration}. Multi-triple assertions are allowed; one entry
+     * per pair. Self-loops ({@code <X> gen:isSubSpaceOf <X>}) are rejected.
+     */
+    private static void extractSubSpaceOf(Nanopub np, Context ctx, List<Statement> out) {
+        for (Statement st : np.getAssertion()) {
+            if (!st.getPredicate().equals(GEN.IS_SUB_SPACE_OF)) continue;
+            if (!(st.getSubject() instanceof IRI childIri)) continue;
+            if (!(st.getObject() instanceof IRI parentIri)) continue;
+            emitSubSpaceDeclaration(np, ctx, childIri, parentIri, out);
+        }
+    }
+
+    /**
+     * Embedded path: scan a {@code gen:Space} nanopub's assertion for
+     * {@code <spaceIri> gen:isSubSpaceOf <parentIri>} triples (subject must equal the
+     * Space IRI we're emitting an entry for, so the subspace declaration is bound to
+     * this particular Space). Self-loops are rejected.
+     */
+    private static void emitSubSpaceDeclarations(Nanopub np, Context ctx, IRI spaceIri,
+                                                 List<Statement> out) {
+        for (Statement st : np.getAssertion()) {
+            if (!st.getPredicate().equals(GEN.IS_SUB_SPACE_OF)) continue;
+            if (!spaceIri.equals(st.getSubject())) continue;
+            if (!(st.getObject() instanceof IRI parentIri)) continue;
+            emitSubSpaceDeclaration(np, ctx, spaceIri, parentIri, out);
+        }
+    }
+
+    /**
+     * Emits one {@code npa:SubSpaceDeclaration} entry, keyed by
+     * {@code (artifactCode, parentHash)} so a single nanopub can declare multiple
+     * parents without subject collision. Self-loops are silently dropped.
+     */
+    private static void emitSubSpaceDeclaration(Nanopub np, Context ctx, IRI childIri,
+                                                IRI parentIri, List<Statement> out) {
+        if (childIri.equals(parentIri)) {
+            log.debug("Ignoring self-loop sub-space declaration on {} in {}", childIri, np.getUri());
+            return;
+        }
+        String parentHash = Utils.createHash(parentIri);
+        IRI subject = SpacesVocab.forSubSpaceDeclaration(ctx.artifactCode(), parentHash);
+
+        // Idempotence: the embedded and standalone paths can both fire on the same
+        // (np, child, parent) combination if a gen:Space nanopub somehow ends up typed
+        // gen:isSubSpaceOf as well. Skip if we've already emitted the type triple for
+        // this subject.
+        Statement typeSt = vf.createStatement(subject, RDF.TYPE, SpacesVocab.SUB_SPACE_DECLARATION, GRAPH);
+        if (out.contains(typeSt)) return;
+
+        out.add(typeSt);
+        out.add(vf.createStatement(subject, SpacesVocab.CHILD_SPACE, childIri, GRAPH));
+        out.add(vf.createStatement(subject, SpacesVocab.PARENT_SPACE, parentIri, GRAPH));
+        out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, np.getUri(), GRAPH));
+        addProvenance(subject, ctx, out);
+    }
+
+    // ---------------- ID-prefix enumeration ----------------
+
+    /**
+     * Enumerates all intermediate path-prefixes of a Space IRI, after normalisation,
+     * for the URL-prefix sub-space fallback. Strips query / fragment / trailing slash,
+     * then strips path segments one at a time after the {@code ://} scheme separator,
+     * down to host-only. Returns an empty list for inputs without a scheme separator
+     * or without any path beyond the host.
+     *
+     * <p>Examples:
+     * <pre>
+     *   https://example.org/a/b/c/space  →  [https://example.org/a/b/c,
+     *                                        https://example.org/a/b,
+     *                                        https://example.org/a,
+     *                                        https://example.org]
+     *   https://example.org/x/           →  [https://example.org]   (trailing slash stripped)
+     *   https://example.org/space?q=1    →  [https://example.org]   (query stripped)
+     *   https://example.org              →  []                       (no path to strip)
+     * </pre>
+     */
+    static List<IRI> enumerateIdPrefixes(IRI spaceIri) {
+        String s = spaceIri.stringValue();
+        int hash = s.indexOf('#');
+        if (hash >= 0) s = s.substring(0, hash);
+        int qmark = s.indexOf('?');
+        if (qmark >= 0) s = s.substring(0, qmark);
+        while (s.endsWith("/")) s = s.substring(0, s.length() - 1);
+
+        int schemeEnd = s.indexOf("://");
+        if (schemeEnd < 0) return Collections.emptyList();
+        int hostStart = schemeEnd + 3;
+        int hostEnd = s.indexOf('/', hostStart);
+        if (hostEnd < 0) return Collections.emptyList();   // host-only, nothing to strip
+
+        List<IRI> prefixes = new ArrayList<>();
+        // Walk back from the right, stripping one segment per step, until we hit host-only.
+        String current = s.substring(0, s.lastIndexOf('/'));
+        while (current.length() > hostEnd) {
+            prefixes.add(vf.createIRI(current));
+            int slash = current.lastIndexOf('/');
+            if (slash <= hostEnd) break;
+            current = current.substring(0, slash);
+        }
+        // Always include the host-only root.
+        prefixes.add(vf.createIRI(s.substring(0, hostEnd)));
+        return prefixes;
     }
 
     // ---------------- shared helpers ----------------

--- a/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
@@ -75,6 +75,14 @@ public class GEN {
      */
     public static final IRI ROLE_ASSIGNMENT = VocabUtils.createIRI(NAMESPACE, "RoleAssignment");
 
+    /**
+     * Predicate declaring a space as a sub-space of another. n-to-n; child &rarr; parent
+     * direction. May appear inside a {@code gen:Space} nanopub's assertion (embedded
+     * path) or as a single-triple-assertion of its own (the predicate IRI is
+     * type-dispatched the same way the backwards-compat role predicates are).
+     */
+    public static final IRI IS_SUB_SPACE_OF = VocabUtils.createIRI(NAMESPACE, "isSubSpaceOf");
+
     private GEN() {
     }
 

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
@@ -21,6 +21,7 @@ import org.nanopub.vocabulary.NPA;
  *   <li>{@link #NPARA_NAMESPACE} ({@code npara:}) — {@link #forRoleAssignment(String) role-attachment} entries (from {@code gen:hasRole} nanopubs).
  *   <li>{@link #NPARD_NAMESPACE} ({@code npard:}) — {@link #forRoleDeclaration(String) role-declaration} entries (from {@code gen:SpaceMemberRole} nanopubs).
  *   <li>{@link #NPAINV_NAMESPACE} ({@code npainv:}) — {@link #forInvalidation(String) invalidation} entries.
+ *   <li>{@link #NPASUB_NAMESPACE} ({@code npasub:}) — {@link #forSubSpaceDeclaration(String, String) sub-space-declaration} entries (one per {@code (child, parent)} pair).
  *   <li>{@link #NPASS_NAMESPACE} ({@code npass:}) — space-state graph IRIs (used by the materializer in a later PR).
  * </ul>
  */
@@ -40,6 +41,8 @@ public final class SpacesVocab {
     public static final String NPARD_NAMESPACE = "http://purl.org/nanopub/admin/roledecl/";
     /** Namespace for invalidation entries ({@code npainv:<artifactCode>}). */
     public static final String NPAINV_NAMESPACE = "http://purl.org/nanopub/admin/invalidation/";
+    /** Namespace for sub-space-declaration entries ({@code npasub:<artifactCode>_<parentHash>}). */
+    public static final String NPASUB_NAMESPACE = "http://purl.org/nanopub/admin/subspace/";
     /** Namespace for space-state graph IRIs ({@code npass:<trustStateHash>_<loadCounter>}). */
     public static final String NPASS_NAMESPACE = "http://purl.org/nanopub/admin/spacestate/";
 
@@ -56,6 +59,9 @@ public final class SpacesVocab {
 
     /** RDF type for an invalidation event recorded as add-only data. */
     public static final IRI INVALIDATION = vf.createIRI(NPA.NAMESPACE, "Invalidation");
+
+    /** RDF type for a sub-space-declaration extraction entry. */
+    public static final IRI SUB_SPACE_DECLARATION = vf.createIRI(NPA.NAMESPACE, "SubSpaceDeclaration");
 
     // -------- Properties on extraction entries --------
 
@@ -100,6 +106,19 @@ public final class SpacesVocab {
 
     /** Links an {@link #INVALIDATION} entry to the nanopub it invalidates. */
     public static final IRI INVALIDATES = vf.createIRI(NPA.NAMESPACE, "invalidates");
+
+    /** Links a {@link #SUB_SPACE_DECLARATION} to the child Space IRI. */
+    public static final IRI CHILD_SPACE = vf.createIRI(NPA.NAMESPACE, "childSpace");
+
+    /** Links a {@link #SUB_SPACE_DECLARATION} to the parent Space IRI. */
+    public static final IRI PARENT_SPACE = vf.createIRI(NPA.NAMESPACE, "parentSpace");
+
+    /**
+     * Links a {@link #SPACE_REF} aggregate to each intermediate path-prefix of its
+     * Space IRI (down to host-only). Identity-derived; reinforced by every contributor.
+     * Used by the URL-prefix sub-space fallback in the materializer.
+     */
+    public static final IRI HAS_ID_PREFIX = vf.createIRI(NPA.NAMESPACE, "hasIdPrefix");
 
     // -------- Named graphs & repo pointers --------
 
@@ -153,6 +172,18 @@ public final class SpacesVocab {
     /** Mints {@code npainv:<artifactCode>} for an invalidation entry. */
     public static IRI forInvalidation(String artifactCode) {
         return vf.createIRI(NPAINV_NAMESPACE, artifactCode);
+    }
+
+    /**
+     * Mints {@code npasub:<artifactCode>_<parentHash>} for a sub-space-declaration entry.
+     * Including the parent-IRI hash in the local name lets a single nanopub declare
+     * multiple parents without subject collision.
+     *
+     * @param artifactCode trusty-URI artifact code of the originating nanopub
+     * @param parentHash   {@code Utils.createHash(<parentSpaceIri>)}
+     */
+    public static IRI forSubSpaceDeclaration(String artifactCode, String parentHash) {
+        return vf.createIRI(NPASUB_NAMESPACE, artifactCode + "_" + parentHash);
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -1,15 +1,18 @@
 package com.knowledgepixels.query;
 
+import static com.knowledgepixels.query.vocabulary.SpacesVocab.CHILD_SPACE;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.CURRENT_LOAD_COUNTER;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.FOR_AGENT;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.FOR_SPACE;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.FOR_SPACE_REF;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.HAS_DEFINITION;
+import static com.knowledgepixels.query.vocabulary.SpacesVocab.HAS_ID_PREFIX;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.HAS_ROLE_TYPE;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.HAS_ROOT_ADMIN;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.INVALIDATES;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.INVALIDATION;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.INVERSE_PROPERTY;
+import static com.knowledgepixels.query.vocabulary.SpacesVocab.PARENT_SPACE;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.PUBKEY_HASH;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.REGULAR_PROPERTY;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.ROLE;
@@ -19,6 +22,7 @@ import static com.knowledgepixels.query.vocabulary.SpacesVocab.SPACES_GRAPH;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.SPACE_DEFINITION;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.SPACE_IRI;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.SPACE_REF;
+import static com.knowledgepixels.query.vocabulary.SpacesVocab.SUB_SPACE_DECLARATION;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.VIA_NANOPUB;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.forInvalidation;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.forRoleAssignment;
@@ -26,6 +30,7 @@ import static com.knowledgepixels.query.vocabulary.SpacesVocab.forRoleDeclaratio
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.forRoleInstantiation;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.forSpaceDefinition;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.forSpaceRef;
+import static com.knowledgepixels.query.vocabulary.SpacesVocab.forSubSpaceDeclaration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -109,6 +114,7 @@ class SpacesExtractorTest {
         assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.HAS_ROLE)));
         assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.SPACE_MEMBER_ROLE)));
         assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.ROLE_INSTANTIATION)));
+        assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.IS_SUB_SPACE_OF)));
     }
 
     @Test
@@ -336,6 +342,185 @@ class SpacesExtractorTest {
         assertContains(out, subject, REGULAR_PROPERTY, plansToAttend);
         assertContains(out, subject, FOR_AGENT, MEMBER_AGENT);       // subject side
         assertDoesNotContain(out, subject, INVERSE_PROPERTY, plansToAttend);
+    }
+
+    // ---------------- gen:isSubSpaceOf ----------------
+
+    @Test
+    void extract_subSpaceStandalone_singlePair_emitsSubSpaceDeclaration() throws Exception {
+        IRI parentSpace = vf.createIRI("https://example.org/spaces/parent");
+        // Single-triple assertion: NanopubUtils.getTypes promotes the predicate to a type.
+        Nanopub np = creator()
+                .assertion(SPACE_IRI_1, GEN.IS_SUB_SPACE_OF, parentSpace)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forSubSpaceDeclaration(ARTIFACT_CODE, Utils.createHash(parentSpace));
+
+        assertAllInSpacesGraph(out);
+        assertContains(out, subject, RDF.TYPE, SUB_SPACE_DECLARATION);
+        assertContains(out, subject, CHILD_SPACE, SPACE_IRI_1);
+        assertContains(out, subject, PARENT_SPACE, parentSpace);
+        assertContains(out, subject, VIA_NANOPUB, NP_URI);
+        assertContains(out, subject, NPX.SIGNED_BY, SIGNER_AGENT);
+    }
+
+    @Test
+    void extract_subSpaceStandalone_multiPair_emitsOnePerParent() throws Exception {
+        // Multi-triple assertion: predicate dispatch may not fire on multi-triple
+        // assertions, so add the type explicitly via npx:hasNanopubType.
+        IRI parent1 = vf.createIRI("https://example.org/spaces/parent1");
+        IRI parent2 = vf.createIRI("https://example.org/spaces/parent2");
+        Nanopub np = creator()
+                .type(GEN.IS_SUB_SPACE_OF)
+                .assertion(SPACE_IRI_1, GEN.IS_SUB_SPACE_OF, parent1)
+                .assertion(SPACE_IRI_1, GEN.IS_SUB_SPACE_OF, parent2)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subj1 = forSubSpaceDeclaration(ARTIFACT_CODE, Utils.createHash(parent1));
+        IRI subj2 = forSubSpaceDeclaration(ARTIFACT_CODE, Utils.createHash(parent2));
+
+        assertContains(out, subj1, RDF.TYPE, SUB_SPACE_DECLARATION);
+        assertContains(out, subj1, PARENT_SPACE, parent1);
+        assertContains(out, subj2, RDF.TYPE, SUB_SPACE_DECLARATION);
+        assertContains(out, subj2, PARENT_SPACE, parent2);
+        // Distinct subjects — different parent hashes.
+        assertFalse(subj1.equals(subj2), "Per-parent subjects must differ");
+    }
+
+    @Test
+    void extract_subSpaceStandalone_selfLoop_isRejected() throws Exception {
+        Nanopub np = creator()
+                .assertion(SPACE_IRI_1, GEN.IS_SUB_SPACE_OF, SPACE_IRI_1)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        assertTrue(out.isEmpty(),
+                "Self-loop sub-space declaration should produce no extraction; got: " + out);
+    }
+
+    @Test
+    void extract_subSpaceEmbeddedInGenSpace_emitsSubSpaceDeclaration() throws Exception {
+        IRI parentSpace = vf.createIRI("https://example.org/spaces/parent");
+        Nanopub np = creator()
+                .type(GEN.SPACE)
+                .assertion(SPACE_IRI_1, RDF.TYPE, GEN.SPACE)
+                .assertion(SPACE_IRI_1, GEN.HAS_ROOT_DEFINITION, NP_URI)
+                .assertion(SPACE_IRI_1, GEN.HAS_ADMIN, ADMIN_AGENT_1)
+                .assertion(SPACE_IRI_1, GEN.IS_SUB_SPACE_OF, parentSpace)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forSubSpaceDeclaration(ARTIFACT_CODE, Utils.createHash(parentSpace));
+
+        // Sub-space declaration emitted alongside the SpaceRef / SpaceDefinition.
+        assertContains(out, subject, RDF.TYPE, SUB_SPACE_DECLARATION);
+        assertContains(out, subject, CHILD_SPACE, SPACE_IRI_1);
+        assertContains(out, subject, PARENT_SPACE, parentSpace);
+        assertContains(out, subject, VIA_NANOPUB, NP_URI);
+
+        // SpaceRef + SpaceDefinition still present (regression guard).
+        String spaceRef = ARTIFACT_CODE + "_" + Utils.createHash(SPACE_IRI_1);
+        assertContains(out, forSpaceRef(spaceRef), RDF.TYPE, SPACE_REF);
+        assertContains(out, forSpaceDefinition(ARTIFACT_CODE), RDF.TYPE, SPACE_DEFINITION);
+    }
+
+    @Test
+    void extract_subSpaceEmbeddedInGenSpace_subjectMustBeDeclaredSpaceIri() throws Exception {
+        // A gen:isSubSpaceOf triple whose subject isn't one of the declared Space IRIs
+        // is ignored on the embedded path. Authors who want to declare for an unrelated
+        // IRI should publish a separate gen:isSubSpaceOf nanopub.
+        IRI unrelated = vf.createIRI("https://example.org/somewhere/else");
+        IRI parentSpace = vf.createIRI("https://example.org/spaces/parent");
+        Nanopub np = creator()
+                .type(GEN.SPACE)
+                .assertion(SPACE_IRI_1, RDF.TYPE, GEN.SPACE)
+                .assertion(SPACE_IRI_1, GEN.HAS_ROOT_DEFINITION, NP_URI)
+                .assertion(SPACE_IRI_1, GEN.HAS_ADMIN, ADMIN_AGENT_1)
+                .assertion(unrelated, GEN.IS_SUB_SPACE_OF, parentSpace)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI rejectedSubject = forSubSpaceDeclaration(ARTIFACT_CODE, Utils.createHash(parentSpace));
+        assertDoesNotContain(out, rejectedSubject, RDF.TYPE, SUB_SPACE_DECLARATION);
+    }
+
+    @Test
+    void extract_genSpace_emitsHasIdPrefixOnSpaceRef() throws Exception {
+        // Regression / new-behaviour check: every gen:Space extraction now decorates
+        // the SpaceRef aggregate with the path-prefix enumeration.
+        Nanopub np = creator()
+                .type(GEN.SPACE)
+                .assertion(SPACE_IRI_1, RDF.TYPE, GEN.SPACE)
+                .assertion(SPACE_IRI_1, GEN.HAS_ROOT_DEFINITION, NP_URI)
+                .assertion(SPACE_IRI_1, GEN.HAS_ADMIN, ADMIN_AGENT_1)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        String spaceRef = ARTIFACT_CODE + "_" + Utils.createHash(SPACE_IRI_1);
+        IRI refIri = forSpaceRef(spaceRef);
+        // SPACE_IRI_1 = https://example.org/spaces/alpha, so prefixes are
+        // https://example.org/spaces and https://example.org.
+        assertContains(out, refIri, HAS_ID_PREFIX, vf.createIRI("https://example.org/spaces"));
+        assertContains(out, refIri, HAS_ID_PREFIX, vf.createIRI("https://example.org"));
+    }
+
+    // ---------------- ID-prefix enumeration ----------------
+
+    @Test
+    void enumerateIdPrefixes_typicalPath_returnsAllIntermediates() {
+        List<IRI> out = SpacesExtractor.enumerateIdPrefixes(
+                vf.createIRI("https://example.org/a/b/c/space"));
+        assertEquals(List.of(
+                vf.createIRI("https://example.org/a/b/c"),
+                vf.createIRI("https://example.org/a/b"),
+                vf.createIRI("https://example.org/a"),
+                vf.createIRI("https://example.org")
+        ), out);
+    }
+
+    @Test
+    void enumerateIdPrefixes_singleSegment_returnsHostOnly() {
+        List<IRI> out = SpacesExtractor.enumerateIdPrefixes(
+                vf.createIRI("https://example.org/space"));
+        assertEquals(List.of(vf.createIRI("https://example.org")), out);
+    }
+
+    @Test
+    void enumerateIdPrefixes_trailingSlash_isStripped() {
+        List<IRI> out = SpacesExtractor.enumerateIdPrefixes(
+                vf.createIRI("https://example.org/a/b/"));
+        assertEquals(List.of(
+                vf.createIRI("https://example.org/a"),
+                vf.createIRI("https://example.org")
+        ), out);
+    }
+
+    @Test
+    void enumerateIdPrefixes_queryAndFragment_areStripped() {
+        List<IRI> out = SpacesExtractor.enumerateIdPrefixes(
+                vf.createIRI("https://example.org/a/space?x=1#frag"));
+        assertEquals(List.of(
+                vf.createIRI("https://example.org/a"),
+                vf.createIRI("https://example.org")
+        ), out);
+    }
+
+    @Test
+    void enumerateIdPrefixes_hostOnlyIri_returnsEmpty() {
+        assertTrue(SpacesExtractor.enumerateIdPrefixes(
+                vf.createIRI("https://example.org")).isEmpty());
+        assertTrue(SpacesExtractor.enumerateIdPrefixes(
+                vf.createIRI("https://example.org/")).isEmpty());
+    }
+
+    @Test
+    void enumerateIdPrefixes_nonHttpScheme_returnsEmptyForUrn() {
+        // URNs have no path-style structure; the enumerator returns empty rather than
+        // try to chop colon-separated NIDs.
+        assertTrue(SpacesExtractor.enumerateIdPrefixes(
+                vf.createIRI("urn:nbn:de:0287-2003-12345")).isEmpty());
     }
 
     // ---------------- Invalidation ----------------


### PR DESCRIPTION
## Summary

First of three PRs implementing #93 (sub-space handling). Pure raw-layer extraction — no materialiser changes, no behaviour change downstream.

- Recognises `gen:isSubSpaceOf` in two paths and emits one `npa:SubSpaceDeclaration` per `(child, parent)` pair into `npa:spacesGraph`:
  - **Embedded** in a `gen:Space` nanopub (`<thisSpaceIri> gen:isSubSpaceOf <parent>` triples in the assertion).
  - **Standalone** `gen:isSubSpaceOf` nanopub (single-triple-assertion type dispatch).
- Rejects self-loops (`<X> gen:isSubSpaceOf <X>`) at extraction.
- Enumerates path-prefixes of every Space IRI (down to host-only) as `npa:hasIdPrefix` triples on the `npa:SpaceRef` aggregate. Powers the URL-prefix sub-space fallback in PR 3.
- Design doc updated: new "Sub-space relations" section covering predicate, declaration paths, authority rule (Mode A single dual-admin / Mode B two single-side admins), URL-prefix fallback, invalidation, consumer pattern.

The materialiser doesn't read any of the new triples yet, so downstream behaviour is unchanged.

## Follow-up PRs

- **PR 2** — `AuthorityResolver` admit pass for explicit declarations (Mode A + Mode B), structural-rebuild flag on `npa:SubSpaceLink` DELETE.
- **PR 3** — URL-prefix fallback admit pass with per-child suppression.
- **PR 4** (Nanodash repo) — replace `SpaceRepository.findSubspaces(...)` URL regex with the SPARQL consumer pattern.

## Test plan

- [x] `SpacesExtractorTest` extended from 17 → 27 tests, all green.
- [x] Full unit-test suite (190 tests) green; no regressions.
- [ ] Integration verification deferred to PR 2 (where the materialiser starts consuming these triples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)