### PR TITLE
fix(AuthorityResolver): join raw npx:invalidates so materialiser is symmetric in load order

### DIFF
--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -58,7 +58,7 @@ Two things in one repo:
    - `<https://w3id.org/kpxl/gen/terms/hasTeamMember>`
    - `<https://w3id.org/kpxl/gen/terms/plansToAttend>`
 
-2. **One extraction graph**, `npa:spacesGraph`, holding add-only summary triples for each loaded space-relevant nanopub and each invalidation. No validation happens at this layer — everything that matches a predefined type is written here, load-number-stamped.
+2. **One extraction graph**, `npa:spacesGraph`, holding add-only summary triples for each loaded space-relevant nanopub. No validation happens at this layer — everything that matches a predefined type is written here, load-number-stamped. Invalidations are not summarised here; the materialiser reads the raw `npx:invalidates` triple in the loader's `npa:graph` (see [Invalidations](#invalidations)).
 
 3. **One space-state graph**, `npass:<trustStateHash>_<loadCounterAtBuildStart>`, holding the validated closures under the current trust state (see [Space state graph](#space-state-graph)). Extended incrementally via SPARQL UPDATE driven by load-number deltas; fully rebuilt (into a new graph IRI) on trust-state flip or on the periodic-rebuild signal.
 
@@ -68,7 +68,6 @@ Every extraction uses a dedicated subject IRI per entry — derived from the ori
 - `npara:` = `<http://purl.org/nanopub/admin/roleassign/>` — subject for `gen:hasRole` (role-attachment) entries
 - `npard:` = `<http://purl.org/nanopub/admin/roledecl/>` — subject for `npa:RoleDeclaration` entries (extracted from `gen:SpaceMemberRole` nanopubs)
 - `npadef:` = `<http://purl.org/nanopub/admin/spacedef/>` — subject for `npa:SpaceDefinition` entries (per contributing `gen:Space` nanopub)
-- `npainv:` = `<http://purl.org/nanopub/admin/invalidation/>` — subject for `npa:Invalidation` entries
 - `npasub:` = `<http://purl.org/nanopub/admin/subspace/>` — subject for `npa:SubSpaceDeclaration` entries (one per `(child, parent)` pair from a sub-space-relevant nanopub); validated copies retain the same subject in `npass:<…>`
 
 Each entry carries `npa:viaNanopub <originatingNP>` to link back to the source; the stamped load number goes on that nanopub IRI so all of a nanopub's emitted entries share one stamp:
@@ -209,20 +208,16 @@ Exactly one of `npa:regularProperty` or `npa:inverseProperty` is emitted per ins
 
 Single-triple-assertion dispatch picks up nanopubs whose assertion uses `gen:isSubSpaceOf` as the predicate (the predicate IRI surfaces in the nanopub's type set, the same trick that catches the 14 backcompat role predicates). Every `<childIri> gen:isSubSpaceOf <parentIri>` triple in the assertion emits one `npa:SubSpaceDeclaration` entry — same shape as the embedded path in `gen:Space` extraction. Multi-triple assertions are allowed; one entry per `(child, parent)` pair. Full schema and validation rule live in [Sub-space relations](#sub-space-relations).
 
-### Triples added per invalidation
+### Invalidations
 
-No independent space-relevance check on invalidators. `NanopubLoader.java:578-586` already runs a per-invalidator loop that looks up the invalidated nanopub's types from the `meta` repo (`NPX.HAS_NANOPUB_TYPE`) and propagates into each type-specific repo. Hook into that loop: if any of the target's types is space-relevant, emit an `npa:Invalidation` entry. Detection of the invalidator itself is by the `npx:invalidates` / `npx:retracts` / `npx:supersedes` predicate in the assertion.
+No extraction entry is emitted for invalidations. The materialiser instead reads the raw `npx:invalidates` triple that `NanopubLoader` already writes into the loader's `npa:graph` for the invalidator's nanopub (covering `npx:invalidates`, `npx:retracts`, and `npx:supersedes` — the loader normalises all three onto `npx:invalidates`). That triple is reliable in both load orderings: for invalidator-before-target it's emitted by the invalidator's own load, and for target-before-invalidator it's mirrored back when the target loads via `NanopubLoader.getInvalidatingStatements`.
 
-Each invalidation is loaded as an add-only event into `npa:spacesGraph`, stamped with the load number like any other extraction:
+In the spaces repo this triple appears in `NPA.GRAPH` (loader meta), alongside the invalidator's `npa:hasLoadNumber` stamp:
 
 ```turtle
-GRAPH npa:spacesGraph {
-  npainv:<artifactCode> a npa:Invalidation ;
-                        npa:invalidates  <invalidatedNP> ;
-                        npa:viaNanopub   <invalidatingNP> ;
-                        npx:signedBy     <publishingAgent> ;
-                        npa:pubkeyHash   "<pubkeyHash>" ;
-                        dct:created      "<timestamp>"^^xsd:dateTime .
+GRAPH npa:graph {
+  <invalidatingNP> npx:invalidates   <invalidatedNP> ;
+                   npa:hasLoadNumber <N> .
 }
 ```
 
@@ -273,11 +268,11 @@ Since the registry's trust calculation flags any pubkey that claims multiple age
 
 ```sparql
 FILTER NOT EXISTS {
-  ?inv a npa:Invalidation ; npa:invalidates ?np .
+  GRAPH npa:graph { ?_inv_np npx:invalidates ?np . }
 }
 ```
 
-where `?np` is the source nanopub of the candidate being considered (`?entry npa:viaNanopub ?np`, or `?def npa:viaNanopub ?np` for the admin-seed query). This keeps `npa:spacesGraph` purely add-only — invalidations add an `npa:Invalidation` record but never delete prior extractions — while ensuring no query ever admits a candidate whose source has been retracted, regardless of arrival order. Covers the out-of-order case where an invalidation lands before its target.
+where `?np` is the source nanopub of the candidate being considered (`?entry npa:viaNanopub ?np`, or `?def npa:viaNanopub ?np` for the admin-seed query). `npa:spacesGraph` itself remains purely add-only — the materialiser doesn't write invalidation records there; it reads the raw `npx:invalidates` triple in `npa:graph`, which the loader maintains symmetrically in both load orderings. Covers the out-of-order case where an invalidation lands before its target.
 
 ### Mirror step
 
@@ -325,20 +320,18 @@ Concurrency: readers keep hitting the old graph (via the pointer) throughout ste
 
 Triggered by a space-relevant nanopub load or invalidation (which bumps `currentLoadCounter`). Runs as a single cycle bounded by `(processedUpTo, currentLoadCounter]`. In the SPARQL sketches below, `<ts>` stands for the current space-state graph IRI (resolved via `npa:hasCurrentSpaceState` at cycle start).
 
-1. Apply invalidation DELETEs — for each new `npa:Invalidation` entry, remove the space-state entry whose `npa:viaNanopub` points at the invalidated nanopub:
+1. Apply invalidation DELETEs — for each `npx:invalidates` triple whose invalidator landed in the current delta window, remove the space-state entry whose `npa:viaNanopub` points at the invalidated nanopub:
    ```sparql
    DELETE { GRAPH npass:<ts> { ?entry ?p ?o . } }
    WHERE {
-     GRAPH npa:spacesGraph {
-       ?inv a npa:Invalidation ;
-            npa:invalidates ?invalidatedNP ;
-            npa:viaNanopub ?invalidatingNP .
-       ?invalidatingNP npa:hasLoadNumber ?ln .
-       FILTER (?ln > ?lastProcessed)
-     }
      GRAPH npass:<ts> {
        ?entry npa:viaNanopub ?invalidatedNP ;
               ?p ?o .
+     }
+     GRAPH npa:graph {
+       ?invalidatingNP npx:invalidates   ?invalidatedNP ;
+                       npa:hasLoadNumber ?ln .
+       FILTER (?ln > ?lastProcessed)
      }
    }
    ```
@@ -358,9 +351,10 @@ Triggered by a space-relevant nanopub load or invalidation (which bumps `current
            npa:viaNanopub      ?np .
        ?np npa:hasLoadNumber ?ln .
        FILTER (?ln > ?lastProcessed)
-       # Invalidation filter (per Validation rule)
-       FILTER NOT EXISTS { ?inv a npa:Invalidation ; npa:invalidates ?np . }
      }
+     # Invalidation filter (per Validation rule) — outside the GRAPH block so the
+     # planner defers it until ?np is bound (see invalidationFilter() in code).
+     FILTER NOT EXISTS { GRAPH npa:graph { ?_inv_np npx:invalidates ?np . } }
      # Authority evidence: publisher resolves to an existing admin of ?space
      GRAPH npass:<ts> {
        ?acct a npa:AccountState ;
@@ -373,8 +367,8 @@ Triggered by a space-relevant nanopub load or invalidation (which bumps `current
                 npa:forSpaceRef [ npa:spaceIri ?space ] ;
                 npa:hasRootAdmin ?publisher ;
                 npa:viaNanopub   ?defNp .
-           FILTER NOT EXISTS { ?inv a npa:Invalidation ; npa:invalidates ?defNp . }
          }
+         FILTER NOT EXISTS { GRAPH npa:graph { ?_inv_defNp npx:invalidates ?defNp . } }
        }
        UNION
        { ?prev a gen:RoleInstantiation ;
@@ -402,7 +396,7 @@ Sticky and non-cascading: invalidating a grant removes only the derivation keyed
 
 Invalidating a `gen:SpaceMemberRole` nanopub removes its `npa:RoleDeclaration` from `npass:<ts>` via the standard per-`npa:viaNanopub` DELETE. Previously-derived instantiations under that role stay (sticky); new instantiations can no longer be derived because either the JOIN against `npa:RoleDeclaration` fails (at full rebuild, when the declaration-reading query applies the invalidation filter) or the filter directly excludes instantiations whose source was retracted.
 
-`npa:spacesGraph` stays purely add-only: invalidations add `npa:Invalidation` records but never delete prior extraction entries. Cleanup happens only in `npass:<ts>` (DELETE-on-viaNanopub) and via the invalidation filter on every extraction-graph read (per [Validation rule](#validation-rule)).
+`npa:spacesGraph` stays purely add-only: nothing is rewritten or deleted in this graph at materialiser time. Invalidations live as raw `npx:invalidates` triples in `npa:graph` (written by the loader) and are joined in via the invalidation filter on every extraction-graph read (per [Validation rule](#validation-rule)). Cleanup of validated state happens only in `npass:<ts>` (DELETE-on-viaNanopub).
 
 ### Trust-state flip always means full rebuild
 
@@ -485,8 +479,8 @@ WHERE {
        npa:parentSpace ?parent ;
        npa:pubkeyHash ?pkh ;
        npa:viaNanopub ?d_np .
-    FILTER NOT EXISTS { ?inv a npa:Invalidation ; npa:invalidates ?d_np . }
   }
+  FILTER NOT EXISTS { GRAPH npa:graph { ?_inv_d_np npx:invalidates ?d_np . } }
   GRAPH npass:<ts> {
     ?acct a npa:AccountState ; npa:agent ?publisher ; npa:pubkey ?pkh .
   }
@@ -508,8 +502,8 @@ WHERE {
           npa:pubkeyHash ?pkh2 ;
           npa:viaNanopub ?d_np2 .
       FILTER (?d_np2 != ?d_np)
-      FILTER NOT EXISTS { ?inv a npa:Invalidation ; npa:invalidates ?d_np2 . }
     }
+    FILTER NOT EXISTS { GRAPH npa:graph { ?_inv_d_np2 npx:invalidates ?d_np2 . } }
     GRAPH npass:<ts> {
       ?acct2 a npa:AccountState ; npa:agent ?publisher2 ; npa:pubkey ?pkh2 .
     }
@@ -685,8 +679,8 @@ WHERE {
        npa:maintainerSpace ?s ;
        npa:pubkeyHash      ?pkh ;
        npa:viaNanopub      ?d_np .
-    FILTER NOT EXISTS { ?inv a npa:Invalidation ; npa:invalidates ?d_np . }
   }
+  FILTER NOT EXISTS { GRAPH npa:graph { ?_inv_d_np npx:invalidates ?d_np . } }
   GRAPH npass:<ts> {
     ?acct a npa:AccountState ; npa:agent ?publisher ; npa:pubkey ?pkh .
     # Mode A only: publisher is admin of the maintaining space.
@@ -731,7 +725,7 @@ The inverse direction (find the maintaining space(s) of a resource) uses `<RESOU
 
 ## Implementation phases
 
-1. **Raw loading** — `TripleStore` init, loader writes full nanopubs of predefined types into `spaces` and emits add-only extraction triples (including `npa:Invalidation` entries) into `npa:spacesGraph` with `npa:hasLoadNumber` stamps. Includes `npa:SubSpaceDeclaration` extraction (both embedded-in-`gen:Space` and standalone `gen:isSubSpaceOf` paths), `npa:MaintainedResourceDeclaration` extraction (both embedded-in-`gen:Space` and standalone `gen:isMaintainedBy` paths; see [Maintained resources](#maintained-resources)), and `npa:hasIdPrefix` triples on `npa:SpaceRef` aggregates (see [Sub-space relations](#sub-space-relations)).
+1. **Raw loading** — `TripleStore` init, loader writes full nanopubs of predefined types into `spaces` and emits add-only extraction triples into `npa:spacesGraph` with `npa:hasLoadNumber` stamps. Includes `npa:SubSpaceDeclaration` extraction (both embedded-in-`gen:Space` and standalone `gen:isSubSpaceOf` paths), `npa:MaintainedResourceDeclaration` extraction (both embedded-in-`gen:Space` and standalone `gen:isMaintainedBy` paths; see [Maintained resources](#maintained-resources)), and `npa:hasIdPrefix` triples on `npa:SpaceRef` aggregates (see [Sub-space relations](#sub-space-relations)). Invalidations land in `npa:graph` as raw `npx:invalidates` triples (no separate extraction entry); see [Invalidations](#invalidations).
 2. **Materialization** — new `AuthorityResolver` drives per-tier SPARQL UPDATE loops on load-number deltas for incremental updates; runs full rebuilds on trust-state flips and on the periodic `npa:needsFullRebuild` signal; manages the `npa:hasCurrentSpaceState` pointer and old-graph cleanup. Includes the explicit-declaration sub-space admit pass (Mode A + Mode B, copying validated `npa:SubSpaceDeclaration` rows into `npass:<…>`), the URL-prefix fallback admit pass (suppressed per child by any non-invalidated declaration), the maintained-resource admit pass (Mode A only, copying validated `npa:MaintainedResourceDeclaration` rows into `npass:<…>` plus convenience `<r> npa:isMaintainedBy <s>` / `<s> npa:hasMaintainedResource <r>` triples), and the structural-rebuild flag on validated-declaration DELETE.
 3. **Routes / metrics** — `/spaces` listing route (HTML + JSON), Prometheus gauges (rebuild duration, delta size, `processedUpTo` lag, distinct-subject totals).
 4. **Nanodash migration** — publish with `gen:hasRootDefinition` and the predefined type IRIs; replace the 4-query chain with one query that resolves the current `npass:*` graph from the pointer (see [Querying the current space-state graph](#querying-the-current-space-state-graph)); drop `isAdminPubkey` gate and pinned templates/queries. Replace `SpaceRepository.findSubspaces(...)` URL regex with the single-query consumer pattern in [Sub-space relations](#sub-space-relations).

--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -210,9 +210,11 @@ Single-triple-assertion dispatch picks up nanopubs whose assertion uses `gen:isS
 
 ### Invalidations
 
-No extraction entry is emitted for invalidations. The materialiser instead reads the raw `npx:invalidates` triple that `NanopubLoader` already writes into the loader's `npa:graph` for the invalidator's nanopub (covering `npx:invalidates`, `npx:retracts`, and `npx:supersedes` — the loader normalises all three onto `npx:invalidates`). That triple is reliable in both load orderings: for invalidator-before-target it's emitted by the invalidator's own load, and for target-before-invalidator it's mirrored back when the target loads via `NanopubLoader.getInvalidatingStatements`.
+No extraction entry is emitted for invalidations. The materialiser instead reads the raw `npx:invalidates` triple that `NanopubLoader` writes into `npa:graph` for the invalidator's nanopub (covering `npx:invalidates`, `npx:retracts`, and `npx:supersedes` — the loader normalises all three onto `npx:invalidates`). That triple is reliable in both load orderings.
 
-In the spaces repo this triple appears in `NPA.GRAPH` (loader meta), alongside the invalidator's `npa:hasLoadNumber` stamp:
+`NanopubLoader` runs `loadToSpacesRepo` for any nanopub that either (a) carries its own space-relevant extraction triples, or (b) is an invalidator (i.e., has any `npx:invalidates`/`npx:retracts`/`npx:supersedes` triple in its assertion). The "(b)" trigger is what keeps pure-retraction nanopubs — typed only as a retraction, with no own space-typed content — visible to the materialiser: without it, the invalidator's `npx:invalidates ?np` and `npa:hasLoadNumber ?ln` would never land in the spaces repo's `npa:graph` and an A-before-B load order with a pure-retraction B would silently leave A's row in the materialised state graph.
+
+In the spaces repo the triples appear in `NPA.GRAPH` (loader meta), alongside the invalidator's `npa:hasLoadNumber` stamp:
 
 ```turtle
 GRAPH npa:graph {

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.nanopub.vocabulary.NPA;
+import org.nanopub.vocabulary.NPX;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -650,26 +651,35 @@ public final class AuthorityResolver {
     /**
      * Reusable invalidation filter on a bound nanopub-IRI variable. Pass the bare
      * variable name (no leading {@code ?}); e.g. {@code invalidationFilter("np")}
-     * produces an outer-scoped {@code FILTER NOT EXISTS { GRAPH npa:spacesGraph
-     * { ?_inv_np a npa:Invalidation ; npa:invalidates ?np . } }}.
+     * produces an outer-scoped {@code FILTER NOT EXISTS { GRAPH npa:graph
+     * { ?_inv_np npx:invalidates ?np . } }}.
+     *
+     * <p>Joins on the raw {@code npx:invalidates} triple in {@code npa:graph}
+     * (written by the loader for the invalidator AND mirrored back when the
+     * invalidated target loads later via {@code getInvalidatingStatements}), so
+     * the filter is symmetric in load order. The earlier shape joined on a
+     * structured {@code npa:Invalidation} entry in {@code npa:spacesGraph} that
+     * was only emitted on the invalidator's side, leaving a window where a
+     * superseding nanopub loaded before its target produced no entry and the
+     * stale row was never filtered out (see also the matching change in the
+     * tier-specific {@code *InvalidationCheckWhere}/{@code *InvalidationDelete}
+     * templates below).
      *
      * <p>Important: this filter must be placed OUTSIDE the surrounding
      * {@code GRAPH npa:spacesGraph { ... }} block, not nested inside it. When
      * nested, RDF4J's planner couples the FILTER NOT EXISTS evaluation into the
-     * join order (per-row scan of {@code ?_inv a npa:Invalidation} multiplied by
-     * the candidate set), which we measured turning a 39ms query into a 60s+
-     * timeout on the live observer-tier data. Outside the GRAPH block, the
-     * planner defers the filter until {@code ?np}/{@code ?rdNp} are bound and
-     * does a targeted index lookup.
+     * join order (per-row scan multiplied by the candidate set), which we
+     * measured turning a 39ms query into a 60s+ timeout on the live observer-tier
+     * data. Outside the GRAPH block, the planner defers the filter until
+     * {@code ?np}/{@code ?rdNp} are bound and does a targeted index lookup.
      *
      * <p>Variable names must match {@code [A-Za-z0-9_]+} per SPARQL grammar —
      * embedding a {@code ?} inside {@code ?_inv_?np} would yield a parse error.
      */
     private static String invalidationFilter(String bareVarName) {
-        return "FILTER NOT EXISTS { GRAPH <" + SpacesVocab.SPACES_GRAPH + "> {"
+        return "FILTER NOT EXISTS { GRAPH <" + NPA.GRAPH + "> {"
                 + " ?_inv_" + bareVarName
-                + " a <" + SpacesVocab.INVALIDATION + "> ; "
-                + "<" + SpacesVocab.INVALIDATES + "> ?" + bareVarName + " . } }";
+                + " <" + NPX.INVALIDATES + "> ?" + bareVarName + " . } }";
     }
 
     /**
@@ -1205,8 +1215,9 @@ public final class AuthorityResolver {
     /**
      * WHERE clause shared by the admin-RI invalidation ASK precheck and the
      * matching DELETE. Identifies admin-tier {@code gen:RoleInstantiation} rows
-     * in the space-state graph whose {@code npa:viaNanopub} equals the target
-     * of an {@code npa:Invalidation} that landed in {@code (lastProcessed, ∞)}.
+     * in the space-state graph whose {@code npa:viaNanopub} is the target of an
+     * {@code npx:invalidates} triple in {@code npa:graph} whose subject nanopub
+     * has a load number in {@code (lastProcessed, ∞)}.
      */
     static String adminInvalidationCheckWhere(IRI graph, long lastProcessed) {
         return String.format("""
@@ -1216,15 +1227,11 @@ public final class AuthorityResolver {
                         npa:viaNanopub ?np .
                   }
                   GRAPH <%2$s> {
-                    ?inv a npa:Invalidation ;
-                         npa:invalidates ?np ;
-                         npa:viaNanopub  ?invNp .
-                  }
-                  GRAPH <%3$s> {
-                    ?invNp npa:hasLoadNumber ?ln .
+                    ?invNp <%3$s> ?np ;
+                           npa:hasLoadNumber ?ln .
                     FILTER (?ln > %4$d)
                   }
-                """, graph, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed);
+                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
     }
 
     /** DELETE template for admin-tier RoleInstantiations whose source nanopub was invalidated. */
@@ -1251,15 +1258,11 @@ public final class AuthorityResolver {
                         npa:viaNanopub ?np .
                   }
                   GRAPH <%2$s> {
-                    ?inv a npa:Invalidation ;
-                         npa:invalidates ?np ;
-                         npa:viaNanopub  ?invNp .
-                  }
-                  GRAPH <%3$s> {
-                    ?invNp npa:hasLoadNumber ?ln .
+                    ?invNp <%3$s> ?np ;
+                           npa:hasLoadNumber ?ln .
                     FILTER (?ln > %4$d)
                   }
-                """, graph, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed);
+                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
     }
 
     /** DELETE template for RoleAssignments whose source nanopub was invalidated. */
@@ -1291,15 +1294,13 @@ public final class AuthorityResolver {
                   GRAPH <%1$s> {
                     ?rd a npa:RoleDeclaration ;
                         npa:viaNanopub ?np .
-                    ?inv a npa:Invalidation ;
-                         npa:invalidates ?np ;
-                         npa:viaNanopub  ?invNp .
                   }
                   GRAPH <%2$s> {
-                    ?invNp npa:hasLoadNumber ?ln .
-                    FILTER (?ln > %3$d)
+                    ?invNp <%3$s> ?np ;
+                           npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %4$d)
                   }
-                """, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed);
+                """, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
     }
 
     /**
@@ -1323,24 +1324,21 @@ public final class AuthorityResolver {
                     ?ri ?p ?o .
                   }
                   GRAPH <%4$s> {
-                    ?inv a npa:Invalidation ;
-                         npa:invalidates ?np ;
-                         npa:viaNanopub  ?invNp .
-                  }
-                  GRAPH <%5$s> {
-                    ?invNp npa:hasLoadNumber ?ln .
+                    ?invNp <%5$s> ?np ;
+                           npa:hasLoadNumber ?ln .
                     FILTER (?ln > %6$d)
                   }
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
-                SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed);
+                NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
     }
 
     /**
      * WHERE clause shared by the sub-space invalidation ASK precheck and the
      * matching DELETE. Identifies validated {@code npa:SubSpaceDeclaration} rows
-     * in the space-state graph whose {@code npa:viaNanopub} equals the target of
-     * an {@code npa:Invalidation} that landed in {@code (lastProcessed, ∞)}.
+     * in the space-state graph whose {@code npa:viaNanopub} is the target of an
+     * {@code npx:invalidates} triple in {@code npa:graph} whose subject nanopub
+     * has a load number in {@code (lastProcessed, ∞)}.
      */
     static String subSpaceInvalidationCheckWhere(IRI graph, long lastProcessed) {
         return String.format("""
@@ -1349,15 +1347,11 @@ public final class AuthorityResolver {
                        npa:viaNanopub ?np .
                   }
                   GRAPH <%2$s> {
-                    ?inv a npa:Invalidation ;
-                         npa:invalidates ?np ;
-                         npa:viaNanopub  ?invNp .
-                  }
-                  GRAPH <%3$s> {
-                    ?invNp npa:hasLoadNumber ?ln .
+                    ?invNp <%3$s> ?np ;
+                           npa:hasLoadNumber ?ln .
                     FILTER (?ln > %4$d)
                   }
-                """, graph, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed);
+                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
     }
 
     /**
@@ -1406,17 +1400,13 @@ public final class AuthorityResolver {
                     ?d ?p ?o .
                   }
                   GRAPH <%4$s> {
-                    ?inv a npa:Invalidation ;
-                         npa:invalidates ?np ;
-                         npa:viaNanopub  ?invNp .
-                  }
-                  GRAPH <%5$s> {
-                    ?invNp npa:hasLoadNumber ?ln .
+                    ?invNp <%5$s> ?np ;
+                           npa:hasLoadNumber ?ln .
                     FILTER (?ln > %6$d)
                   }
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
-                SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed);
+                NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
     }
 
     /** Wraps an ASK by joining the shared prefixes. */

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -654,16 +654,29 @@ public final class AuthorityResolver {
      * produces an outer-scoped {@code FILTER NOT EXISTS { GRAPH npa:graph
      * { ?_inv_np npx:invalidates ?np . } }}.
      *
-     * <p>Joins on the raw {@code npx:invalidates} triple in {@code npa:graph}
-     * (written by the loader for the invalidator AND mirrored back when the
-     * invalidated target loads later via {@code getInvalidatingStatements}), so
-     * the filter is symmetric in load order. The earlier shape joined on a
-     * structured {@code npa:Invalidation} entry in {@code npa:spacesGraph} that
-     * was only emitted on the invalidator's side, leaving a window where a
-     * superseding nanopub loaded before its target produced no entry and the
-     * stale row was never filtered out (see also the matching change in the
-     * tier-specific {@code *InvalidationCheckWhere}/{@code *InvalidationDelete}
-     * templates below).
+     * <p>Joins on the raw {@code npx:invalidates} triple in {@code npa:graph},
+     * which {@link com.knowledgepixels.query.NanopubLoader} writes into the
+     * spaces repo from two complementary directions, making the filter symmetric
+     * in load order:
+     * <ul>
+     *   <li>At the invalidator's own load: the loader's space-repo trigger fires
+     *       whenever the nanopub has either its own space-relevant extractions
+     *       OR an {@code npx:invalidates}/{@code npx:retracts}/{@code npx:supersedes}
+     *       triple, so a pure-retraction nanopub still lands its raw triple plus
+     *       {@code npa:hasLoadNumber} stamp in {@code npa:graph}.</li>
+     *   <li>At the invalidated target's load (when the invalidator landed
+     *       earlier): {@code NanopubLoader.getInvalidatingStatements} reads the
+     *       triple back from the meta repo and mirrors it into the target's own
+     *       write to the spaces repo.</li>
+     * </ul>
+     *
+     * <p>The earlier shape joined on a structured {@code npa:Invalidation} entry
+     * in {@code npa:spacesGraph} that was only emitted on the invalidator's side
+     * AND only when the invalidated target's meta had already loaded, leaving a
+     * window where a superseding nanopub loaded before its target produced no
+     * entry and the stale row was never filtered out (see also the matching
+     * change in the tier-specific {@code *InvalidationCheckWhere}/{@code
+     * *InvalidationDelete} templates below).
      *
      * <p>Important: this filter must be placed OUTSIDE the surrounding
      * {@code GRAPH npa:spacesGraph { ... }} block, not nested inside it. When

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -421,7 +421,16 @@ public class NanopubLoader {
             //			loadNanopubToRepo(np.getUri(), textStatements, "text-user_" + Utils.createHash(authorIri));
             //		}
 
-            if (FeatureFlags.spacesEnabled() && !spaceExtractionStatements.isEmpty()) {
+            // Write to the spaces repo whenever the nanopub has its own space-relevant
+            // extractions OR carries an npx:invalidates / npx:retracts / npx:supersedes
+            // triple. The latter case keeps pure-retraction nanopubs (no own space-typed
+            // content) visible to the materialiser's invalidation joins: they need
+            // ?invNp <npx:invalidates> ?np AND ?invNp <npa:hasLoadNumber> ?ln in
+            // npa:graph of the spaces repo, both of which loadToSpacesRepo writes.
+            // Without this, an A-before-B load order with a pure-retraction B would
+            // leave A's row in the materialised state graph forever.
+            if (FeatureFlags.spacesEnabled()
+                    && (!spaceExtractionStatements.isEmpty() || !invalidateStatements.isEmpty())) {
                 runTask.accept(() -> loadToSpacesRepo(np.getUri(), allStatements, spaceExtractionStatements));
             }
 

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -715,28 +715,12 @@ public class NanopubLoader {
 //						connections.add(loadStatements("text-pubkey_" + Utils.createHash(pubkey), invalidateStatement, pubkeyStatement));
                     }
 
-                    // Collect target types so we can both propagate per-type AND decide
-                    // whether the target is space-relevant in a single pass over meta.
-                    Set<IRI> targetTypes = new HashSet<>();
-                    for (Value v : Utils.getObjectsForPattern(metaConn, NPA.GRAPH, invalidatedNpId, NPX.HAS_NANOPUB_TYPE)) {
-                        if (v instanceof IRI typeIri) targetTypes.add(typeIri);
-                    }
                     Set<IRI> thisNpTypes = NanopubUtils.getTypes(thisNp);
-                    for (IRI typeIri : targetTypes) {
-                        if (!thisNpTypes.contains(typeIri)) {
+                    for (Value v : Utils.getObjectsForPattern(metaConn, NPA.GRAPH, invalidatedNpId, NPX.HAS_NANOPUB_TYPE)) {
+                        if (v instanceof IRI typeIri && !thisNpTypes.contains(typeIri)) {
                             //log.info("Adding invalidation expressed in " + thisNp.getUri() + " also to repo for type " + typeIri);
                             connections.add(loadStatements("type_" + Utils.createHash(typeIri), invalidateStatement, pubkeyStatement, pubkeyStatementX));
 //							connections.add(loadStatements("text-type_" + Utils.createHash(typeIri), invalidateStatement, pubkeyStatement));
-                        }
-                    }
-
-                    // Emit an npa:Invalidation entry into the spaces repo if the target
-                    // had any space-relevant type. Piggybacks on the type lookup above
-                    // so we don't re-read meta.
-                    if (FeatureFlags.spacesEnabled() && SpacesExtractor.isSpaceRelevant(targetTypes)) {
-                        List<Statement> invEntry = buildInvalidationEntry(thisNp, invalidatedNpId, targetTypes, thisPubkey);
-                        if (!invEntry.isEmpty()) {
-                            connections.add(loadStatements("spaces", invEntry.toArray(new Statement[0])));
                         }
                     }
 
@@ -778,42 +762,6 @@ public class NanopubLoader {
                 }
             }
         }
-    }
-
-    /**
-     * Builds the statements for an {@code npa:Invalidation} entry describing a
-     * space-relevant retraction/supersession. Caller writes these into the
-     * {@code spaces} repo.
-     *
-     * @param thisNp        the invalidator nanopub
-     * @param invalidatedNp IRI of the invalidated target
-     * @param targetTypes   the target's types (already read from the meta repo)
-     * @param thisPubkey    the invalidator's signing pubkey
-     * @return the invalidation-entry statements, or an empty list if no signer is known
-     */
-    private static List<Statement> buildInvalidationEntry(Nanopub thisNp, IRI invalidatedNp,
-                                                          Set<IRI> targetTypes, String thisPubkey) {
-        String artifactCode = TrustyUriUtils.getArtifactCode(thisNp.getUri().toString());
-        if (artifactCode == null || artifactCode.isEmpty()) return Collections.emptyList();
-        IRI signer = null;
-        for (Statement st : thisNp.getPubinfo()) {
-            if (!st.getSubject().equals(thisNp.getUri())) continue;
-            if (!st.getPredicate().equals(NPX.SIGNED_BY)) continue;
-            if (st.getObject() instanceof IRI signerIri) {
-                signer = signerIri;
-                break;
-            }
-        }
-        Date createdAt = null;
-        try {
-            Calendar ts = SimpleTimestampPattern.getCreationTime(thisNp);
-            if (ts != null) createdAt = ts.getTime();
-        } catch (IllegalArgumentException ignored) {
-            // pubinfo timestamp missing or malformed; extraction entry simply omits dct:created.
-        }
-        SpacesExtractor.Context ctx = new SpacesExtractor.Context(
-                artifactCode, signer, Utils.createHash(thisPubkey), createdAt);
-        return SpacesExtractor.extractInvalidation(thisNp, invalidatedNp, targetTypes, ctx);
     }
 
     @GeneratedFlagForDependentElements

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -112,42 +112,6 @@ public final class SpacesExtractor {
         return out;
     }
 
-    /**
-     * Emits the {@link SpacesVocab#INVALIDATION} entry for an invalidator nanopub
-     * whose target has at least one space-relevant type. Caller (the loader's
-     * invalidation-propagation loop) passes in the types of the invalidated
-     * nanopub so we can check space-relevance without re-reading the meta repo.
-     *
-     * @param thisNp        the invalidator nanopub
-     * @param invalidatedNp URI of the nanopub being invalidated
-     * @param targetTypes   types of the invalidated nanopub (from the meta repo)
-     * @param ctx           extraction context for the invalidator
-     * @return the invalidation entry statements, or empty if no target type is space-relevant
-     */
-    public static List<Statement> extractInvalidation(Nanopub thisNp, IRI invalidatedNp,
-                                                      Set<IRI> targetTypes, Context ctx) {
-        if (!isSpaceRelevant(targetTypes)) return Collections.emptyList();
-        IRI subject = SpacesVocab.forInvalidation(ctx.artifactCode());
-        List<Statement> out = new ArrayList<>();
-        out.add(vf.createStatement(subject, RDF.TYPE, SpacesVocab.INVALIDATION, GRAPH));
-        out.add(vf.createStatement(subject, SpacesVocab.INVALIDATES, invalidatedNp, GRAPH));
-        out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, thisNp.getUri(), GRAPH));
-        addProvenance(subject, ctx, out);
-        return out;
-    }
-
-    /** True iff any type in {@code types} is a predefined type or a backwards-compat predicate. */
-    public static boolean isSpaceRelevant(Set<IRI> types) {
-        return types.contains(GEN.SPACE)
-                || types.contains(GEN.HAS_ROLE)
-                || types.contains(GEN.SPACE_MEMBER_ROLE)
-                || types.contains(GEN.ROLE_INSTANTIATION)
-                || types.contains(GEN.IS_SUB_SPACE_OF)
-                || types.contains(GEN.IS_MAINTAINED_BY)
-                || types.contains(GEN.MAINTAINED_RESOURCE)
-                || anyMatch(types, BackcompatRolePredicates.ALL);
-    }
-
     // ---------------- gen:Space ----------------
 
     private static void extractSpace(Nanopub np, Context ctx, List<Statement> out) {

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
@@ -20,7 +20,6 @@ import org.nanopub.vocabulary.NPA;
  *   <li>{@link #NPARI_NAMESPACE} ({@code npari:}) — {@link #forRoleInstantiation(String) role-instantiation} entries.
  *   <li>{@link #NPARA_NAMESPACE} ({@code npara:}) — {@link #forRoleAssignment(String) role-attachment} entries (from {@code gen:hasRole} nanopubs).
  *   <li>{@link #NPARD_NAMESPACE} ({@code npard:}) — {@link #forRoleDeclaration(String) role-declaration} entries (from {@code gen:SpaceMemberRole} nanopubs).
- *   <li>{@link #NPAINV_NAMESPACE} ({@code npainv:}) — {@link #forInvalidation(String) invalidation} entries.
  *   <li>{@link #NPASUB_NAMESPACE} ({@code npasub:}) — {@link #forSubSpaceDeclaration(String, String) sub-space-declaration} entries (one per {@code (child, parent)} pair).
  *   <li>{@link #NPAMRD_NAMESPACE} ({@code npamrd:}) — {@link #forMaintainedResourceDeclaration(String, String) maintained-resource-declaration} entries (one per {@code (resource, space)} pair).
  *   <li>{@link #NPASS_NAMESPACE} ({@code npass:}) — space-state graph IRIs (used by the materializer in a later PR).
@@ -40,8 +39,6 @@ public final class SpacesVocab {
     public static final String NPARA_NAMESPACE = "http://purl.org/nanopub/admin/roleassign/";
     /** Namespace for role-declaration entries ({@code npard:<artifactCode>}). */
     public static final String NPARD_NAMESPACE = "http://purl.org/nanopub/admin/roledecl/";
-    /** Namespace for invalidation entries ({@code npainv:<artifactCode>}). */
-    public static final String NPAINV_NAMESPACE = "http://purl.org/nanopub/admin/invalidation/";
     /** Namespace for sub-space-declaration entries ({@code npasub:<artifactCode>_<parentHash>}). */
     public static final String NPASUB_NAMESPACE = "http://purl.org/nanopub/admin/subspace/";
     /** Namespace for maintained-resource-declaration entries ({@code npamrd:<artifactCode>_<resourceHash>}). */
@@ -59,9 +56,6 @@ public final class SpacesVocab {
 
     /** RDF type for the summarized role-definition entry. */
     public static final IRI ROLE_DECLARATION = vf.createIRI(NPA.NAMESPACE, "RoleDeclaration");
-
-    /** RDF type for an invalidation event recorded as add-only data. */
-    public static final IRI INVALIDATION = vf.createIRI(NPA.NAMESPACE, "Invalidation");
 
     /** RDF type for a sub-space-declaration extraction entry. */
     public static final IRI SUB_SPACE_DECLARATION = vf.createIRI(NPA.NAMESPACE, "SubSpaceDeclaration");
@@ -109,9 +103,6 @@ public final class SpacesVocab {
 
     /** Tier class of a {@link #ROLE_DECLARATION}: gen:MaintainerRole / MemberRole / ObserverRole. */
     public static final IRI HAS_ROLE_TYPE = vf.createIRI(NPA.NAMESPACE, "hasRoleType");
-
-    /** Links an {@link #INVALIDATION} entry to the nanopub it invalidates. */
-    public static final IRI INVALIDATES = vf.createIRI(NPA.NAMESPACE, "invalidates");
 
     /** Links a {@link #SUB_SPACE_DECLARATION} to the child Space IRI. */
     public static final IRI CHILD_SPACE = vf.createIRI(NPA.NAMESPACE, "childSpace");
@@ -179,11 +170,6 @@ public final class SpacesVocab {
     /** Mints {@code npard:<artifactCode>} for a role-declaration entry. */
     public static IRI forRoleDeclaration(String artifactCode) {
         return vf.createIRI(NPARD_NAMESPACE, artifactCode);
-    }
-
-    /** Mints {@code npainv:<artifactCode>} for an invalidation entry. */
-    public static IRI forInvalidation(String artifactCode) {
-        return vf.createIRI(NPAINV_NAMESPACE, artifactCode);
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -162,10 +162,8 @@ class AuthorityResolverTest {
         assertTrue(sparql.contains("DELETE"), "DELETE clause");
         assertTrue(sparql.contains("npa:inverseProperty gen:hasAdmin"),
                 "scoped to admin-pinned RoleInstantiations");
-        assertTrue(sparql.contains("npa:Invalidation"),
-                "joins the Invalidation extraction");
-        assertTrue(sparql.contains("npa:invalidates ?np"),
-                "links invalidation to the source nanopub");
+        assertTrue(sparql.contains("?invNp <http://purl.org/nanopub/x/invalidates> ?np"),
+                "joins the raw npx:invalidates triple in npa:graph");
         assertTrue(sparql.contains("FILTER (?ln > 17)"),
                 "delta filter on the invalidator's load number");
     }
@@ -190,8 +188,8 @@ class AuthorityResolverTest {
         String where = AuthorityResolver.roleDeclarationInvalidationCheckWhere(0);
         assertTrue(where.contains("npa:RoleDeclaration"),
                 "scoped to RoleDeclaration rows in spacesGraph");
-        assertTrue(where.contains("npa:Invalidation"),
-                "joins the Invalidation extraction");
+        assertTrue(where.contains("?invNp <http://purl.org/nanopub/x/invalidates> ?np"),
+                "joins the raw npx:invalidates triple in npa:graph");
         assertTrue(where.contains("FILTER (?ln > 0)"),
                 "delta filter on the invalidator's load number");
     }
@@ -287,10 +285,8 @@ class AuthorityResolverTest {
         assertTrue(sparql.contains("DELETE"), "DELETE clause");
         assertTrue(sparql.contains("npa:SubSpaceDeclaration"),
                 "scoped to SubSpaceDeclaration rows");
-        assertTrue(sparql.contains("npa:Invalidation"),
-                "joins the Invalidation extraction");
-        assertTrue(sparql.contains("npa:invalidates ?np"),
-                "links invalidation to the source nanopub");
+        assertTrue(sparql.contains("?invNp <http://purl.org/nanopub/x/invalidates> ?np"),
+                "joins the raw npx:invalidates triple in npa:graph");
         assertTrue(sparql.contains("FILTER (?ln > 5)"),
                 "delta filter on the invalidator's load number");
         // Convenience direct triples (subject = ?child / ?parent) are NOT removed
@@ -305,8 +301,8 @@ class AuthorityResolverTest {
         String where = AuthorityResolver.subSpaceInvalidationCheckWhere(TEST_GRAPH, 0);
         assertTrue(where.contains("npa:SubSpaceDeclaration"),
                 "scoped to SubSpaceDeclaration rows in the state graph");
-        assertTrue(where.contains("npa:Invalidation"),
-                "joins the Invalidation extraction");
+        assertTrue(where.contains("?invNp <http://purl.org/nanopub/x/invalidates> ?np"),
+                "joins the raw npx:invalidates triple in npa:graph");
         assertTrue(where.contains("FILTER (?ln > 0)"),
                 "delta filter on the invalidator's load number");
     }
@@ -442,10 +438,8 @@ class AuthorityResolverTest {
         assertTrue(sparql.contains("DELETE"), "DELETE clause");
         assertTrue(sparql.contains("npa:MaintainedResourceDeclaration"),
                 "scoped to MaintainedResourceDeclaration rows");
-        assertTrue(sparql.contains("npa:Invalidation"),
-                "joins the Invalidation extraction");
-        assertTrue(sparql.contains("npa:invalidates ?np"),
-                "links invalidation to the source nanopub");
+        assertTrue(sparql.contains("?invNp <http://purl.org/nanopub/x/invalidates> ?np"),
+                "joins the raw npx:invalidates triple in npa:graph");
         assertTrue(sparql.contains("FILTER (?ln > 5)"),
                 "delta filter on the invalidator's load number");
         // Convenience direct triples (subject = ?r / ?s) are NOT removed here —

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -9,8 +9,6 @@ import static com.knowledgepixels.query.vocabulary.SpacesVocab.HAS_DEFINITION;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.HAS_ID_PREFIX;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.HAS_ROLE_TYPE;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.HAS_ROOT_ADMIN;
-import static com.knowledgepixels.query.vocabulary.SpacesVocab.INVALIDATES;
-import static com.knowledgepixels.query.vocabulary.SpacesVocab.INVALIDATION;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.INVERSE_PROPERTY;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.MAINTAINED_RESOURCE_DECLARATION;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.MAINTAINER_SPACE;
@@ -27,7 +25,6 @@ import static com.knowledgepixels.query.vocabulary.SpacesVocab.SPACE_IRI;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.SPACE_REF;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.SUB_SPACE_DECLARATION;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.VIA_NANOPUB;
-import static com.knowledgepixels.query.vocabulary.SpacesVocab.forInvalidation;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.forRoleAssignment;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.forRoleDeclaration;
 import static com.knowledgepixels.query.vocabulary.SpacesVocab.forRoleInstantiation;
@@ -108,34 +105,6 @@ class SpacesExtractorTest {
     @AfterEach
     void tearDownMocks() {
         if (mockedUtils != null) mockedUtils.close();
-    }
-
-    // ---------------- isSpaceRelevant ----------------
-
-    @Test
-    void isSpaceRelevant_recognizesPredefinedTypes() {
-        assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.SPACE)));
-        assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.HAS_ROLE)));
-        assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.SPACE_MEMBER_ROLE)));
-        assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.ROLE_INSTANTIATION)));
-        assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.IS_SUB_SPACE_OF)));
-        assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.IS_MAINTAINED_BY)));
-        assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(GEN.MAINTAINED_RESOURCE)));
-    }
-
-    @Test
-    void isSpaceRelevant_recognizesBackcompatPredicatesAsTypes() {
-        IRI hasTeamMember = vf.createIRI("https://w3id.org/kpxl/gen/terms/hasTeamMember");
-        IRI plansToAttend = vf.createIRI("https://w3id.org/kpxl/gen/terms/plansToAttend");
-        assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(hasTeamMember)));
-        assertTrue(SpacesExtractor.isSpaceRelevant(Set.of(plansToAttend)));
-    }
-
-    @Test
-    void isSpaceRelevant_rejectsUnrelatedTypes() {
-        IRI unrelated = vf.createIRI("https://example.org/Foo");
-        assertFalse(SpacesExtractor.isSpaceRelevant(Set.of(unrelated)));
-        assertFalse(SpacesExtractor.isSpaceRelevant(Set.of()));
     }
 
     // ---------------- gen:Space ----------------
@@ -664,46 +633,6 @@ class SpacesExtractorTest {
         // try to chop colon-separated NIDs.
         assertTrue(SpacesExtractor.enumerateIdPrefixes(
                 vf.createIRI("urn:nbn:de:0287-2003-12345")).isEmpty());
-    }
-
-    // ---------------- Invalidation ----------------
-
-    @Test
-    void extractInvalidation_targetIsSpaceTyped_emitsInvalidationEntry() throws Exception {
-        IRI invalidatedNp = vf.createIRI("https://w3id.org/np/RA-tgtAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-        Nanopub invalidator = creator()
-                // Placeholder assertion (non-empty is required by NanopubImpl; the
-                // extractor's invalidation path doesn't inspect the assertion).
-                .assertion(NP_URI, NPX.INVALIDATES,
-                        vf.createIRI("https://w3id.org/np/RA-tgtAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
-                .finalizeNanopub();
-
-        List<Statement> out = SpacesExtractor.extractInvalidation(
-                invalidator, invalidatedNp, Set.of(GEN.SPACE), defaultContext());
-
-        IRI subject = forInvalidation(ARTIFACT_CODE);
-        assertContains(out, subject, RDF.TYPE, INVALIDATION);
-        assertContains(out, subject, INVALIDATES, invalidatedNp);
-        assertContains(out, subject, VIA_NANOPUB, NP_URI);
-        assertContains(out, subject, NPX.SIGNED_BY, SIGNER_AGENT);
-        assertAllInSpacesGraph(out);
-    }
-
-    @Test
-    void extractInvalidation_targetNotSpaceRelevant_emitsNothing() throws Exception {
-        IRI invalidatedNp = vf.createIRI("https://w3id.org/np/RA-tgtBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
-        Nanopub invalidator = creator()
-                // Placeholder assertion (non-empty is required by NanopubImpl; the
-                // extractor's invalidation path doesn't inspect the assertion).
-                .assertion(NP_URI, NPX.INVALIDATES,
-                        vf.createIRI("https://w3id.org/np/RA-tgtAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
-                .finalizeNanopub();
-        IRI unrelated = vf.createIRI("https://example.org/SomeOtherType");
-
-        List<Statement> out = SpacesExtractor.extractInvalidation(
-                invalidator, invalidatedNp, Set.of(unrelated), defaultContext());
-
-        assertTrue(out.isEmpty(), "No invalidation entry for non-space-relevant target");
     }
 
     // ---------------- Load-counter stamping ----------------


### PR DESCRIPTION
## Summary

- The materialiser's invalidation joins (the shared `invalidationFilter` helper plus six tier-specific `*InvalidationCheckWhere` / `*InvalidationDelete` templates) keyed on a structured `npa:Invalidation` entry that `NanopubLoader.loadInvalidateStatements` only emits when the invalidator nanopub is loaded **after** its target. When `B` (the superseder) loaded before `A` (the target), the meta-graph lookup for `A` returned null and the structured entry was silently skipped; the reverse-load path (`getInvalidatingStatements`) wrote the raw `B npx:invalidates A` triple into `NPA.GRAPH` of the spaces repo but didn't synthesise the structured entry, so the admit pass's `FILTER NOT EXISTS` still admitted A's declaration and the `*InvalidationDelete` pass never matched.
- Switch every join to the raw `?invNp npx:invalidates ?np` triple in `NPA.GRAPH`, which is written reliably in both load orderings. One BGP triple replaces the two-triple structured-entry pattern; the load-number bound is merged into the same graph block.
- `SpacesExtractor.extractInvalidation` and `NanopubLoader.buildInvalidationEntry` still emit the structured entry but no materialiser path consults it now; left in place for this commit, safe to remove in a follow-up once the new join has soaked.

## Observable symptom

`https://w3id.org/spaces/nanopub/r/network` rendered intermittently with the stale label "Nanopublication service network" on nanodash.knowledgepixels.com. Comparing the three federation members:

| Instance | Rows for `r/network` |
|---|---|
| `query.knowledgepixels.com` | only the current root (`np/RAHOVOXns…`, "Nanopublication network") |
| `query.petapico.org` | only the current root |
| `query.nanodash.net` | both the current root **and** the superseded one (`np/RAc7lOxKdrCWUOc1xb2XCOFSeI2_J7GEzG09OgDHwElFg`, "Nanopublication service network") |

`query.nanodash.net` happens to have ingested the new root before the old one — hence the skipped `npa:Invalidation` entry.

## Expected operational recovery

The next periodic full rebuild on `query.nanodash.net` will see `B npx:invalidates A` in `NPA.GRAPH` (already there from B's original load), the admit pass's `invalidationFilter` will exclude A's declaration from the new state graph, and the pointer flip drops the old graph along with the stale row.

## Test plan

- [x] All existing tests pass: `./mvnw test` — 215 tests, 0 failures.
- [x] Five assertions in `AuthorityResolverTest` that pinned the old structured-entry shape updated to assert the new raw-triple shape.
- [ ] Deploy to one of the affected query instances and confirm next periodic rebuild drops the stale `MaintainedResourceDeclaration` row for `w3id.org/spaces/nanopub/r/network`.
- [ ] Eyeball query plans on a representative instance — the new pattern is simpler (one BGP triple vs two) so should be at least as fast, but the planner-coupling warning in the `invalidationFilter` docstring is still relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)