### PR TITLE
Validate sub-space declarations in materialiser admit pass (#93, PR 2/3)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -241,16 +241,16 @@ public final class AuthorityResolver {
         long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
         lastSubjectTotals = totals;
         lastInsertedTriplesTotal = (long) counts.admin + counts.attachment
-                + counts.maintainer + counts.member + counts.observer;
+                + counts.maintainer + counts.member + counts.observer + counts.subSpace;
         lastFullBuildDurationMs = durationMs;
         lastProcessedUpToLag = 0L;
         log.info("AuthorityResolver: full build complete — graph={} mirrored={} rows loadCounter={} "
                         + "subjects: adminRIs={} attachmentRAs={} nonAdminRIs={} "
-                        + "(inserted-triples: admin={} attachment={} maintainer={} member={} observer={}) "
+                        + "(inserted-triples: admin={} attachment={} maintainer={} member={} observer={} subspace={}) "
                         + "durationMs={}",
                 newGraph, mirrored, loadCounter,
                 totals.adminRIs(), totals.attachmentRAs(), totals.nonAdminRIs(),
-                counts.admin, counts.attachment, counts.maintainer, counts.member, counts.observer,
+                counts.admin, counts.attachment, counts.maintainer, counts.member, counts.observer, counts.subSpace,
                 durationMs);
     }
 
@@ -295,17 +295,22 @@ public final class AuthorityResolver {
         TierInsertedTriples counts = runAllTierLoops(graph, lastProcessed);
         boolean structuralAdds = (counts.admin > 0)
                 || (counts.attachment > 0)
+                || (counts.subSpace > 0)
                 || newRoleDeclarationsArrived(lastProcessed);
         if (structuralAdds) {
-            // Late-arrival sweep: only the leaf tiers (attachment/maintainer/member/observer)
-            // can promote candidates whose enabling event arrived in this same cycle. Skip
-            // the admin tier — its only enabling event is the admin grant itself, already
-            // handled by the regular pass.
+            // Late-arrival sweep: leaf tiers (attachment/maintainer/member/observer)
+            // can promote candidates whose enabling event arrived in this same cycle.
+            // Sub-space admit is also re-run here for Mode-B late-arrival (a new
+            // partner declaration can validate an older primary that the regular
+            // pass's load-number filter excluded). Skip the admin tier — its only
+            // enabling event is the admin grant itself, already handled by the
+            // regular pass.
             TierInsertedTriples lateCounts = runDownstreamWithoutLoadFilter(graph);
             counts.attachment += lateCounts.attachment;
             counts.maintainer += lateCounts.maintainer;
             counts.member     += lateCounts.member;
             counts.observer   += lateCounts.observer;
+            counts.subSpace   += lateCounts.subSpace;
         }
 
         writeProcessedUpTo(graph, currentLoadCounter);
@@ -314,15 +319,15 @@ public final class AuthorityResolver {
         long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
         lastSubjectTotals = totals;
         lastInsertedTriplesTotal = (long) counts.admin + counts.attachment
-                + counts.maintainer + counts.member + counts.observer;
+                + counts.maintainer + counts.member + counts.observer + counts.subSpace;
         lastIncrementalCycleDurationMs = durationMs;
         log.info("AuthorityResolver: incremental cycle complete — graph={} delta=({}, {}] "
                         + "subjects: adminRIs={} attachmentRAs={} nonAdminRIs={} "
-                        + "(inserted-triples: admin={} attachment={} maintainer={} member={} observer={}) "
+                        + "(inserted-triples: admin={} attachment={} maintainer={} member={} observer={} subspace={}) "
                         + "structuralInvalidation={} structuralAdds={} durationMs={}",
                 graph, lastProcessed, currentLoadCounter,
                 totals.adminRIs(), totals.attachmentRAs(), totals.nonAdminRIs(),
-                counts.admin, counts.attachment, counts.maintainer, counts.member, counts.observer,
+                counts.admin, counts.attachment, counts.maintainer, counts.member, counts.observer, counts.subSpace,
                 structuralInvalidation, structuralAdds, durationMs);
     }
 
@@ -353,6 +358,15 @@ public final class AuthorityResolver {
                             roleDeclarationInvalidationCheckWhere(lastProcessed))) {
             structural = true;
         }
