### PR TITLE
fix(spaces): ingest gen:hasGuest / gen:hasHost member RIs (#114)

### DIFF
--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -53,6 +53,8 @@ Two things in one repo:
    - `<https://w3id.org/fair/3pff/participatedAsImplementerAspirantIn>`
    - `<https://w3id.org/fair/3pff/participatedAsParticipantIn>`
    - `<https://w3id.org/kpxl/gen/terms/hasAdmin>`
+   - `<https://w3id.org/kpxl/gen/terms/hasGuest>`
+   - `<https://w3id.org/kpxl/gen/terms/hasHost>`
    - `<https://w3id.org/kpxl/gen/terms/hasObserver>`
    - `<https://w3id.org/kpxl/gen/terms/hasProjectLead>`
    - `<https://w3id.org/kpxl/gen/terms/hasTeamMember>`

--- a/src/main/java/com/knowledgepixels/query/vocabulary/BackcompatRolePredicates.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/BackcompatRolePredicates.java
@@ -62,6 +62,8 @@ public final class BackcompatRolePredicates {
             Map.entry(iri("https://w3id.org/fair/3pff/participatedAsTrainerIn"),              Direction.REGULAR),
             // KPXL gen terms
             Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasAdmin"),       Direction.INVERSE),
+            Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasGuest"),       Direction.INVERSE),
+            Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasHost"),        Direction.INVERSE),
             Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasObserver"),    Direction.INVERSE),
             Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasProjectLead"), Direction.INVERSE),
             Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasTeamMember"),  Direction.INVERSE),

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -348,6 +348,30 @@ class SpacesExtractorTest {
     }
 
     @Test
+    void extract_backcompatHasGuestAndHost_emitsRoleInstantiation_issue114() throws Exception {
+        // gen:hasGuest / gen:hasHost are space-centric (INVERSE), like hasObserver/hasAdmin.
+        // They were missing from BackcompatRolePredicates, so the extractor dropped
+        // guest/host member RIs entirely (issue #114).
+        for (String pred : new String[] {
+                "https://w3id.org/kpxl/gen/terms/hasGuest",
+                "https://w3id.org/kpxl/gen/terms/hasHost" }) {
+            IRI predicate = vf.createIRI(pred);
+            // Single-triple assertion → auto-typed by the predicate via NanopubUtils.getTypes.
+            Nanopub np = creator()
+                    .assertion(SPACE_IRI_1, predicate, MEMBER_AGENT)
+                    .finalizeNanopub();
+
+            List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+            IRI subject = forRoleInstantiation(ARTIFACT_CODE);
+
+            assertContains(out, subject, RDF.TYPE, GEN.ROLE_INSTANTIATION);
+            assertContains(out, subject, FOR_SPACE, SPACE_IRI_1);
+            assertContains(out, subject, INVERSE_PROPERTY, predicate);
+            assertContains(out, subject, FOR_AGENT, MEMBER_AGENT);
+        }
+    }
+
+    @Test
     void extract_backcompatRegularDirection_swapsSpaceAndAgent() throws Exception {
         // Agent-centric source: <agent> <predicate> <space>. REGULAR under the publisher
         // convention. plansToAttend is classified REGULAR in BackcompatRolePredicates.


### PR DESCRIPTION
Fixes #114.

## Problem

`gen:hasGuest` and `gen:hasHost` were missing from `BackcompatRolePredicates.DIRECTIONS`. A member role-instantiation like `<space> gen:hasGuest <agent>` is a single-triple assertion, so the registry auto-types it with the predicate IRI itself. Since that IRI wasn't in `TRIGGER_TYPES`, `isSpaceRelevant(...)` returned `false` and `SpacesExtractor.extract(...)` dropped the nanopub entirely (not even stored). Guest/host members silently vanished, while their sibling predicates (`hasObserver`, `hasAdmin`, `hasProjectLead`, `hasTeamMember`) — all present in the list — worked fine.

## Fix

Add both predicates as `Direction.INVERSE` (space-centric, matching `hasObserver`/`hasAdmin`):

```java
Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasGuest"), Direction.INVERSE),
Map.entry(iri("https://w3id.org/kpxl/gen/terms/hasHost"),  Direction.INVERSE),
```

A re-materialization then picks up the existing guest/host RIs (e.g. for `https://w3id.org/spaces/TheNanoPub`: 6 guests + 1 host). Also added to the backcompat-predicate list in `doc/design-space-repositories.md`.

## Verification

- New test `extract_backcompatHasGuestAndHost_emitsRoleInstantiation_issue114` (mirrors the existing INVERSE backcompat test) confirms both predicates now produce a `gen:RoleInstantiation` with `npa:inverseProperty` and the right space/agent binding.
- Full unit suite green (216 tests).

Independent of #113 / #115 (that one is about roles attached to an `owl:sameAs` alias); here everything is on the canonical IRI — the predicate was simply unrecognized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)