### PR TITLE
fix(env): read environment via System.getenv instead of forking a subprocess (#117)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -1,6 +1,5 @@
 package com.knowledgepixels.query;
 
-import org.apache.commons.exec.environment.EnvironmentUtils;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -79,10 +78,14 @@ public class TripleStore {
     }
 
     private TripleStore() throws IOException {
-        Map<String, String> env = EnvironmentUtils.getProcEnvironment();
-        endpointBase = env.get("ENDPOINT_BASE");
+        // Read directly from the JVM's in-memory environment block rather than via
+        // Apache Commons Exec's EnvironmentUtils.getProcEnvironment(), which forks a
+        // subprocess and can throw under memory pressure / a restart storm — leaving
+        // the singleton uninitialised. Same fragile mechanism that caused issue #117
+        // on the per-nanopub hot path (see Utils.getEnvString); retired here too.
+        endpointBase = System.getenv("ENDPOINT_BASE");
         log.info("Endpoint base: {}", endpointBase);
-        endpointType = env.get("ENDPOINT_TYPE");
+        endpointType = System.getenv("ENDPOINT_TYPE");
 
         getRepository("empty");  // Make sure empty repo exists
     }

--- a/src/main/java/com/knowledgepixels/query/Utils.java
+++ b/src/main/java/com/knowledgepixels/query/Utils.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.commons.exec.environment.EnvironmentUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
@@ -165,13 +164,17 @@ public class Utils {
      * @return environment variable value
      */
     public static String getEnvString(String envVarName, String defaultValue) {
-        try {
-            String s = EnvironmentUtils.getProcEnvironment().get(envVarName);
-            if (s != null && !s.isEmpty()) {
-                return s;
-            }
-        } catch (Exception ex) {
-            log.info("Could not get environment variable", ex);
+        // Read straight from the JVM's in-memory environment block. The previous
+        // implementation used Apache Commons Exec's EnvironmentUtils.getProcEnvironment(),
+        // which forks a subprocess (env/sh) and parses its stdout on every call. That is
+        // neither thread-safe nor robust under load, and since this method is on the
+        // per-nanopub hot path (FeatureFlags.fullRepoEnabled() and friends, called from
+        // the 4-thread loading pool) an intermittently mangled read made
+        // fullRepoEnabled() evaluate to false and silently skip the full-repo write for
+        // individual nanopubs — leaving full behind meta undetectably (issue #117).
+        String s = System.getenv(envVarName);
+        if (s != null && !s.isEmpty()) {
+            return s;
         }
         return defaultValue;
     }

--- a/src/main/java/com/knowledgepixels/query/Utils.java
+++ b/src/main/java/com/knowledgepixels/query/Utils.java
@@ -164,19 +164,33 @@ public class Utils {
      * @return environment variable value
      */
     public static String getEnvString(String envVarName, String defaultValue) {
-        // Read straight from the JVM's in-memory environment block. The previous
-        // implementation used Apache Commons Exec's EnvironmentUtils.getProcEnvironment(),
-        // which forks a subprocess (env/sh) and parses its stdout on every call. That is
-        // neither thread-safe nor robust under load, and since this method is on the
-        // per-nanopub hot path (FeatureFlags.fullRepoEnabled() and friends, called from
-        // the 4-thread loading pool) an intermittently mangled read made
-        // fullRepoEnabled() evaluate to false and silently skip the full-repo write for
-        // individual nanopubs — leaving full behind meta undetectably (issue #117).
-        String s = System.getenv(envVarName);
+        String s = getRawEnv(envVarName);
         if (s != null && !s.isEmpty()) {
             return s;
         }
         return defaultValue;
+    }
+
+    /**
+     * Reads a single environment variable from the JVM's in-memory environment
+     * block. The previous implementation used Apache Commons Exec's
+     * {@code EnvironmentUtils.getProcEnvironment()}, which forks a subprocess
+     * ({@code env}/{@code sh}) and parses its stdout on every call. That is neither
+     * thread-safe nor robust under load, and since {@link #getEnvString} is on the
+     * per-nanopub hot path ({@link FeatureFlags#fullRepoEnabled()} and friends,
+     * called from the 4-thread loading pool) an intermittently mangled read made
+     * {@code fullRepoEnabled()} evaluate to {@code false} and silently skip the
+     * full-repo write for individual nanopubs — leaving {@code full} behind
+     * {@code meta} undetectably (issue #117).
+     *
+     * <p>Extracted as a package-private seam because {@link System} static methods
+     * cannot be mocked directly with Mockito; tests stub this instead.
+     *
+     * @param envVarName environment variable name
+     * @return the raw value, or {@code null} if unset
+     */
+    static String getRawEnv(String envVarName) {
+        return System.getenv(envVarName);
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/query/UtilsTest.java
+++ b/src/test/java/com/knowledgepixels/query/UtilsTest.java
@@ -1,7 +1,6 @@
 package com.knowledgepixels.query;
 
 import com.github.jsonldjava.shaded.com.google.common.hash.Hashing;
-import org.apache.commons.exec.environment.EnvironmentUtils;
 import org.apache.http.client.config.RequestConfig;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
@@ -14,7 +13,6 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.nanopub.vocabulary.NPA;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -128,24 +126,20 @@ class UtilsTest {
     @Test
     void getEnvString() {
         final String defaultValue = "default";
+        final String mockValueString = "value";
 
-        Map<String, String> mockEnv = new HashMap<>();
-        String mockValueString = "value";
-        mockEnv.put("EXISTING_VAR", mockValueString);
-        mockEnv.put("EMPTY_VAR", "");
-        mockEnv.put("NULL_VAR", null);
-
-        try (MockedStatic<EnvironmentUtils> mockedEnvUtils = Mockito.mockStatic(EnvironmentUtils.class)) {
-            mockedEnvUtils.when(EnvironmentUtils::getProcEnvironment).thenReturn(mockEnv);
+        // getEnvString now reads the env via the Utils.getRawEnv seam (System.getenv
+        // cannot be mocked directly — see #117). CALLS_REAL_METHODS keeps getEnvString real.
+        try (MockedStatic<Utils> mockedUtils = Mockito.mockStatic(Utils.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedUtils.when(() -> Utils.getRawEnv("EXISTING_VAR")).thenReturn(mockValueString);
+            mockedUtils.when(() -> Utils.getRawEnv("EMPTY_VAR")).thenReturn("");
+            mockedUtils.when(() -> Utils.getRawEnv("NULL_VAR")).thenReturn(null);
+            mockedUtils.when(() -> Utils.getRawEnv("NON_EXISTING_VAR")).thenReturn(null);
 
             assertEquals(mockValueString, Utils.getEnvString("EXISTING_VAR", defaultValue));
             assertEquals(defaultValue, Utils.getEnvString("NON_EXISTING_VAR", defaultValue));
             assertEquals(defaultValue, Utils.getEnvString("EMPTY_VAR", defaultValue));
             assertEquals(defaultValue, Utils.getEnvString("NULL_VAR", defaultValue));
-
-            mockedEnvUtils.when(EnvironmentUtils::getProcEnvironment).thenThrow(IOException.class);
-            assertEquals(defaultValue, Utils.getEnvString("EXISTING_VAR", defaultValue));
-
         }
     }
 
@@ -156,14 +150,12 @@ class UtilsTest {
         final int validInt = Integer.parseInt(validIntValue);
         final String invalidIntValue = "not_an_int";
 
-        Map<String, String> mockEnv = new HashMap<>();
-        mockEnv.put("VALID_INT", validIntValue);
-        mockEnv.put("INVALID_INT", invalidIntValue);
-        mockEnv.put("EMPTY_VAR", "");
-        mockEnv.put("NULL_VAR", null);
-
-        try (MockedStatic<EnvironmentUtils> mockedEnvUtils = Mockito.mockStatic(EnvironmentUtils.class)) {
-            mockedEnvUtils.when(EnvironmentUtils::getProcEnvironment).thenReturn(mockEnv);
+        try (MockedStatic<Utils> mockedUtils = Mockito.mockStatic(Utils.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedUtils.when(() -> Utils.getRawEnv("VALID_INT")).thenReturn(validIntValue);
+            mockedUtils.when(() -> Utils.getRawEnv("INVALID_INT")).thenReturn(invalidIntValue);
+            mockedUtils.when(() -> Utils.getRawEnv("EMPTY_VAR")).thenReturn("");
+            mockedUtils.when(() -> Utils.getRawEnv("NULL_VAR")).thenReturn(null);
+            mockedUtils.when(() -> Utils.getRawEnv("NON_EXISTING_VAR")).thenReturn(null);
 
             assertEquals(validInt, Utils.getEnvInt("VALID_INT", defaultValue));
             assertEquals(defaultValue, Utils.getEnvInt("NON_EXISTING_VAR", defaultValue));


### PR DESCRIPTION
## Summary

Fixes #117 — the `full` repo silently falling behind `meta`, undetectable by the monitor.

`Utils.getEnvString` read the environment via Apache Commons Exec's `EnvironmentUtils.getProcEnvironment()`, which **forks a subprocess (`env`/`sh`) and parses its stdout on every call**. Since the per-repo feature flags (`FeatureFlags.fullRepoEnabled()` and friends) are evaluated for **every nanopub, from the 4-thread loading pool**, this brittle, non-thread-safe read could intermittently return a mangled value. When the result wasn't a clean `"true"`, `fullRepoEnabled()` evaluated to `false` and the **full-repo write was skipped for that one nanopub** — while `pubkey`/`type`/`meta` proceeded.

The lock-step ordering in `executeLoading` only guarantees `full ≥ meta` *while the full task is submitted*; the flag gate sits **before** submission, outside the wait-for-all guard. So a single mis-read leaves a permanent, invisible hole: the monitor and the `Nanopub-Query-Loaded-Nanopub-Count`/`-Checksum` headers both source from `meta`.

This matches the observed signature exactly: sparse, intermittent, recent, `full`-only misses where the missing nanopubs are present in `meta` **and** their per-pubkey repos (`meta=true, pubkey=true, full=false`, zero content in `full` — never written, not deleted).

## Changes

- **`Utils.getEnvString`** → `System.getenv()`: reads the JVM's in-memory environment block (thread-safe, allocation-free, deterministic; never forks or throws). *This is the #117 fix.*
- **`TripleStore` constructor** → `System.getenv(...)`: retires the same `getProcEnvironment()` mechanism. Startup-only and not part of the #117 trigger, but a fork failure there throws `IOException` and leaves the singleton uninitialised — this removes that failure mode and the last use of the fragile API. `ENDPOINT_BASE`/`ENDPOINT_TYPE` are container env vars set at launch, so the read is semantically identical.
- Removed the now-unused `EnvironmentUtils` imports.

## Remediation note

This stops the gap from **growing**, but does not **backfill** nanopubs already missing from `full` — those must be rebuilt via `FORCE_RESYNC`/`FORCE_RELOAD` on affected instances (already done on nanodash and knowledgepixels; petapico still pending at time of writing).

## Testing

`./mvnw -o compile` passes. The change is a behavior-preserving swap of the env-read mechanism (subprocess fork → in-memory lookup) with identical fallback semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)