### PR TITLE
docs(spaces): correct npa:RoleAssignment → gen:RoleAssignment in prose

### DIFF
--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -155,7 +155,7 @@ GRAPH npa:spacesGraph {
 
 Prefix: `npx:` = `<http://purl.org/nanopub/x/>`. `npa:forSpace` points to the Space IRI (not the space-ref form), as used in the source nanopub's assertion. The attached `<roleIri>` is the IRI of a role instance defined in some `gen:SpaceMemberRole` nanopub; consumers JOIN against that def for the role's predicates and tier.
 
-A single role (one `gen:SpaceMemberRole` nanopub) may be attached to multiple spaces via separate `gen:hasRole` nanopubs — each attachment is independent, gated by the respective space's admin closure, and produces its own `npa:RoleAssignment` entry.
+A single role (one `gen:SpaceMemberRole` nanopub) may be attached to multiple spaces via separate `gen:hasRole` nanopubs — each attachment is independent, gated by the respective space's admin closure, and produces its own `gen:RoleAssignment` entry.
 
 ### Triples added per `gen:SpaceMemberRole` nanopub
 


### PR DESCRIPTION
## Summary

One stale prose mention in `design-space-repositories.md` referred to `npa:RoleAssignment`, but the extractor emits `gen:RoleAssignment`:

- `SpacesExtractor.java:291` uses `GEN.ROLE_ASSIGNMENT`
- `GEN.java:76` defines `ROLE_ASSIGNMENT = …/gen/terms/RoleAssignment`
- `MetricsCollector.java:82` description matches (`gen:RoleAssignment`)
- The turtle schema example in the same doc section already shows `gen:RoleAssignment` (line 146); only the prose paragraph was stale

Found while migrating nanodash to query the spaces repo directly (https://github.com/knowledgepixels/nanodash/pull/468) — a SPARQL written verbatim from the doc returned zero rows until I switched to the namespace the extractor actually uses.

## Test plan

- [x] Doc-only change; no code path affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)