### PR TITLE
fix(spaces): Phase 1.5 — IRI-valued dual-emit on structural-edge tiers

### DIFF
--- a/doc/canary-checklist-spaceref-1.15.md
+++ b/doc/canary-checklist-spaceref-1.15.md
@@ -1,0 +1,95 @@
+# Canary checklist — space-ref 1.15.x redeploy (post-Phase 1.5)
+
+**Purpose:** the 1.15.0 revert happened because the canary verified *state shape* but never
+exercised the **published query read path** (`/api`). nanopub-java's `QueryCall` races the
+whole fleet and accepts the first 2xx, so a single instance that returns valid-looking empty
+(or doubled) rows for a published query poisons consumers fleet-wide. This checklist makes
+the read-path canary concrete: run each published query that touches the `npa:` state
+structural edges via `/api` on the canary, and diff against a 1.14.4 reference instance.
+
+See `doc/report-2026-06-12-mixed-fleet-spaceref-breakage.md` and the Phase 1.5 section of
+`doc/design-spaceref-isolation.md`.
+
+## Scope: published queries that read `npa:` state structural edges
+
+Enumerated from `query.knowledgepixels.com/repo/full` (grlc query nanopubs whose SPARQL
+references `isMaintainedBy` / `hasMaintainedResource` / `isSubSpaceOf` / `hasSubSpace` /
+`sameAsSpace`), deduped to the **latest version** per family, then filtered to the ones that
+actually read the `npa:`-namespaced edges in the **state graph** (not `gen:`-namespaced edges
+in assertion graphs — those are unaffected by this change).
+
+### A. Broken on ref-only 1.15.0 → RESTORED by Phase 1.5 (must return rows again)
+
+These gate on the bare Space IRI via an admin `npa:forSpace` join or an IRI-subject edge
+bind. On ref-only 1.15.0 they returned empty; Phase 1.5 must make them match 1.14.4.
+
+| Query family | Latest np | Param | Edge / gate |
+|---|---|---|---|
+| Get view displays | `RAy49uUd2fPLHJAZ_7QKDtIDVgqaQ589OgQhMwNamKy-4` | `resource` | `isMaintainedBy` + `forSpace` admin gate |
+| List view displays | `RAe63temfrauWIRVIpGa5booRJgioepZSg8t54lgMxmNo` | `resource` | `isMaintainedBy` + `forSpace` admin gate |
+| Get preset views | `RApvCh39fmAuEO4S8XbzwY4_jKkmB44lIRdp_QTINF5UU` | `resource` | `isMaintainedBy` + `forSpace` admin gate |
+| List preset assignments | `RAZYHKDeAsHTPN5IsXNKa0rZwmhiWklXcnxOU7IBS4vtk` | `resource` | `isMaintainedBy` + `forSpace` admin gate |
+| View/preset test | `RAj2bKNyyK2WMh5GM43OHx3zU6CDoOPQkDmXSRt0sL8Ow` | `resource` | `isMaintainedBy` + `forSpace` admin gate |
+| List sub-spaces of a space | `RAeATx6AKEtCllXCfsBlXlA1nov1SZXuurnKOIW8qe7o8` | `space` | `?spaceIRI npa:hasSubSpace ?sub` (IRI-subject) |
+| List maintained resources of a space | `RAKTTYw5VcuK0aIRlTvSEVYFPA7mH3Yq_nKnC1qcpzHiI` | `space` | `?spaceIRI npa:hasMaintainedResource ?r` (IRI-subject) |
+
+**Pass criterion:** for representative params, canary row count == 1.14.4 reference row count
+(and non-empty where the reference is non-empty).
+
+### B. DOUBLING RISK introduced by Phase 1.5 (verify or mitigate before rollout)
+
+| Query family | Latest np | Param | Issue |
+|---|---|---|---|
+| Get sub-space links | `RAWgoQbP9_B9h3Bnwd1FGYX1gLYPyZFOxaeqIeA3TTPSU` | _(none)_ | `select ?child ?parent { ?child npa:isSubSpaceOf ?parent }` — **unconstrained** enumeration. Dual-emit returns **both** the ref-to-ref and IRI-to-IRI edge → ~2× rows, half of them ref-shaped IRIs (`…/admin/space/…`) that consumers don't recognize as spaces. |
+
+**Options (pick one before/with rollout):**
+1. **Bridge-supersede** this one query to constrain to IRI pairs, working on both fleet
+   versions — e.g. add `FILTER NOT EXISTS { ?parent a npa:SpaceRef }` or require
+   `?child a gen:Space . ?parent a gen:Space` against the definition graph. On 1.14.4 the
+   filter is a no-op (only IRI pairs exist); on 1.15.x it drops the ref pairs.
+2. **Confirm consumer tolerance:** check whether the Nanodash view that calls this query
+   already filters edge endpoints to known `gen:Space` nodes (in which case the ref pairs
+   drop out client-side and doubling is cosmetic). If so, no action — but `log()` the
+   decision.
+3. Confirm the query is **dead** (superseded by `List sub-spaces of a space`); if nothing
+   calls it, no action.
+
+### C. False positives (no action — read `gen:` edges in assertion graphs, not `npa:` state)
+
+`Get maintained resources`, `Get maintained resources from spaces repo`, `Get sub-resources
+of Space or Maintained Resource`, `Get collections for resource` — these match on
+`gen:isMaintainedBy` inside the nanopub assertion graph (`graph ?a`), which Phase 1/1.5 does
+not touch. Unaffected; listed here so a future audit doesn't re-flag them.
+
+## Procedure
+
+1. Deploy 1.15.x (this PR) to **one** canary instance with `FORCE_RESYNC`; wait for READY +
+   stable load counter.
+2. Capture state-shape baseline as before (`spaceref-baseline-capture.py <canary>/repo/spaces`)
+   and diff vs `spaceref-baseline-nanodash-postresync.json` — admin/role parity, ref-keying,
+   per-ref fan-out. (Necessary but **not sufficient** — that's the lesson.)
+3. **Read-path diff (the new, mandatory step):** for each query in §A, hit
+   `https://<canary>/api/<np>/<slug>?<param>=<value>` and the same on a 1.14.4 reference
+   (`query.knowledgepixels.com` / `query.petapico.org`), compare row counts. Representative
+   params: `resource=https://w3id.org/spaces/knowledgepixels/nanodash/r/home` (a maintained
+   resource), `space=https://w3id.org/spaces/knowledgepixels/nanodash`. Note `/api` results
+   can be cached — re-run after the resync settles.
+4. Resolve §B before opening the canary to the public rotation (or accept option 2/3 with a
+   logged rationale).
+5. Only then roll 1.15.x to the remaining instances.
+
+## One-shot diff helper
+
+```python
+import json, urllib.request
+CANARY="https://<canary-host>"; REF="https://query.knowledgepixels.com"
+SLUG={"RAy49uUd2fPLHJAZ_7QKDtIDVgqaQ589OgQhMwNamKy-4":("get-view-displays","resource",
+      "https://w3id.org/spaces/knowledgepixels/nanodash/r/home")}  # extend with §A rows
+def rows(host, np, slug, p, v):
+    u=f"{host}/api/{np}/{slug}?{p}={urllib.parse.quote(v,safe='')}"
+    req=urllib.request.Request(u, headers={"Accept":"text/csv"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return max(0, r.read().decode().count("\n")-1)
+for np,(slug,p,v) in SLUG.items():
+    print(slug, "canary", rows(CANARY,np,slug,p,v), "ref", rows(REF,np,slug,p,v))
+```

--- a/doc/canary-checklist-spaceref-1.15.md
+++ b/doc/canary-checklist-spaceref-1.15.md
@@ -36,23 +36,30 @@ bind. On ref-only 1.15.0 they returned empty; Phase 1.5 must make them match 1.1
 **Pass criterion:** for representative params, canary row count == 1.14.4 reference row count
 (and non-empty where the reference is non-empty).
 
-### B. DOUBLING RISK introduced by Phase 1.5 (verify or mitigate before rollout)
+### B. DOUBLING introduced by Phase 1.5 — RESOLVED (harmless; no action needed)
 
-| Query family | Latest np | Param | Issue |
+| Query family | Latest np | Param | Behavior |
 |---|---|---|---|
-| Get sub-space links | `RAWgoQbP9_B9h3Bnwd1FGYX1gLYPyZFOxaeqIeA3TTPSU` | _(none)_ | `select ?child ?parent { ?child npa:isSubSpaceOf ?parent }` — **unconstrained** enumeration. Dual-emit returns **both** the ref-to-ref and IRI-to-IRI edge → ~2× rows, half of them ref-shaped IRIs (`…/admin/space/…`) that consumers don't recognize as spaces. |
+| Get sub-space links | `RAWgoQbP9_B9h3Bnwd1FGYX1gLYPyZFOxaeqIeA3TTPSU` | _(none)_ | `select ?child ?parent { ?child npa:isSubSpaceOf ?parent }` — **unconstrained** enumeration. Dual-emit returns **both** the ref-to-ref and IRI-to-IRI edge. Measured on the localhost canary: **304 rows vs 59 on 1.14.4 (5.15×)**, the extra 245 being ref-shaped (`…/admin/space/…`). |
 
-**Options (pick one before/with rollout):**
-1. **Bridge-supersede** this one query to constrain to IRI pairs, working on both fleet
-   versions — e.g. add `FILTER NOT EXISTS { ?parent a npa:SpaceRef }` or require
-   `?child a gen:Space . ?parent a gen:Space` against the definition graph. On 1.14.4 the
-   filter is a no-op (only IRI pairs exist); on 1.15.x it drops the ref pairs.
-2. **Confirm consumer tolerance:** check whether the Nanodash view that calls this query
-   already filters edge endpoints to known `gen:Space` nodes (in which case the ref pairs
-   drop out client-side and doubling is cosmetic). If so, no action — but `log()` the
-   decision.
-3. Confirm the query is **dead** (superseded by `List sub-spaces of a space`); if nothing
-   calls it, no action.
+**Resolution (option 2 — consumer tolerance, confirmed 2026-06-13):** the only live consumer
+is `SpaceRepository.populateSubspaceRelations` in Nanodash (branch `feat/magic-query-params`,
+the co-release candidate; released 4.28.0 doesn't read this repo at all). It resolves both
+endpoints through `spacesById` (keyed by space IRI via `byId.put(space.getId(), space)`) and
+`continue`s when either is `null`:
+
+```java
+Space child  = spacesById.get(r.get("child"));
+Space parent = spacesById.get(r.get("parent"));
+if (child == null || parent == null) continue;   // ref-shaped IRIs aren't keys → dropped
+subspaceMap.computeIfAbsent(parent, k -> new HashSet<>()).add(child);
+```
+
+The ref namespace (`http://purl.org/nanopub/admin/space/…`) is disjoint from space IRIs, so
+the 245 ref-shaped rows are silently dropped; the `HashSet` dedups regardless. The doubling
+is **cosmetic** (extra wire payload only, 304 vs 59 rows) — no correctness impact, **no
+bridge-supersede required** for rollout. A supersede remains a nice-to-have if the wire cost
+ever matters, and is the natural Phase 2 form anyway.
 
 ### C. False positives (no action — read `gen:` edges in assertion graphs, not `npa:` state)
 

--- a/doc/design-spaceref-isolation.md
+++ b/doc/design-spaceref-isolation.md
@@ -244,9 +244,39 @@ always); they are simply never selected for display.
 
 ## Backwards compatibility
 
-- **Nanodash 4.28.0 (released):** does not read the spaces repo. **Zero impact.**
+- **Nanodash 4.28.0 (released):** does not read the spaces repo directly. **Zero impact.**
 - **Post-4.28.0 Nanodash (unreleased):** co-released with the query revisions above.
-- No deprecation window, no dual-keying for legacy reads.
+
+### Phase 1.5 — transitional IRI-valued dual-emit (correction)
+
+The original plan above ("no dual-keying for legacy reads") was **wrong for the structural
+edges**, and 1.15.0 was reverted because of it (see
+`doc/report-2026-06-12-mixed-fleet-spaceref-breakage.md`). The overlooked consumers are not
+a Nanodash version but the **published grlc query nanopubs** themselves: they embed
+`service` hops into the spaces repo and gate on the bare Space IRI
+(`?r npa:isMaintainedBy ?space . ?ri npa:forSpace ?space`). nanopub-java's `QueryCall`
+races the whole fleet and accepts the first 2xx, so a single instance whose structural
+edges are ref-valued-only returns valid-looking empty results fleet-wide.
+
+The row tiers already mitigated this — they kept a transitional `npa:forSpace` dual-emit
+alongside `npa:forSpaceRef`. Phase 1.5 extends the same treatment to the structural-edge
+tiers: each admit pass emits the 1.14.4 **IRI-valued edge alongside** the ref-valued one.
+
+| Tier | Authoritative (ref-valued) | Transitional dual-emit (IRI-valued) |
+|---|---|---|
+| sub-space (explicit + URL-prefix fallback) | `?childRef npa:isSubSpaceOf ?parentRef` (+inv) | `?child npa:isSubSpaceOf ?parent` (+inv) |
+| maintained-resource | `?r npa:isMaintainedBy ?sRef` (+inv) | `?r npa:isMaintainedBy ?s` (+inv) |
+| alias | `?alias npa:sameAsSpace ?canonRef` | `?alias npa:sameAsSpace ?canonical` |
+
+Validation still joins on `npa:forSpaceRef` internally, so isolation is untouched; the
+IRI-valued edges are read-only sugar for pre-ref consumers and are **inert** for the
+internal tiers (which key on refs — an IRI object never binds a `forSpaceRef` variable).
+All seven transitional emits (3 row-tier + 4 structural) carry a `TRANSITIONAL-DUAL-EMIT`
+marker comment so Phase 4 removal is a single grep. No invalidation change: the structural
+convenience edges are already left sticky and reaped by the periodic full rebuild.
+
+This makes a 1.15.x instance safe to deploy onto the mixed-version fleet **ahead of** the
+Nanodash/query co-release, decoupling the rollout from Phases 2–3.
 
 ## Migration
 

--- a/doc/report-2026-06-12-mixed-fleet-spaceref-breakage.md
+++ b/doc/report-2026-06-12-mixed-fleet-spaceref-breakage.md
@@ -1,0 +1,121 @@
+# Report: 1.15.0 space-ref keying breaks IRI-keyed consumers on a mixed-version fleet
+
+**Date:** 2026-06-12
+**Status:** RESOLVED by Phase 1.5 (option 2, generalized) — see "Resolution" below
+**Affects:** Nanodash against the public query fleet; any consumer of the `spaces` repo's validated state
+
+## Symptom
+
+On a fresh Nanodash start (local dev, current `feat/magic-query-params`), the home page
+(`/`) intermittently renders "(no views have been added yet)" instead of the home
+resource's views, and space data appears not to load. Reproduced in-process: five
+identical `QueryAccess.get` calls for
+`get-view-displays?resource=https://w3id.org/spaces/knowledgepixels/nanodash/r/home`
+returned 0, 5, 0, 5, 5 rows.
+
+## Diagnosis chain
+
+1. The nanopub-java client (`QueryCall`, hardcoded list) races two of three instances —
+   `query.knowledgepixels.com`, `query.petapico.org`, `query.nanodash.net` — and accepts
+   the first HTTP-2xx response.
+2. `query.nanodash.net` **deterministically returns 200 with zero rows** for the above
+   query; the other two instances return the 5 home views. When nanodash.net wins the
+   race, Nanodash caches a valid-looking empty result and marks the resource initialized
+   with no views. Nothing fails loudly.
+3. The fleet is version-skewed: knowledgepixels and petapico run **1.14.4**;
+   nanodash.net runs **1.15.0** (all three report READY with the same 83,040 nanopubs).
+4. On nanodash.net, the same SPARQL run ad-hoc against `/repo/...` works (its `service`
+   IRIs resolve via w3id to the public endpoint); only the grlc `/api` route — which
+   rewrites `service` calls to the instance's **own** in-cluster repos — returns empty.
+   So the divergence is in that instance's own `spaces` state.
+5. Bisection of the query via `_nanopub_trig` on nanodash.net isolated the failure to the
+   admin/maintainer authority gate, specifically the maintained-resource hop:
+   `?resource npa:isMaintainedBy? ?space . ?ri ... npa:forSpace ?space .`
+6. Live state on nanodash.net (1.15.0):
+   `<…/nanodash/r/home> npa:isMaintainedBy <http://purl.org/nanopub/admin/space/RAjQAT9…_7918…>`
+   — the object is a **space ref**, not the space IRI. The IRI-keyed join finds nothing →
+   gate yields no authorized pubkeys → zero rows.
+
+## Root cause
+
+PR #119 (per-space-ref authority isolation, Phases 0+1; released in **1.15.0**) re-keys
+the validated `spaces` state to space refs, per `doc/design-spaceref-isolation.md`:
+
+- `npa:isMaintainedBy` edges become resource→**ref**; sub-space edges ref-to-ref;
+  `npa:sameAsSpace` ref-valued on the canonical side.
+- Authority rows join on `npa:forSpaceRef`, with per-ref fan-out (state-row counts
+  differ accordingly: e.g. 709 vs 613 RoleInstantiations on the two versions), plus the
+  intended "members fix" (downward grants validate for the first time).
+
+The change itself is correct and fixes a real privilege-merge bug. The breakage comes
+from **rollout sequencing**: the design's "Read contract" requires co-released,
+ref-explicit Nanodash queries, but all currently published spaces queries (the internal
+`get-view-displays` plus the About-page listings: list-view-displays,
+list-preset-assignments, list-space-roles, list-sub-spaces, list-maintained-resources,
+members/observers, …) are still IRI-keyed. A 1.15.0 instance entered the public rotation
+ahead of that co-release, and the client races mixed-version instances trusting any 2xx.
+
+Spaces themselves still pass the gate on 1.15.0 (the `isMaintainedBy?` zero-hop binds the
+IRI to itself), which made the breakage look flaky and resource-specific: queries about
+`…/spaces/preset-test` worked on nanodash.net while `…/nanodash/r/home` (a maintained
+resource) returned empty.
+
+## Options
+
+1. **Immediate mitigation:** take `query.nanodash.net` out of the public rotation (or
+   roll it back to 1.14.4) until the read side is migrated. The mixed-version fleet is
+   the active hazard — every IRI-keyed spaces query silently flips between full and
+   empty results depending on which instance wins the race.
+2. **Bridge queries (if the fleet must stay mixed):** make the gates dual-model, e.g.
+   `?r npa:isMaintainedBy ?x . optional { ?x npa:spaceIri ?iri } bind(coalesce(?iri, ?x) as ?space)`
+   — resolves both ref-valued (1.15.0) and IRI-valued (1.14.4) edges. Mechanical
+   supersedes of the affected queries; reversible once the fleet converges.
+3. **The planned path:** the read-contract co-release — ref-explicit queries, Nanodash
+   carrying the selected ref into follow-up calls, plus the stray-ref cleanup already
+   scoped in the design doc (6 spaces / 10 stray refs, all benign same-owner duplicates).
+4. **Client robustness (nanopub-java):** `QueryCall` treats any 2xx from any instance as
+   authoritative, giving zero protection against version-skewed or state-divergent
+   instances. A consistency/health check, version pinning, or honoring a configured
+   instance list would have surfaced this loudly instead of as a flaky empty home page.
+
+## Resolution (Phase 1.5)
+
+Chosen fix: option 2, generalized into the materializer instead of into the published
+queries — **transitional IRI-valued dual-emit on the structural-edge tiers**. The root
+cause was that the structural edges (`isMaintainedBy`/`hasMaintainedResource`,
+`isSubSpaceOf`/`hasSubSpace`, `sameAsSpace`) were re-keyed to be ref-valued *only*, while
+the row tiers (admin/attachment/member) had already kept a transitional `npa:forSpace`
+dual-emit. Phase 1.5 closes that asymmetry: every structural admit pass now emits the
+1.14.4 IRI-valued edge *alongside* the ref-valued one. Validation still joins on the ref
+internally, so the privilege-isolation fix is untouched; the IRI edge is read-only sugar
+for pre-ref consumers.
+
+- `AuthorityResolver.subSpaceAdmitUpdate`, `maintainedResourceAdmitUpdate`,
+  `aliasAdmitUpdate`, `subSpacePrefixFallbackUpdate` — each gains the IRI-valued edge in
+  its INSERT block, tagged `TRANSITIONAL-DUAL-EMIT (Phase 1.5; remove in Phase 4)`.
+- The three pre-existing row-tier `forSpace` dual-emits were retro-tagged with the same
+  marker, so the eventual Phase 4 cleanup is one `grep TRANSITIONAL-DUAL-EMIT`.
+- No invalidation change: structural convenience edges are already left sticky and reaped
+  by the periodic full rebuild; the IRI-valued ones inherit that policy.
+- Why generalize rather than supersede published queries (literal option 2): it fixes
+  *every* IRI-keyed consumer, including ones not enumerated, and decouples redeploy from
+  the Nanodash co-release. Option 2's `coalesce(?iri, ?x)` shape remains the right pattern
+  for the Phase 2 ref-explicit rewrites.
+
+Tests: `AuthorityResolverStructuralDualEmitTest` (6) asserts each pass emits both shapes,
+that the exact legacy `get-view-displays` maintained gate binds the admin again, and that
+the IRI-valued alias edge stays inert for the internal ref-keyed attachment tier. Full
+suite 243 green. Safe to redeploy onto the mixed-version fleet; reverted in Phase 4 once
+Phase 2/3 land. The class is expected to be deleted together with the dual-emit blocks.
+
+## Evidence quick-reference
+
+- `query.nanodash.net/api/RAy49uUd…/get-view-displays?resource=…/r/home` → 200, header
+  only (deterministic, 4/4); same call on knowledgepixels/petapico → 5 rows.
+- Same SPARQL ad-hoc via POST on `query.nanodash.net/repo/type/11daee46…` → 5 rows
+  (services resolve via w3id to the public endpoint, masking the local divergence).
+- Gate-less variant of the query via `_nanopub_trig` on nanodash.net → 5 rows;
+  gate-only variant → 0 rows.
+- `select ?o { … <r/home> npa:isMaintainedBy ?o }` on nanodash.net's current state →
+  `http://purl.org/nanopub/admin/space/RAjQAT9PGfqv-YlzUMYAK79xx_LH48BZuOYLJYGdJlLbI_7918859685a77dffb48a5a44ed2e923de10ae412b326830de6701738ff8a2d5d`;
+  on knowledgepixels → `https://w3id.org/spaces/knowledgepixels/nanodash`.

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -750,9 +750,10 @@ public final class AuthorityResolver {
         // so we project it per-ref by joining each instantiation naming ?space to the
         // admin rows of every ref of ?space whose admin set contains the publisher. The
         // inserted subject is minted per (?ri, ?spaceRef) so one instantiation validating
-        // into N refs yields N distinct rows. Transitional: forSpace is still emitted
-        // alongside forSpaceRef so the not-yet-migrated downstream tiers / read queries
-        // keep functioning; it is dropped once everything keys on forSpaceRef.
+        // into N refs yields N distinct rows. TRANSITIONAL-DUAL-EMIT (Phase 4: remove):
+        // forSpace is still emitted alongside forSpaceRef so the not-yet-migrated
+        // downstream tiers / pre-ref read queries keep functioning on a mixed-version
+        // fleet; it is dropped once everything keys on forSpaceRef.
         return """
                 PREFIX npa:  <%1$s>
                 PREFIX gen:  <%2$s>
@@ -877,9 +878,10 @@ public final class AuthorityResolver {
         // contains the publisher (direct), or — when the named IRI is an owl:sameAs alias
         // — for the canonical ref it maps to (issue #113). ?targetRef is the ref the
         // RoleAssignment attaches to; the inserted subject is minted per (?ra, ?targetRef)
-        // so one attachment validating into N refs yields N distinct rows. forSpace (the
-        // attached IRI, possibly an alias) is kept so the non-admin tier can probe the
-        // IRI-keyed instantiations naming it.
+        // so one attachment validating into N refs yields N distinct rows.
+        // TRANSITIONAL-DUAL-EMIT (Phase 4: remove): forSpace (the attached IRI, possibly an
+        // alias) is kept so the non-admin tier can probe the IRI-keyed instantiations
+        // naming it, and so pre-ref read queries keep functioning on a mixed-version fleet.
         return """
                 PREFIX npa:  <%1$s>
                 PREFIX gen:  <%2$s>
@@ -1003,6 +1005,9 @@ public final class AuthorityResolver {
                 INSERT { GRAPH <%3$s> {
                   ?ri2 a gen:RoleInstantiation ;
                        npa:forSpaceRef ?spaceRef ;
+                       # TRANSITIONAL-DUAL-EMIT (Phase 4: remove): forSpace alongside
+                       # forSpaceRef so pre-ref read queries (e.g. get-space-members) keep
+                       # functioning on a mixed-version fleet; downstream tiers key on the ref.
                        npa:forSpace ?space ;
                        npa:forAgent ?agent ;
                        ?dirPred ?pred ;
@@ -1112,6 +1117,12 @@ public final class AuthorityResolver {
                      npa:viaNanopub  ?np .
                   ?childRef  npa:isSubSpaceOf ?parentRef .
                   ?parentRef npa:hasSubSpace  ?childRef  .
+                  # TRANSITIONAL-DUAL-EMIT (Phase 1.5; remove in Phase 4): IRI-valued
+                  # sub-space edge alongside the ref-to-ref one, so pre-ref published
+                  # queries that key on the bare Space IRI keep binding on a mixed-version
+                  # fleet. See doc/report-2026-06-12-mixed-fleet-spaceref-breakage.md.
+                  ?child  npa:isSubSpaceOf ?parent .
+                  ?parent npa:hasSubSpace  ?child  .
                 } }
                 WHERE {
                   # 1. Anchor: candidate declarations from the extraction graph.
@@ -1229,6 +1240,13 @@ public final class AuthorityResolver {
                      npa:viaNanopub      ?np .
                   ?r npa:isMaintainedBy        ?sRef .
                   ?sRef npa:hasMaintainedResource ?r .
+                  # TRANSITIONAL-DUAL-EMIT (Phase 1.5; remove in Phase 4): IRI-valued
+                  # maintained-resource edge alongside the resource→ref one, so pre-ref
+                  # published queries (e.g. get-view-displays' maintained hop) keep binding
+                  # on a mixed-version fleet. This is the edge whose absence broke 1.15.0 —
+                  # see doc/report-2026-06-12-mixed-fleet-spaceref-breakage.md.
+                  ?r npa:isMaintainedBy        ?s .
+                  ?s npa:hasMaintainedResource ?r .
                 } }
                 WHERE {
                   # 1. Anchor: candidate declarations from the extraction graph.
@@ -1321,6 +1339,14 @@ public final class AuthorityResolver {
                      npa:aliasSpace     ?alias ;
                      npa:viaNanopub     ?np .
                   ?alias npa:sameAsSpace ?canonRef .
+                  # TRANSITIONAL-DUAL-EMIT (Phase 1.5; remove in Phase 4): IRI-valued
+                  # alias edge alongside the ref-valued one, so pre-ref published queries
+                  # that resolve owl:sameAs by bare canonical IRI keep binding on a
+                  # mixed-version fleet. Internal alias-aware lookups (attachment tier)
+                  # join through npa:forSpaceRef, which is ref-valued, so this IRI-valued
+                  # object never satisfies them — it is inert internally, read-only for
+                  # legacy consumers. See doc/report-2026-06-12-mixed-fleet-spaceref-breakage.md.
+                  ?alias npa:sameAsSpace ?canonical .
                 } }
                 WHERE {
                   # 1. Anchor: candidate alias declarations from the extraction graph.
@@ -1418,6 +1444,12 @@ public final class AuthorityResolver {
                 INSERT { GRAPH <%2$s> {
                   ?childRef  npa:isSubSpaceOf ?parentRef .
                   ?parentRef npa:hasSubSpace  ?childRef  .
+                  # TRANSITIONAL-DUAL-EMIT (Phase 1.5; remove in Phase 4): IRI-valued
+                  # derived sub-space edge alongside the ref-to-ref one, mirroring the
+                  # explicit sub-space pass, so pre-ref published queries keep binding on a
+                  # mixed-version fleet. See doc/report-2026-06-12-mixed-fleet-spaceref-breakage.md.
+                  ?child  npa:isSubSpaceOf ?parent .
+                  ?parent npa:hasSubSpace  ?child  .
                   ?tagIri a npa:DerivedSubSpaceLink ;
                           npa:childSpace     ?child ;
                           npa:parentSpace    ?parent ;

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverStructuralDualEmitTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverStructuralDualEmitTest.java
@@ -1,0 +1,289 @@
+package com.knowledgepixels.query;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.vocabulary.NPA;
+
+import com.knowledgepixels.query.vocabulary.GEN;
+import com.knowledgepixels.query.vocabulary.SpacesVocab;
+
+/**
+ * Phase 1.5 — transitional IRI-valued dual-emit on the structural-edge tiers.
+ *
+ * <p>Phase 1 ({@link AuthorityResolverTierIsolationTest}) re-keyed the structural edges
+ * (sub-space, maintained-resource, alias) to be ref-valued only. That silently broke
+ * pre-ref published query nanopubs on a mixed-version fleet — they gate on the bare Space
+ * IRI ({@code ?r npa:isMaintainedBy ?space . ?ri npa:forSpace ?space}) and the ref-valued
+ * object no longer binds (see {@code doc/report-2026-06-12-mixed-fleet-spaceref-breakage.md}).
+ *
+ * <p>Phase 1.5 restores the IRI-valued edges <em>alongside</em> the ref-valued ones
+ * (validation still keys on the ref internally). These tests assert each structural admit
+ * pass emits BOTH shapes, that the exact legacy gate that broke now binds again, and that
+ * the IRI-valued alias edge stays inert for the internal (ref-keyed) attachment tier.
+ *
+ * <p>When Phase 4 drops the transitional emits, this whole class is expected to be deleted
+ * together with the {@code TRANSITIONAL-DUAL-EMIT} blocks it guards.
+ */
+class AuthorityResolverStructuralDualEmitTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+    private static final IRI STATE = SpacesVocab.forSpaceState(
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", 1L);
+    private static final IRI SPACES = SpacesVocab.SPACES_GRAPH;
+
+    private static IRI npa(String ln) { return vf.createIRI(NPA.NAMESPACE, ln); }
+    private static IRI ex(String ln)  { return vf.createIRI("http://example.org/", ln); }
+
+    private static final IRI S     = ex("space-S");
+    private static final IRI R1    = ex("ref-R1");
+    private static final IRI R2    = ex("ref-R2");
+    private static final IRI ALICE = ex("alice");
+    private static final IRI BOB   = ex("bob");
+    private static final Literal PKH_A = vf.createLiteral("pkhA");
+    private static final Literal PKH_B = vf.createLiteral("pkhB");
+
+    private Repository repo;
+    private RepositoryConnection c;
+
+    @BeforeEach
+    void setUp() {
+        repo = new SailRepository(new MemoryStore());
+        repo.init();
+        c = repo.getConnection();
+        // Two refs sharing IRI S; Alice admins R1, Bob admins R2. Admin rows dual-emit
+        // forSpace (as the real admin tier does) so the IRI-keyed legacy gate can resolve.
+        refIri(R1, S);
+        refIri(R2, S);
+        account("acctA", ALICE, PKH_A);
+        account("acctB", BOB, PKH_B);
+        admin("adm_a", R1, S, ALICE);
+        admin("adm_b", R2, S, BOB);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (c != null) c.close();
+        if (repo != null) repo.shutDown();
+    }
+
+    @Test
+    void subSpaceDualEmitsRefAndIriEdges() {
+        IRI sc = ex("child"), sp = ex("parent");
+        IRI rc = ex("ref-child"), rp = ex("ref-parent");
+        refIri(rc, sc);
+        refIri(rp, sp);
+        admin("adm_ac", rc, sc, ALICE);
+        admin("adm_ap", rp, sp, ALICE);
+        extSubSpace("ss1", sc, sp, PKH_A, ex("np_ss"));
+        runToFixpoint(AuthorityResolver.subSpaceAdmitUpdate(STATE, -1));
+
+        // ref-to-ref (Phase 1, the internal/authoritative shape)
+        assertTrue(edge(rc, npa("isSubSpaceOf"), rp), "ref-to-ref sub-space edge present");
+        assertTrue(edge(rp, npa("hasSubSpace"), rc), "inverse ref-to-ref edge present");
+        // IRI-to-IRI (Phase 1.5 transitional, for legacy consumers)
+        assertTrue(edge(sc, npa("isSubSpaceOf"), sp), "IRI-valued sub-space edge dual-emitted");
+        assertTrue(edge(sp, npa("hasSubSpace"), sc), "inverse IRI-valued edge dual-emitted");
+    }
+
+    @Test
+    void maintainedResourceDualEmitsRefAndIriEdges() {
+        IRI res = ex("resource-1");
+        extMaintained("mr1", res, S, PKH_A, ex("np_mr"));
+        runToFixpoint(AuthorityResolver.maintainedResourceAdmitUpdate(STATE, -1));
+
+        // resource → ref (Phase 1)
+        assertTrue(edge(res, npa("isMaintainedBy"), R1), "resource → ref edge present");
+        assertTrue(edge(R1, npa("hasMaintainedResource"), res), "inverse ref edge present");
+        // resource → IRI (Phase 1.5)
+        assertTrue(edge(res, npa("isMaintainedBy"), S), "IRI-valued maintained edge dual-emitted");
+        assertTrue(edge(S, npa("hasMaintainedResource"), res), "inverse IRI-valued edge dual-emitted");
+        // isolation is preserved: still no edge to Bob's ref
+        assertFalse(edge(res, npa("isMaintainedBy"), R2), "must NOT map to the un-governed ref R2");
+    }
+
+    @Test
+    void aliasDualEmitsRefAndIriEdges() {
+        IRI aold = ex("space-S-old");
+        extAlias("al1", S, aold, PKH_A, ex("np_al"));   // canonical=S, alias=aold
+        runToFixpoint(AuthorityResolver.aliasAdmitUpdate(STATE, -1));
+
+        assertTrue(edge(aold, npa("sameAsSpace"), R1), "ref-valued alias edge present (canonical ref R1)");
+        assertTrue(edge(aold, npa("sameAsSpace"), S), "IRI-valued alias edge dual-emitted (canonical IRI S)");
+        assertFalse(edge(aold, npa("sameAsSpace"), R2), "must NOT map to the un-governed ref R2");
+    }
+
+    @Test
+    void prefixFallbackDualEmitsRefAndIriEdges() {
+        // Child SpaceRef whose id-prefix is the parent IRI; no explicit declaration, so the
+        // URL-prefix fallback engages.
+        IRI parent = ex("p");
+        IRI child  = ex("p/sub");
+        IRI rc = ex("ref-pchild"), rp = ex("ref-pparent");
+        c.add(rc, SpacesVocab.SPACE_IRI, child, SPACES);
+        c.add(rc, npa("hasIdPrefix"), parent, SPACES);
+        c.add(rp, SpacesVocab.SPACE_IRI, parent, SPACES);
+        runToFixpoint(AuthorityResolver.subSpacePrefixFallbackUpdate(STATE));
+
+        assertTrue(edge(rc, npa("isSubSpaceOf"), rp), "derived ref-to-ref edge present");
+        assertTrue(edge(child, npa("isSubSpaceOf"), parent), "derived IRI-valued edge dual-emitted");
+        assertTrue(edge(parent, npa("hasSubSpace"), child), "derived inverse IRI-valued edge dual-emitted");
+    }
+
+    /**
+     * The regression: the exact gate shape that get-view-displays embeds — bind the space
+     * via the IRI-valued maintained edge, then require an admin RoleInstantiation
+     * {@code npa:forSpace ?space}. Pre-1.5 this returned no admin (the maintained object was
+     * a ref, forSpace was the IRI); Phase 1.5 makes it bind again.
+     */
+    @Test
+    void legacyIriKeyedMaintainedGateBindsAdmin() {
+        IRI res = ex("resource-1");
+        extMaintained("mr1", res, S, PKH_A, ex("np_mr"));
+        runToFixpoint(AuthorityResolver.maintainedResourceAdmitUpdate(STATE, -1));
+
+        boolean adminVisible = c.prepareBooleanQuery(QueryLanguage.SPARQL, """
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                ASK { GRAPH <%3$s> {
+                  { <%4$s> npa:isMaintainedBy ?space . } UNION { BIND(<%4$s> AS ?space) }
+                  ?ri a gen:RoleInstantiation ;
+                      npa:inverseProperty gen:hasAdmin ;
+                      npa:forSpace ?space ;
+                      npa:forAgent ?adminAgent .
+                  ?acct a npa:AccountState ;
+                        npa:agent ?adminAgent ;
+                        npa:pubkey ?pubkey .
+                } }
+                """.formatted(NPA.NAMESPACE, GEN.NAMESPACE, STATE, res)).evaluate();
+        assertTrue(adminVisible,
+                "legacy IRI-keyed maintained-resource gate resolves the maintaining space's admin");
+    }
+
+    /**
+     * Safety: the IRI-valued alias edge must stay inert for the internal attachment tier,
+     * which joins {@code ?space npa:sameAsSpace ?targetRef . ?adminRI npa:forSpaceRef ?targetRef}.
+     * Because {@code forSpaceRef} is ref-valued, the IRI object can never bind ?targetRef —
+     * so an attachment naming the alias still validates into exactly the canonical ref, never
+     * the bare IRI.
+     */
+    @Test
+    void iriValuedAliasEdgeIsInertForInternalAttachmentTier() {
+        IRI aold = ex("space-S-old");
+        IRI roleX = ex("roleX");
+        extAlias("al1", S, aold, PKH_A, ex("np_al"));
+        runToFixpoint(AuthorityResolver.aliasAdmitUpdate(STATE, -1));
+        // Alice attaches roleX to the alias IRI; it must validate into canonical ref R1.
+        extAttachment("att1", aold, roleX, PKH_A, ex("np_att"));
+        runToFixpoint(AuthorityResolver.attachmentValidationUpdate(STATE, -1));
+
+        assertTrue(hasAssignment(R1, roleX), "aliased attachment validated into canonical ref R1");
+        assertFalse(hasAssignment(R2, roleX), "must NOT leak into the un-governed ref R2");
+        // The IRI-valued alias object (S) must not have produced a bogus IRI-keyed assignment.
+        assertFalse(hasAssignment(S, roleX), "IRI-valued alias edge produced no spurious IRI-keyed row");
+        assertFalse(hasAssignment(aold, roleX), "no assignment keyed on the bare alias IRI");
+    }
+
+    // ---------------- seeding helpers ----------------
+
+    private void refIri(IRI ref, IRI iri) { c.add(ref, SpacesVocab.SPACE_IRI, iri, SPACES); }
+
+    private void account(String name, IRI agent, Literal pkh) {
+        IRI a = ex(name);
+        c.add(a, RDF.TYPE, npa("AccountState"), STATE);
+        c.add(a, npa("agent"), agent, STATE);
+        c.add(a, npa("pubkey"), pkh, STATE);
+    }
+
+    private void admin(String name, IRI ref, IRI iri, IRI agent) {
+        IRI ri = ex(name);
+        c.add(ri, RDF.TYPE, GEN.ROLE_INSTANTIATION, STATE);
+        c.add(ri, SpacesVocab.FOR_SPACE_REF, ref, STATE);
+        c.add(ri, SpacesVocab.FOR_SPACE, iri, STATE);
+        c.add(ri, SpacesVocab.INVERSE_PROPERTY, GEN.HAS_ADMIN, STATE);
+        c.add(ri, SpacesVocab.FOR_AGENT, agent, STATE);
+    }
+
+    private void loadNum(IRI np) { c.add(np, npa("hasLoadNumber"), vf.createLiteral(0L), NPA.GRAPH); }
+
+    private void extAttachment(String name, IRI iri, IRI role, Literal pkh, IRI np) {
+        IRI ra = ex(name);
+        c.add(ra, RDF.TYPE, vf.createIRI(GEN.NAMESPACE, "RoleAssignment"), SPACES);
+        c.add(ra, SpacesVocab.FOR_SPACE, iri, SPACES);
+        c.add(ra, GEN.HAS_ROLE, role, SPACES);
+        c.add(ra, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(ra, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        loadNum(np);
+    }
+
+    private void extAlias(String name, IRI canonical, IRI alias, Literal pkh, IRI np) {
+        IRI d = ex(name);
+        c.add(d, RDF.TYPE, SpacesVocab.SPACE_ALIAS_DECLARATION, SPACES);
+        c.add(d, SpacesVocab.CANONICAL_SPACE, canonical, SPACES);
+        c.add(d, SpacesVocab.ALIAS_SPACE, alias, SPACES);
+        c.add(d, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(d, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        loadNum(np);
+    }
+
+    private void extSubSpace(String name, IRI child, IRI parent, Literal pkh, IRI np) {
+        IRI d = ex(name);
+        c.add(d, RDF.TYPE, SpacesVocab.SUB_SPACE_DECLARATION, SPACES);
+        c.add(d, SpacesVocab.CHILD_SPACE, child, SPACES);
+        c.add(d, SpacesVocab.PARENT_SPACE, parent, SPACES);
+        c.add(d, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(d, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        loadNum(np);
+    }
+
+    private void extMaintained(String name, IRI resource, IRI space, Literal pkh, IRI np) {
+        IRI d = ex(name);
+        c.add(d, RDF.TYPE, SpacesVocab.MAINTAINED_RESOURCE_DECLARATION, SPACES);
+        c.add(d, SpacesVocab.RESOURCE_IRI, resource, SPACES);
+        c.add(d, SpacesVocab.MAINTAINER_SPACE, space, SPACES);
+        c.add(d, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(d, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        loadNum(np);
+    }
+
+    // ---------------- execution + assertions ----------------
+
+    private void runToFixpoint(String update) {
+        long before = c.size(STATE);
+        while (true) {
+            c.prepareUpdate(QueryLanguage.SPARQL, update).execute();
+            long after = c.size(STATE);
+            if (after <= before) break;
+            before = after;
+        }
+    }
+
+    private boolean hasAssignment(IRI ref, IRI role) {
+        return ask("?ra a gen:RoleAssignment ; npa:forSpaceRef <" + ref + "> ; gen:hasRole <" + role + "> .");
+    }
+
+    private boolean edge(IRI s, IRI p, IRI o) {
+        return ask("<" + s + "> <" + p + "> <" + o + "> .");
+    }
+
+    private boolean ask(String pattern) {
+        return c.prepareBooleanQuery(QueryLanguage.SPARQL, """
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                ASK { GRAPH <%3$s> { %4$s } }
+                """.formatted(NPA.NAMESPACE, GEN.NAMESPACE, STATE, pattern)).evaluate();
+    }
+}


### PR DESCRIPTION
## Why

1.15.0 (PR #119) re-keyed the structural edges (`isMaintainedBy`/`hasMaintainedResource`, `isSubSpaceOf`/`hasSubSpace`, `sameAsSpace`) to be **ref-valued only**. That silently broke the published grlc query nanopubs on a mixed-version fleet: they gate on the bare Space IRI (`?r npa:isMaintainedBy ?space . ?ri npa:forSpace ?space`), the ref-valued object no longer binds, and nanopub-java's `QueryCall` — which races the fleet and accepts the first 2xx — served valid-looking **empty** results. 1.15.0 was reverted in the field.

Full diagnosis: `doc/report-2026-06-12-mixed-fleet-spaceref-breakage.md`.

## What

Restore the 1.14.4 IRI-valued edge **alongside** the ref-valued one in each structural admit pass:

| Pass | Authoritative (ref) | Transitional dual-emit (IRI) |
|---|---|---|
| `subSpaceAdmitUpdate` | `?childRef isSubSpaceOf ?parentRef` (+inv) | `?child isSubSpaceOf ?parent` (+inv) |
| `subSpacePrefixFallbackUpdate` | derived ref-to-ref | derived IRI-to-IRI |
| `maintainedResourceAdmitUpdate` | `?r isMaintainedBy ?sRef` (+inv) | `?r isMaintainedBy ?s` (+inv) |
| `aliasAdmitUpdate` | `?alias sameAsSpace ?canonRef` | `?alias sameAsSpace ?canonical` |

Validation still joins on `npa:forSpaceRef` internally, so per-ref **isolation is untouched**; the IRI-valued edges are read-only sugar for pre-ref consumers and are **inert** for the internal ref-keyed tiers (a `forSpaceRef` variable never binds a bare IRI).

All **seven** transitional emits (3 pre-existing row-tier `forSpace`, retro-tagged, + 4 new structural) carry a `TRANSITIONAL-DUAL-EMIT` marker so the eventual Phase 4 cleanup is one grep. **No invalidation change** — structural convenience edges are already left sticky and reaped by the periodic full rebuild, so the IRI-valued ones inherit that policy.

## Tests

New `AuthorityResolverStructuralDualEmitTest` (6): each pass emits both shapes; the exact legacy `get-view-displays` maintained gate binds the admin again; the IRI-valued alias edge stays inert for the internal attachment tier. **Full suite 243 green.**

## Rollout note

Safe to deploy onto the still-mixed (1.14.4) fleet ahead of the Nanodash/query co-release. Re-canary must run the **published queries via `/api`** (not just state shape — that's the gap that let 1.15.0 through). One follow-up flagged: **"Get sub-space links"** is an *unconstrained* enumeration (`?child npa:isSubSpaceOf ?parent`) and will return doubled (ref + IRI) rows under dual-emit — needs a bridge-supersede or a Nanodash-tolerance check before/with rollout. The constrained `List sub-spaces of a space` / `List maintained resources of a space` are IRI-subject-keyed and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)