### PR TITLE
Surface and contain silent load-time failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,12 @@ services:
     # Source branch: https://github.com/Ostrzyciel/rdf4j/tree/piotr/merged-fixes-2025-12-10
     # (Commented out because it seems it doesn't have curl installed, which is needed for the healthcheck.)
     #image: ostrzyciel/rdf4j-workbench-tomcat:5.2.2-SNAPSHOT-b
-    image: eclipse/rdf4j-workbench:5.2.2-tomcat
+    image: eclipse/rdf4j-workbench:5.3.1-tomcat
     restart: unless-stopped
+    # Start as root so init.sh can apt-get install curl (missing from the
+    # 5.3.1-tomcat image but required by the healthcheck). init.sh drops to
+    # the tomcat user before launching the JVM.
+    user: "0"
     environment:
       - JAVA_OPTS=-Dorg.eclipse.rdf4j.client.http.connectionTimeout=10000 -Dorg.eclipse.rdf4j.client.http.connectionRequestTimeout=10000 -Dorg.eclipse.rdf4j.client.http.socketTimeout=10000
     volumes:
@@ -44,15 +48,23 @@ services:
       - "8081:8080"
     entrypoint: /var/entrypoint/init.sh
     healthcheck:
-        test: >
-          curl -fsS --retry 2 --max-time 10 --retry-delay 2 --retry-max-time 10 --retry-connrefused \
-            "http://localhost:8080/rdf4j-server/repositories/full?query=select%2Awhere%7B%3Fs%3Cx%3A%3E%3Fo%7Dlimit1" > /dev/null \
-          || (
+        # If curl succeeds, mark the instance as "has been ready". Only force a
+        # restart (via pkill) when the probe fails AND we've previously seen it
+        # ready -- otherwise we'd kill Tomcat mid-deploy during the start_period
+        # (default start_interval is 5s, well below the war-deploy time).
+        test: |
+          if curl -fsS --retry 2 --max-time 10 --retry-delay 2 --retry-max-time 10 --retry-connrefused \
+              "http://localhost:8080/rdf4j-server/repositories/full?query=select%2Awhere%7B%3Fs%3Cx%3A%3E%3Fo%7Dlimit1" > /dev/null; then
+            touch /var/info/ready
+            exit 0
+          fi
+          if [ -f /var/info/ready ]; then
             date >> /var/info/restart
             pkill -15 java
             sleep 10
             pkill -9 java
-          )
+          fi
+          exit 1
         interval: 60s
         timeout: 60s
         start_period: 300s

--- a/entrypoint/init.sh
+++ b/entrypoint/init.sh
@@ -3,4 +3,13 @@
 # This script is needed so the main Java command doesn't get PID 1 and therefore
 # it can be killed on a negative healthcheck.
 
-catalina.sh run
+# Ensure curl is available for the healthcheck. The eclipse/rdf4j-workbench
+# image (>=5.3.1-tomcat) ships without curl, which makes the healthcheck's
+# `curl ... || (pkill java)` branch fire on every probe and kills Tomcat
+# mid-deploy. Requires the container to start as root (see docker-compose.yml).
+if ! command -v curl >/dev/null 2>&1; then
+    apt-get update && apt-get install -y --no-install-recommends curl
+fi
+
+# Drop privileges back to the image's default tomcat user for the JVM itself.
+runuser -u tomcat -- catalina.sh run

--- a/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
@@ -317,12 +317,16 @@ public class JellyNanopubLoader {
                             ", received counter: " + m.getCounter());
                 }
                 NanopubLoader.load(m.getNanopub(), m.getCounter());
+                // Bump the in-memory counter BEFORE persisting it. The previous order
+                // wrote the *previous* nanopub's counter to the DB at each checkpoint,
+                // so a crash-restart silently re-processed one extra nanopub and the
+                // contract "saved counter == last fully loaded nanopub" was violated.
+                lastCommittedCounter = m.getCounter();
                 if (m.getCounter() % 10 == 0) {
                     // Save the committed counter only every 10 nanopubs to reduce DB load
                     saveCommittedCounter(type);
                     lastSavedCounter.set(m.getCounter());
                 }
