### PR TITLE
fix: allow setResetting() from LOADING_INITIAL and RESETTING

### DIFF
--- a/src/main/java/com/knowledgepixels/query/StatusController.java
+++ b/src/main/java/com/knowledgepixels/query/StatusController.java
@@ -234,11 +234,14 @@ public class StatusController {
 
     /**
      * Transition the service to the RESETTING state, resetting the load counter to -1.
-     * This is triggered when a registry reset is detected (setupId changed or counter decreased).
+     * This is triggered when a registry reset is detected (setupId changed or counter decreased),
+     * or when FORCE_RESYNC is set on startup. Accepts any post-initialize source state:
+     * a reset discards prior load progress, so it's valid from LOADING_INITIAL (crashed mid-init),
+     * LOADING_UPDATES, READY, or RESETTING (retry after a crashed prior reset).
      */
     public void setResetting() {
         synchronized (this) {
-            if (state != State.READY && state != State.LOADING_UPDATES) {
+            if (state == State.LAUNCHING) {
                 throw new IllegalStateException("Cannot transition to RESETTING, as the " + "current state is " + state);
             }
             updateState(State.RESETTING, -1);

--- a/src/test/java/com/knowledgepixels/query/StatusControllerTest.java
+++ b/src/test/java/com/knowledgepixels/query/StatusControllerTest.java
@@ -227,7 +227,7 @@ class StatusControllerTest {
     }
 
     @Test
-    void setResettingFromInvalidStatesThrows() {
+    void setResettingFromLaunchingThrows() {
         try (MockedStatic<TripleStore> mockedTripleStoreStatic = mockStatic(TripleStore.class)) {
             StatusController controller = StatusController.get();
             mockedTripleStoreStatic.when(TripleStore::get).thenReturn(mock(TripleStore.class));
@@ -237,12 +237,48 @@ class StatusControllerTest {
 
             controller.initialize();
 
-            // LAUNCHING -> RESETTING should throw
+            // LAUNCHING -> RESETTING should throw (uninitialized state machine)
             assertThrows(IllegalStateException.class, controller::setResetting);
+        }
+    }
 
-            // LOADING_INITIAL -> RESETTING should throw
-            controller.updateState(StatusController.State.LOADING_INITIAL, 0);
-            assertThrows(IllegalStateException.class, controller::setResetting);
+    @Test
+    void setResettingFromLoadingInitial() {
+        // FORCE_RESYNC on a service that previously crashed mid-initial-load
+        // leaves the persisted state at LOADING_INITIAL. A reset from that state
+        // must succeed so the resync path isn't blocked.
+        try (MockedStatic<TripleStore> mockedTripleStoreStatic = mockStatic(TripleStore.class)) {
+            StatusController controller = StatusController.get();
+            mockedTripleStoreStatic.when(TripleStore::get).thenReturn(mock(TripleStore.class));
+            when(TripleStore.get().getAdminRepoConnection()).thenReturn(mock(RepositoryConnection.class));
+            when(TripleStore.get().getAdminRepoConnection().getValueFactory()).thenReturn(SimpleValueFactory.getInstance());
+            when(TripleStore.get().getAdminRepoConnection().getStatements(any(), any(), any(), any())).thenReturn(mock(RepositoryResult.class));
+
+            controller.initialize();
+            controller.updateState(StatusController.State.LOADING_INITIAL, 42);
+            controller.setResetting();
+
+            assertEquals(StatusController.State.RESETTING, controller.getState().state);
+            assertEquals(-1, controller.getState().loadCounter);
+        }
+    }
+
+    @Test
+    void setResettingFromResetting() {
+        // A crashed prior reset attempt should be retryable.
+        try (MockedStatic<TripleStore> mockedTripleStoreStatic = mockStatic(TripleStore.class)) {
+            StatusController controller = StatusController.get();
+            mockedTripleStoreStatic.when(TripleStore::get).thenReturn(mock(TripleStore.class));
+            when(TripleStore.get().getAdminRepoConnection()).thenReturn(mock(RepositoryConnection.class));
+            when(TripleStore.get().getAdminRepoConnection().getValueFactory()).thenReturn(SimpleValueFactory.getInstance());
+            when(TripleStore.get().getAdminRepoConnection().getStatements(any(), any(), any(), any())).thenReturn(mock(RepositoryResult.class));
+
+            controller.initialize();
+            controller.updateState(StatusController.State.RESETTING, -1);
+            controller.setResetting();
+
+            assertEquals(StatusController.State.RESETTING, controller.getState().state);
+            assertEquals(-1, controller.getState().loadCounter);
         }
     }
 


### PR DESCRIPTION
## Summary

- A live instance with `FORCE_RESYNC=true` and persisted state `LOADING_INITIAL` (typical after a previous crash mid-initial-load) is stuck in a restart loop. The `FORCE_RESYNC` block in `MainVerticle.start()` calls `StatusController.setResetting()`, which only accepted `READY` or `LOADING_UPDATES` as source states. The throw bubbles to the init thread's catch, which logs `"Initial load failed, terminating..."` and calls `Runtime.exit(1)`.
- A reset is semantically "discard prior load progress, restart from -1" — valid from any post-initialize state. Loosen the guard to reject only `LAUNCHING` (state machine not yet initialized).
- Also makes `RESETTING → RESETTING` (retry of a crashed prior reset) idempotent, and fixes the same latent hole in `JellyNanopubLoader.performResync()` for free.

## Test plan

- [x] `StatusControllerTest` updated: `setResettingFromInvalidStatesThrows` split into `setResettingFromLaunchingThrows`; added `setResettingFromLoadingInitial` (the live failure scenario) and `setResettingFromResetting`. All 16 tests pass.
- [ ] On the affected live instance: restart with `FORCE_RESYNC=true` and persisted state `LOADING_INITIAL`; confirm the resync proceeds instead of looping on `IllegalStateException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)