+        // Sub-space declarations are structural — invalidating one (Mode A) or one
+        // of two co-declarations (Mode B) changes the validated parent/child
+        // topology. The DELETE removes the per-declaration row; the convenience
+        // direct triples are left sticky and cleaned on the next periodic rebuild.
+        if (wouldInvalidate(graph, lastProcessed, /*adminPinned=*/ false,
+                            subSpaceInvalidationCheckWhere(graph, lastProcessed))) {
+            executeUpdate(subSpaceInvalidationDelete(graph, lastProcessed));
+            structural = true;
+        }
         // Leaf-tier RI deletes — no flag.
         executeUpdate(leafTierInvalidationDelete(graph, lastProcessed));
         if (structural) setNeedsFullRebuild();
@@ -367,6 +381,10 @@ public final class AuthorityResolver {
      */
     TierInsertedTriples runDownstreamWithoutLoadFilter(IRI graph) {
         TierInsertedTriples c = new TierInsertedTriples();
+        // Sub-space late-arrival: catches Mode-B candidates whose primary
+        // declaration is older than lastProcessed but whose partner just landed.
+        c.subSpace = runTierLabeled("subspace(late)", graph,
+                subSpaceAdmitUpdate(graph, -1));
         c.attachment = runTierLabeled("attachment(late)", graph,
                 attachmentValidationUpdate(graph, -1));
         c.maintainer = runTierLabeled("maintainer(late)", graph,
@@ -432,6 +450,7 @@ public final class AuthorityResolver {
         int maintainer;
         int member;
         int observer;
+        int subSpace;
     }
 
     /**
@@ -451,6 +470,10 @@ public final class AuthorityResolver {
     TierInsertedTriples runAllTierLoops(IRI graph, long lastProcessed) {
         TierInsertedTriples c = new TierInsertedTriples();
         c.admin = runTierLabeled("admin", graph, adminTierUpdate(graph, lastProcessed));
+        // Sub-space admit runs after admin closure has settled (Mode A + Mode B both
+        // need the admin set). Independent of role tiers — order between subspace
+        // and attachment / maintainer / member / observer doesn't matter.
+        c.subSpace = runTierLabeled("subspace", graph, subSpaceAdmitUpdate(graph, lastProcessed));
         c.attachment = runTierLabeled("attachment", graph,
                 attachmentValidationUpdate(graph, lastProcessed));
         c.maintainer = runTierLabeled("maintainer", graph, nonAdminTierUpdate(graph, lastProcessed,
@@ -878,6 +901,126 @@ public final class AuthorityResolver {
                 NPA.GRAPH);
     }
 
+    /**
+     * Sub-space admit pass. Copies validated {@code npa:SubSpaceDeclaration}
+     * extraction rows into the space-state graph (preserving the {@code npasub:}
+     * subject) and emits convenience {@code <child> npa:isSubSpaceOf <parent>} and
+     * {@code <parent> npa:hasSubSpace <child>} direct triples. Two satisfaction
+     * modes joined by UNION:
+     * <ul>
+     *   <li>Mode A — the declaration's publisher is a validated admin of both the
+     *       child and the parent space.</li>
+     *   <li>Mode B — a different non-invalidated declaration for the same
+     *       {@code (child, parent)} pair exists, and the two publishers between
+     *       them cover both admin sides (i.e. one of them is admin of the child,
+     *       one of them is admin of the parent — possibly the same one twice if
+     *       both happen to be admin of both).</li>
+     * </ul>
+     *
+     * <p>Mode-B late-arrival: when only the partner declaration is new in this
+     * cycle (the primary is older than {@code lastProcessed}), the load-number
+     * filter on {@code ?np} excludes the candidate. The late-arrival sweep
+     * ({@link #runDownstreamWithoutLoadFilter}) re-runs this pass without the
+     * load filter and catches it.
+     */
+    static String subSpaceAdmitUpdate(IRI graph, long lastProcessed) {
+        return """
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                INSERT { GRAPH <%3$s> {
+                  ?d a npa:SubSpaceDeclaration ;
+                     npa:childSpace  ?child ;
+                     npa:parentSpace ?parent ;
+                     npa:viaNanopub  ?np .
+                  ?child  npa:isSubSpaceOf ?parent .
+                  ?parent npa:hasSubSpace  ?child  .
+                } }
+                WHERE {
+                  # 1. Anchor: candidate declarations from the extraction graph.
+                  GRAPH <%4$s> {
+                    ?d a npa:SubSpaceDeclaration ;
+                       npa:childSpace  ?child ;
+                       npa:parentSpace ?parent ;
+                       npa:pubkeyHash  ?pkh ;
+                       npa:viaNanopub  ?np .
+                  }
+                  # 2. Mirror: resolve ?pkh → ?publisher via the trust-approved row.
+                  GRAPH <%3$s> {
+                    ?acct a npa:AccountState ;
+                          npa:pubkey ?pkh ;
+                          npa:agent  ?publisher .
+                  }
+                  # 3. Authority gate.
+                  {
+                    # Mode A — publisher is admin of BOTH child and parent.
+                    FILTER EXISTS { GRAPH <%3$s> {
+                      ?riC a gen:RoleInstantiation ;
+                           npa:inverseProperty gen:hasAdmin ;
+                           npa:forSpace ?child ;
+                           npa:forAgent ?publisher .
+                    } }
+                    FILTER EXISTS { GRAPH <%3$s> {
+                      ?riP a gen:RoleInstantiation ;
+                           npa:inverseProperty gen:hasAdmin ;
+                           npa:forSpace ?parent ;
+                           npa:forAgent ?publisher .
+                    } }
+                  }
+                  UNION
+                  {
+                    # Mode B — co-declaration whose publisher covers the side this
+                    # one's publisher doesn't. Between {publisher, publisher2},
+                    # both admin sides must be covered.
+                    GRAPH <%4$s> {
+                      ?d2 a npa:SubSpaceDeclaration ;
+                          npa:childSpace  ?child ;
+                          npa:parentSpace ?parent ;
+                          npa:pubkeyHash  ?pkh2 ;
+                          npa:viaNanopub  ?np2 .
+                      FILTER (?np2 != ?np)
+                    }
+                    %8$s
+                    GRAPH <%3$s> {
+                      ?acct2 a npa:AccountState ;
+                             npa:pubkey ?pkh2 ;
+                             npa:agent  ?publisher2 .
+                    }
+                    FILTER EXISTS { GRAPH <%3$s> {
+                      ?riA a gen:RoleInstantiation ;
+                           npa:inverseProperty gen:hasAdmin ;
+                           npa:forSpace ?child .
+                      { ?riA npa:forAgent ?publisher } UNION { ?riA npa:forAgent ?publisher2 }
+                    } }
+                    FILTER EXISTS { GRAPH <%3$s> {
+                      ?riB a gen:RoleInstantiation ;
+                           npa:inverseProperty gen:hasAdmin ;
+                           npa:forSpace ?parent .
+                      { ?riB npa:forAgent ?publisher } UNION { ?riB npa:forAgent ?publisher2 }
+                    } }
+                  }
+                  # 4. Invalidation filter on the primary declaration's nanopub.
+                  %6$s
+                  # 5. Load-number filter on bound ?np.
+                  GRAPH <%7$s> {
+                    ?np npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
+                  }
+                  # 6. Dedup last.
+                  FILTER NOT EXISTS { GRAPH <%3$s> {
+                    ?d a npa:SubSpaceDeclaration .
+                  } }
+                }
+                """.formatted(
+                NPA.NAMESPACE,
+                GEN.NAMESPACE,
+                graph,
+                SpacesVocab.SPACES_GRAPH,
+                lastProcessed,
+                invalidationFilter("np"),
+                NPA.GRAPH,
+                invalidationFilter("np2"));
+    }
+
     // ---------------- Invalidation templates (incremental cycle) ----------------
 
     /**
@@ -1012,6 +1155,53 @@ public final class AuthorityResolver {
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
                 SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed);
+    }
+
+    /**
+     * WHERE clause shared by the sub-space invalidation ASK precheck and the
+     * matching DELETE. Identifies validated {@code npa:SubSpaceDeclaration} rows
+     * in the space-state graph whose {@code npa:viaNanopub} equals the target of
+     * an {@code npa:Invalidation} that landed in {@code (lastProcessed, ∞)}.
+     */
+    static String subSpaceInvalidationCheckWhere(IRI graph, long lastProcessed) {
+        return String.format("""
+                  GRAPH <%1$s> {
+                    ?d a npa:SubSpaceDeclaration ;
+                       npa:viaNanopub ?np .
+                  }
+                  GRAPH <%2$s> {
+                    ?inv a npa:Invalidation ;
+                         npa:invalidates ?np ;
+                         npa:viaNanopub  ?invNp .
+                  }
+                  GRAPH <%3$s> {
+                    ?invNp npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %4$d)
+                  }
+                """, graph, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed);
+    }
+
+    /**
+     * DELETE template for validated {@code npa:SubSpaceDeclaration} rows whose
+     * source nanopub was invalidated. Removes the per-declaration row by subject;
+     * the convenience direct triples ({@code <child> npa:isSubSpaceOf <parent>}
+     * and inverse) are left sticky and cleaned by the next periodic full rebuild
+     * (same staleness policy as admin-RI invalidation — see {@code
+     * doc/design-space-repositories.md} on the structural-rebuild flag).
+     */
+    static String subSpaceInvalidationDelete(IRI graph, long lastProcessed) {
+        return String.format("""
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                DELETE { GRAPH <%3$s> {
+                  ?d ?p ?o .
+                } }
+                WHERE {
+                  GRAPH <%3$s> { ?d ?p ?o . }
+                %4$s
+                }
+                """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
+                subSpaceInvalidationCheckWhere(graph, lastProcessed));
     }
 
     /** Wraps an ASK by joining the shared prefixes. */

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -206,4 +206,109 @@ class AuthorityResolverTest {
                 "must skip admin-pinned RIs (those are handled by adminInvalidationDelete)");
     }
 
+    // ---------------- Sub-space admit + invalidation (PR 2) ----------------
+
+    @Test
+    void subSpaceAdmitUpdate_copiesDeclarationAndEmitsDirectTriples() {
+        String sparql = AuthorityResolver.subSpaceAdmitUpdate(TEST_GRAPH, 17);
+        assertTrue(sparql.contains("INSERT"), "INSERT clause");
+        // Per-declaration row preserved with viaNanopub provenance.
+        assertTrue(sparql.contains("npa:SubSpaceDeclaration"),
+                "SubSpaceDeclaration type inserted");
+        assertTrue(sparql.contains("npa:childSpace"), "childSpace predicate");
+        assertTrue(sparql.contains("npa:parentSpace"), "parentSpace predicate");
+        assertTrue(sparql.contains("npa:viaNanopub"), "viaNanopub provenance preserved");
+        // Convenience direct triples on Space IRIs themselves.
+        assertTrue(sparql.contains("?child  npa:isSubSpaceOf ?parent"),
+                "direct child→parent triple emitted");
+        assertTrue(sparql.contains("?parent npa:hasSubSpace  ?child"),
+                "direct parent→child triple emitted");
+    }
+
+    @Test
+    void subSpaceAdmitUpdate_modeAChecksDualAdminPublisher() {
+        String sparql = AuthorityResolver.subSpaceAdmitUpdate(TEST_GRAPH, 0);
+        // Mode A — two FILTER EXISTS on admin-tier RoleInstantiations, one for child,
+        // one for parent, both with the same publisher.
+        assertTrue(sparql.contains("?riC"), "Mode A admin RI for child bound");
+        assertTrue(sparql.contains("?riP"), "Mode A admin RI for parent bound");
+        // Whitespace-tolerant check for "?riC ... npa:forSpace ?child ... npa:forAgent ?publisher".
+        java.util.regex.Pattern modeAChild = java.util.regex.Pattern.compile(
+                "\\?riC[\\s\\S]*?npa:forSpace\\s+\\?child[\\s\\S]*?npa:forAgent\\s+\\?publisher");
+        java.util.regex.Pattern modeAParent = java.util.regex.Pattern.compile(
+                "\\?riP[\\s\\S]*?npa:forSpace\\s+\\?parent[\\s\\S]*?npa:forAgent\\s+\\?publisher");
+        assertTrue(modeAChild.matcher(sparql).find(),
+                "Mode A: same publisher must be admin of child");
+        assertTrue(modeAParent.matcher(sparql).find(),
+                "Mode A: same publisher must be admin of parent");
+    }
+
+    @Test
+    void subSpaceAdmitUpdate_modeBChecksTwoDeclarationsCoveringBothSides() {
+        String sparql = AuthorityResolver.subSpaceAdmitUpdate(TEST_GRAPH, 0);
+        // Mode B — co-declaration ?d2 with a different ?np2.
+        assertTrue(sparql.contains("UNION"),
+                "Mode A and Mode B joined by UNION");
+        assertTrue(sparql.contains("?d2 a npa:SubSpaceDeclaration"),
+                "Mode B co-declaration bound");
+        assertTrue(sparql.contains("FILTER (?np2 != ?np)"),
+                "co-declaration must be a different nanopub");
+        assertTrue(sparql.contains("?publisher2"),
+                "second publisher bound from the co-declaration's pubkey");
+        // Each side's admin check accepts either publisher (so they jointly cover both).
+        assertTrue(sparql.contains("?riA npa:forAgent ?publisher } UNION { ?riA npa:forAgent ?publisher2"),
+                "Mode B child-side admin check unions both publishers");
+        assertTrue(sparql.contains("?riB npa:forAgent ?publisher } UNION { ?riB npa:forAgent ?publisher2"),
+                "Mode B parent-side admin check unions both publishers");
+    }
+
+    @Test
+    void subSpaceAdmitUpdate_hasDeltaAndInvalidationFiltersAndDedup() {
+        String sparql = AuthorityResolver.subSpaceAdmitUpdate(TEST_GRAPH, 17);
+        assertTrue(sparql.contains("FILTER (?ln > 17)"),
+                "load-number delta filter on the primary declaration");
+        // Two invalidation filters (np primary, np2 co-declaration). Both produced
+        // by the helper, so we know they're outside the GRAPH block.
+        assertTrue(sparql.contains("?_inv_np "),
+                "invalidation filter for primary nanopub");
+        assertTrue(sparql.contains("?_inv_np2 "),
+                "invalidation filter for Mode B co-declaration");
+        // Dedup against the state graph's existing SubSpaceDeclaration rows.
+        java.util.regex.Pattern dedup = java.util.regex.Pattern.compile(
+                "FILTER\\s+NOT\\s+EXISTS\\s*\\{\\s*GRAPH\\s+<" + java.util.regex.Pattern.quote(TEST_GRAPH.stringValue())
+                        + ">\\s*\\{\\s*\\?d\\s+a\\s+npa:SubSpaceDeclaration");
+        assertTrue(dedup.matcher(sparql).find(),
+                "dedup excludes already-validated declarations");
+    }
+
+    @Test
+    void subSpaceInvalidationDelete_targetsSubSpaceDeclarationRowsOnly() {
+        String sparql = AuthorityResolver.subSpaceInvalidationDelete(TEST_GRAPH, 5);
+        assertTrue(sparql.contains("DELETE"), "DELETE clause");
+        assertTrue(sparql.contains("npa:SubSpaceDeclaration"),
+                "scoped to SubSpaceDeclaration rows");
+        assertTrue(sparql.contains("npa:Invalidation"),
+                "joins the Invalidation extraction");
+        assertTrue(sparql.contains("npa:invalidates ?np"),
+                "links invalidation to the source nanopub");
+        assertTrue(sparql.contains("FILTER (?ln > 5)"),
+                "delta filter on the invalidator's load number");
+        // Convenience direct triples (subject = ?child / ?parent) are NOT removed
+        // here — they're left sticky and cleaned by the next periodic rebuild.
+        // The DELETE pattern is keyed on ?d (the per-declaration subject).
+        assertFalse(sparql.contains("?child npa:isSubSpaceOf"),
+                "direct triples are not part of the DELETE — sticky until rebuild");
+    }
+
+    @Test
+    void subSpaceInvalidationCheckWhere_allowsAskOnlyUse() {
+        String where = AuthorityResolver.subSpaceInvalidationCheckWhere(TEST_GRAPH, 0);
+        assertTrue(where.contains("npa:SubSpaceDeclaration"),
+                "scoped to SubSpaceDeclaration rows in the state graph");
+        assertTrue(where.contains("npa:Invalidation"),
+                "joins the Invalidation extraction");
+        assertTrue(where.contains("FILTER (?ln > 0)"),
+                "delta filter on the invalidator's load number");
+    }
+
 }


### PR DESCRIPTION
## Summary

Second of three PRs for #93 (sub-space handling). Adds the explicit-declaration admit pass to `AuthorityResolver`, completing the server-side path from extraction (PR 1, #94) to validated `npass:<…>` rows.

- New SPARQL template `subSpaceAdmitUpdate` — Mode A (single dual-admin publisher) and Mode B (two declarations whose publishers between them cover both admin sides) joined by UNION.
- Validated `npa:SubSpaceDeclaration` rows are copied into `npass:<…>` keeping their `npasub:` subject, plus convenience `<child> npa:isSubSpaceOf <parent>` and `<parent> npa:hasSubSpace <child>` direct triples in the same INSERT clause.
- Wired into `runAllTierLoops` (after the admin closure), the late-arrival sweep (`runDownstreamWithoutLoadFilter` — for Mode B partner late-arrival), and `applyInvalidations` (per-`viaNanopub` DELETE on the per-declaration row; sets the `npa:needsFullRebuild` flag since sub-space links are structural).
- Convenience direct triples are left sticky on invalidation and cleaned by the next periodic rebuild — same staleness policy as admin-RI invalidation.
- `structuralAdds` trigger now includes `counts.subSpace > 0` so a Mode B partner arriving in a cycle re-fires the sweep.

## Follow-up PRs

- **PR 3** — URL-prefix fallback admit pass (uses the `npa:hasIdPrefix` triples PR 1 already emits) with per-child suppression based on validated rows in `npass:<…>`. After this lands the basic `<parent> npa:hasSubSpace ?subspace` consumer query gives "approved + URL-derived for orphans" semantics with no silent-drop edge case.
- **PR 4** (Nanodash repo) — replace `SpaceRepository.findSubspaces(...)` URL regex with the SPARQL consumer pattern.

## Test plan

- [x] `AuthorityResolverTest` extended from 12 → 18 tests, all green. Pure-logic template-structure assertions matching the existing pattern (RDF4J UPDATE doesn't behave reliably under the project's mixed dependency versions, so live integration is the validation surface — same approach as the existing admin/attachment/role-tier tests).
- [x] Full unit-test suite (196 tests) green; no regressions.
- [ ] Live integration verification deferred to PR 3 once URL-prefix fallback lands and end-to-end behaviour can be exercised together against a real deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)