-                lastCommittedCounter = m.getCounter();
                 loaded.getAndIncrement();
 
                 if (loaded.get() % 50 == 0) {

--- a/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
@@ -123,11 +123,28 @@ public class JellyNanopubLoader {
         }
         lastCommittedCounter = afterCounter;
         while (lastCommittedCounter < targetCounter) {
+            // Same circuit-breaker logic as loadUpdates: after BREAKER_THRESHOLD
+            // consecutive failed batches, pause before retrying so a saturated RDF4J
+            // (e.g. during a restart storm) can drain instead of being hammered on the
+            // 5-second RETRY_DELAY_JELLY cadence.
+            if (consecutiveBatchFailures >= BREAKER_THRESHOLD) {
+                log.warn("Circuit breaker active during initial load after {} consecutive batch failures; pausing {} ms before next attempt",
+                        consecutiveBatchFailures, BREAKER_PAUSE_MS);
+                try {
+                    Thread.sleep(BREAKER_PAUSE_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted while waiting for circuit breaker.");
+                }
+            }
             try {
                 loadBatch(lastCommittedCounter, LoadingType.INITIAL);
+                consecutiveBatchFailures = 0;
                 log.info("Initial load: loaded batch up to counter {}", lastCommittedCounter);
             } catch (Exception e) {
-                log.info("Failed to load batch starting from counter {}", lastCommittedCounter);
+                consecutiveBatchFailures++;
+                log.info("Failed to load batch starting from counter {} (consecutive failures: {})",
+                        lastCommittedCounter, consecutiveBatchFailures);
                 log.info("Failure reason: ", e);
                 try {
                     Thread.sleep(RETRY_DELAY_JELLY);

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -131,6 +131,14 @@ public class NanopubLoader {
             notes.add("Signature error");
         }
         if (!hasValidSignature(el)) {
+            // Audit trail for the silent-false path: without this, an aborted nanopub
+            // is invisible in the admin repo and only detectable as a gap between the
+            // stream counter and the loaded count. See issue around RDF4J-instability
+            // load gaps (full vs registry, meta vs full) where signature validation
+            // returned false but no GeneralSecurityException was thrown.
+            if (notes.isEmpty()) {
+                notes.add("Invalid signature");
+            }
             aborted = true;
             return;
         }
@@ -886,10 +894,16 @@ public class NanopubLoader {
     }
 
     static boolean hasValidSignature(NanopubSignatureElement el) {
+        if (el == null) {
+            log.warn("Signature validation: signature element is null");
+            return false;
+        }
         try {
-            if (el != null && SignatureUtils.hasValidSignature(el) && el.getPublicKeyString() != null) {
+            if (SignatureUtils.hasValidSignature(el) && el.getPublicKeyString() != null) {
                 return true;
             }
+            log.warn("Signature validation returned false for {} (pubkey present: {})",
+                    el.getUri(), el.getPublicKeyString() != null);
         } catch (GeneralSecurityException ex) {
             log.warn("Signature validation failed for signature element {}", el.getUri(), ex);
         }

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -429,11 +429,17 @@ public class NanopubLoader {
                 runTask.accept(() -> loadInvalidateStatements(np, el.getPublicKeyString(), st, pubkeyStatement, pubkeyStatementX));
             }
 
-            // Wait for all non-meta tasks to complete successfully before submitting the meta task
+            // Wait for all non-meta tasks to complete successfully before submitting the meta task.
+            // On failure, cancel the remaining futures so orphaned tasks don't keep running in the
+            // shared loadingPool and race with the next batch retry (which re-submits the same
+            // nanopub against the same repos).
             for (var task : runningTasks) {
                 try {
                     task.get();
                 } catch (ExecutionException | InterruptedException ex) {
+                    for (var t : runningTasks) {
+                        if (!t.isDone()) t.cancel(true);
+                    }
                     throw new RuntimeException("Error in nanopub loading thread", ex.getCause());
                 }
             }

--- a/src/test/java/com/knowledgepixels/query/NanopubLoaderTest.java
+++ b/src/test/java/com/knowledgepixels/query/NanopubLoaderTest.java
@@ -82,13 +82,19 @@ class NanopubLoaderTest {
     @Test
     void loadWhenNanopubNotLoadedInvalidSignature() throws MalformedNanopubException, IOException {
         try (MockedStatic<NanopubLoader> mockedLoader = mockStatic(NanopubLoader.class, CALLS_REAL_METHODS);
-             MockedStatic<GetNanopub> mockedGetNanopub = mockStatic(GetNanopub.class)) {
+             MockedStatic<GetNanopub> mockedGetNanopub = mockStatic(GetNanopub.class);
+             MockedStatic<TripleStore> mockedStore = mockStatic(TripleStore.class)) {
 
             Nanopub nanopub = new NanopubImpl(NanopubTestSuite.getLatest().getByNanopubUri("http://example.org/nanopub-validator-example/RAeUPiCKlke8Pw9wYbqIESyBqFJM5UDSkx4uF9kkRfCh0").getFirst().toFile());
 
             mockedLoader.when(() -> NanopubLoader.isNanopubLoaded(anyString())).thenReturn(false);
             mockedLoader.when(NanopubLoader::getHttpClient).thenReturn(mock(HttpClient.class));
             mockedGetNanopub.when(() -> GetNanopub.get(anyString(), any(HttpClient.class))).thenReturn(nanopub);
+            // The invalid-signature path now writes an "Invalid signature" audit note
+            // to the admin repo so silent aborts aren't invisible. Mock the TripleStore
+            // so the test doesn't try to hit a real RDF4J endpoint.
+            mockedStore.when(TripleStore::get).thenReturn(mock(TripleStore.class));
+            when(TripleStore.get().getAdminRepoConnection()).thenReturn(mock(RepositoryConnection.class));
 
             NanopubLoader.load(nanopubUri);
             mockedLoader.verify(() -> NanopubLoader.load(nanopub, -1), times(1));


### PR DESCRIPTION
## Summary

After a recent incident on `query.petapico.org` where the loader stopped at 78405/81037 nanopubs in `full` (and 74669/81037 in `meta`) while reporting `READY` and a load-counter that matched the registry, a `FORCE_RESYNC` filled the gap. The root cause window (RDF4J restarted three times during the initial load) was not in the available logs because the missing failures left no breadcrumbs.

Four small, independent fixes — three diagnostic/audit, one resilience — that would make the next such incident self-documenting and reduce the chance of it happening at all. Plus one fix for the rdf4j healthcheck that was self-DoSing the container on the new `5.3.1-tomcat` image. Each commit stands on its own.

## Commits

1. **`fix(NanopubLoader): record audit note when signature validation fails silently`** — the `hasValidSignature(el)` false-return path was silent unless a `MalformedCryptoElementException` had been thrown earlier. Now adds an `npa:note "Invalid signature"` to the admin repo (and a WARN log) on every silent false. Next time a load gap appears it can be located with one SPARQL query.
2. **`fix(NanopubLoader): cancel orphan tasks when executeLoading throws`** — when one repo's task fails after MAX_RETRIES, the others in the shared `loadingPool` keep running and race with the next batch retry. `cancel(true)` them before re-throwing.
3. **`fix(JellyNanopubLoader): bump lastCommittedCounter before persisting it`** — the checkpoint save read the static counter *before* the assignment that advances it, so every persisted checkpoint was one nanopub behind. Off-by-one in the saved counter; crash-restart re-processed one extra nanopub each time.
4. **`feat(JellyNanopubLoader): engage circuit breaker on initial load too`** — the `consecutiveBatchFailures` breaker (already protecting `loadUpdates`) didn't engage during initial load. During an RDF4J restart storm `loadInitial` hammered a recovering RDF4J every 5s; now it backs off to `BREAKER_PAUSE_MS` after the threshold.
5. **`fix: keep rdf4j alive on cold start under 5.3.1-tomcat image`** — `eclipse/rdf4j-workbench:5.3.1-tomcat` ships without `curl`, so the healthcheck command itself errored on every probe and fell into the `pkill java` branch, killing Tomcat mid-deploy. Even with curl, the probe targets `repositories/full` (created by `query` later in boot), so a fresh data volume still triggered the kill branch during `start_period`. `init.sh` now installs curl on first start (container runs as `user: "0"`) and drops privileges to `tomcat` via `runuser` before launching the JVM; the healthcheck records a `/var/info/ready` marker on first success and only fires `pkill` when that marker exists — preventing self-DoS during cold start while preserving hang-restart behavior afterwards.

## Test plan

- [x] `./mvnw test` — 215 / 215 pass
- [x] `loadWhenNanopubNotLoadedInvalidSignature` updated to mock `TripleStore` for the new note-write path
- [ ] After deploy, verify next load gap (if any) is locatable via `SELECT ?np WHERE { GRAPH npa:graph { ?np npa:note ?n FILTER(?n IN ("Invalid signature", "Signature error", "could not load nanopub as not all graphs contained the artifact code")) } }`
- [ ] Watch for `Signature validation returned false for …` WARN log lines on next initial load
- [x] `docker compose down && docker compose up -d` on a fresh data volume: rdf4j stays up through `LOADING_INITIAL`, no entries in `/var/info/restart`, no kill loop
- [ ] After deploy, simulate a hang on rdf4j after readiness (e.g. SIGSTOP on the JVM): healthcheck fires `pkill`, container restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
