### PR TITLE
feat(spaces): materialize preset-bundled roles as validated attachments

### DIFF
--- a/doc/design-preset-role-materialization.md
+++ b/doc/design-preset-role-materialization.md
@@ -1,7 +1,29 @@
 # Design: materialize preset-bundled roles as validated role attachments
 
-Status: **design, not yet implemented** (handed off from the Nanodash side, presets issue #302 "point 1").
+Status: **implemented** (presets issue #302 "point 1"; handed off from the Nanodash side).
 Scope: this document covers the **nanopub-query** work. The Nanodash side needs no role-loading change (see §6).
+
+> **Implementation notes — two deviations from this design, verified against Nanodash source:**
+> 1. **Activation is active-by-default, not require-explicit.** §4.2 said "log+skip if neither
+>    `gen:ActivatedPresetAssignment` nor `gen:DeactivatedPresetAssignment`." Nanodash's
+>    `PresetAssignment.isActive()` is `!types.contains(DeactivatedPresetAssignment)` — an assignment
+>    typed only `gen:PresetAssignment` is **active**. Skipping it would silently drop valid
+>    assignments, so extraction emits `npa:isActivated = false` iff explicitly deactivated, else `true`.
+> 2. **The join keys on the canonical preset *kind*, with latest-declaration-per-kind resolution
+>    — consistent with how Nanodash views work.** Nanodash keys views on their `dct:isVersionOf`
+>    kind (`ViewDisplay.getViewKindIri()`, node-IRI fallback) and resolves each to its latest current
+>    head server-side in the `get-view-displays` query; the per-view-kind latest-wins lives in
+>    `AbstractResourceWithProfile.getViewDisplays()`. The preset-role materialization mirrors this:
+>    - `extractPreset` emits `npa:presetKind` = the `dct:isVersionOf` kind (or the `gen:Preset` node IRI
+>      as fallback), plus `npa:ofPreset` for **both** the node IRI and the kind as lookup keys (the wire
+>      IRI in `gen:isAssignmentOfPreset` may be either).
+>    - `presetAttachmentValidationUpdate` maps the assignment's referenced IRI → canonical kind (via any
+>      declaration's `npa:ofPreset`/`npa:presetKind`), then draws roles only from the **latest live**
+>      declaration of that kind (`MAX(dct:created)` among non-invalidated declarations, subject-IRI
+>      tiebreak). A superseded preset version's roles never leak — closing what was previously flagged as
+>      a version-supersession limitation. Equivalent to the view "most-recent current head" rule in the
+>      common case; invalidation filtering drops superseded versions, and the timestamp tiebreak handles
+>      transient multi-head.
 
 ## 1. Context & goal
 

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -241,18 +241,18 @@ public final class AuthorityResolver {
         TierSubjectTotals totals = computeTierSubjectTotals(newGraph);
         long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
         lastSubjectTotals = totals;
-        lastInsertedTriplesTotal = (long) counts.admin + counts.alias + counts.attachment
-                + counts.maintainer + counts.member + counts.observer
+        lastInsertedTriplesTotal = (long) counts.admin + counts.alias + counts.presetAttachment
+                + counts.attachment + counts.maintainer + counts.member + counts.observer
                 + counts.subSpace + counts.subSpacePrefix + counts.maintainedResource;
         lastFullBuildDurationMs = durationMs;
         lastProcessedUpToLag = 0L;
         logger.info("AuthorityResolver: full build complete — graph={} mirrored={} rows loadCounter={} "
                         + "subjects: adminRIs={} attachmentRAs={} nonAdminRIs={} "
-                        + "(inserted-triples: admin={} alias={} attachment={} maintainer={} member={} observer={} "
+                        + "(inserted-triples: admin={} alias={} preset-attachment={} attachment={} maintainer={} member={} observer={} "
                         + "subspace={} subspace-prefix={} maintained-resource={}) durationMs={}",
                 newGraph, mirrored, loadCounter,
                 totals.adminRIs(), totals.attachmentRAs(), totals.nonAdminRIs(),
-                counts.admin, counts.alias, counts.attachment, counts.maintainer, counts.member, counts.observer,
+                counts.admin, counts.alias, counts.presetAttachment, counts.attachment, counts.maintainer, counts.member, counts.observer,
                 counts.subSpace, counts.subSpacePrefix, counts.maintainedResource,
                 durationMs);
     }
@@ -298,9 +298,11 @@ public final class AuthorityResolver {
         TierInsertedTriples counts = runAllTierLoops(graph, lastProcessed);
         boolean structuralAdds = (counts.admin > 0)
                 || (counts.alias > 0)
+                || (counts.presetAttachment > 0)
                 || (counts.attachment > 0)
                 || (counts.subSpace > 0)
-                || newRoleDeclarationsArrived(lastProcessed);
+                || newRoleDeclarationsArrived(lastProcessed)
+                || newPresetAssignmentsArrived(lastProcessed);
         if (structuralAdds) {
             // Late-arrival sweep: leaf tiers (attachment/maintainer/member/observer)
             // can promote candidates whose enabling event arrived in this same cycle.
@@ -312,6 +314,7 @@ public final class AuthorityResolver {
             // already handled by the regular pass.
             TierInsertedTriples lateCounts = runDownstreamWithoutLoadFilter(graph);
             counts.alias              += lateCounts.alias;
+            counts.presetAttachment   += lateCounts.presetAttachment;
             counts.attachment         += lateCounts.attachment;
             counts.maintainer         += lateCounts.maintainer;
             counts.member             += lateCounts.member;
@@ -326,18 +329,18 @@ public final class AuthorityResolver {
         TierSubjectTotals totals = computeTierSubjectTotals(graph);
         long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
         lastSubjectTotals = totals;
-        lastInsertedTriplesTotal = (long) counts.admin + counts.alias + counts.attachment
-                + counts.maintainer + counts.member + counts.observer
+        lastInsertedTriplesTotal = (long) counts.admin + counts.alias + counts.presetAttachment
+                + counts.attachment + counts.maintainer + counts.member + counts.observer
                 + counts.subSpace + counts.subSpacePrefix + counts.maintainedResource;
         lastIncrementalCycleDurationMs = durationMs;
         logger.info("AuthorityResolver: incremental cycle complete — graph={} delta=({}, {}] "
                         + "subjects: adminRIs={} attachmentRAs={} nonAdminRIs={} "
-                        + "(inserted-triples: admin={} alias={} attachment={} maintainer={} member={} observer={} "
+                        + "(inserted-triples: admin={} alias={} preset-attachment={} attachment={} maintainer={} member={} observer={} "
                         + "subspace={} subspace-prefix={} maintained-resource={}) "
                         + "structuralInvalidation={} structuralAdds={} durationMs={}",
                 graph, lastProcessed, currentLoadCounter,
                 totals.adminRIs(), totals.attachmentRAs(), totals.nonAdminRIs(),
-                counts.admin, counts.alias, counts.attachment, counts.maintainer, counts.member, counts.observer,
+                counts.admin, counts.alias, counts.presetAttachment, counts.attachment, counts.maintainer, counts.member, counts.observer,
                 counts.subSpace, counts.subSpacePrefix, counts.maintainedResource,
                 structuralInvalidation, structuralAdds, durationMs);
     }
@@ -388,6 +391,19 @@ public final class AuthorityResolver {
             executeUpdate(aliasInvalidationDelete(graph, lastProcessed));
             structural = true;
         }
+        // Preset-derived RoleAssignment removal (issue #302). NOT npx:invalidates: a newer
+        // admin-authored same-(preset,resource) assignment supersedes by dct:created (a
+        // gen:DeactivatedPresetAssignment, or any newer assignment that is no longer active).
+        // Structural — sticky downstream non-admin RIs derived through a removed attachment
+        // are bounded by the periodic full rebuild. The DELETE is scoped by
+        // npa:derivedFromPreset so directly-published gen:hasRole attachments are never
+        // touched; the §4.3 re-INSERT re-materializes only currently-active pairs in the same
+        // cycle. See doc/design-preset-role-materialization.md §4.4.
+        if (wouldInvalidate(graph, lastProcessed, /*adminPinned=*/ false,
+                            presetDeactivationCheckWhere(graph, lastProcessed))) {
+            executeUpdate(presetDeactivationDelete(graph, lastProcessed));
+            structural = true;
+        }
         // Leaf-tier RI deletes — no flag.
         executeUpdate(leafTierInvalidationDelete(graph, lastProcessed));
         // Maintained-resource declaration deletes — no flag (leaf relation, no
@@ -423,6 +439,11 @@ public final class AuthorityResolver {
         // future inserts) and any newly-orphaned children pick up fallback edges.
         c.subSpacePrefix = runTierLabeled("subspace-prefix(late)", graph,
                 subSpacePrefixFallbackUpdate(graph));
+        // Preset-attachment late-arrival: catches assignments whose preset declaration or
+        // admin grant only became valid in this same cycle. Runs before attachment(late)
+        // so the non-admin late tiers below see this cycle's fresh preset-derived RAs.
+        c.presetAttachment = runTierLabeled("preset-attachment(late)", graph,
+                presetAttachmentValidationUpdate(graph, -1));
         c.attachment = runTierLabeled("attachment(late)", graph,
                 attachmentValidationUpdate(graph, -1));
         c.maintainer = runTierLabeled("maintainer(late)", graph,
@@ -468,6 +489,31 @@ public final class AuthorityResolver {
         return runAsk(ask);
     }
 
+    /**
+     * Cheap ASK: did any new {@code npa:PresetAssignment} or {@code npa:PresetDeclaration}
+     * extraction land in the load-number delta {@code (lastProcessed, ∞)}? Drives the
+     * late-arrival re-run so a preset assignment that arrives in the same cycle as its
+     * declaration (or admin grant) still materializes, and so an arriving newer assignment
+     * triggers the deactivation/latest-wins re-evaluation.
+     */
+    boolean newPresetAssignmentsArrived(long lastProcessed) {
+        String ask = String.format("""
+                PREFIX npa: <%1$s>
+                ASK {
+                  GRAPH <%2$s> {
+                    ?x a ?t ;
+                       npa:viaNanopub ?np .
+                    FILTER (?t = npa:PresetAssignment || ?t = npa:PresetDeclaration)
+                  }
+                  GRAPH <%3$s> {
+                    ?np npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %4$d)
+                  }
+                }
+                """, NPA.NAMESPACE, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed);
+        return runAsk(ask);
+    }
+
     // ---------------- Tier UPDATE loops ----------------
 
     /**
@@ -485,6 +531,7 @@ public final class AuthorityResolver {
     static final class TierInsertedTriples {
         int admin;
         int alias;
+        int presetAttachment;
         int attachment;
         int maintainer;
         int member;
@@ -531,6 +578,13 @@ public final class AuthorityResolver {
         // delta-arrivals; the dedup FILTER NOT EXISTS prevents re-insertion.
         c.subSpacePrefix = runTierLabeled("subspace-prefix", graph,
                 subSpacePrefixFallbackUpdate(graph));
+        // Preset-attachment runs immediately before the regular attachment tier so the
+        // gen:RoleAssignment rows it materializes (from active, admin-authored preset
+        // assignments) are picked up by the downstream non-admin tiers in the same pass,
+        // exactly like directly-published attachments. See
+        // doc/design-preset-role-materialization.md.
+        c.presetAttachment = runTierLabeled("preset-attachment", graph,
+                presetAttachmentValidationUpdate(graph, lastProcessed));
         c.attachment = runTierLabeled("attachment", graph,
                 attachmentValidationUpdate(graph, lastProcessed));
         c.maintainer = runTierLabeled("maintainer", graph, nonAdminTierUpdate(graph, lastProcessed,
@@ -946,6 +1000,156 @@ public final class AuthorityResolver {
                 lastProcessed,
                 invalidationFilter("np"),
                 NPA.GRAPH);
+    }
+
+    /**
+     * Preset-bundled role materialization (Nanodash issue #302). For each active,
+     * admin-authored {@code gen:PresetAssignment} targeting a {@code gen:Space}, inserts
+     * one {@code gen:RoleAssignment} per role the preset bundles — exactly as if
+     * {@code <space> gen:hasRole <role>} had been published by the assignment's publisher.
+     * The materialized rows carry {@code npa:derivedFromPreset} (the assignment nanopub)
+     * so the deactivation delete and read-side marking can scope to them without touching
+     * directly-published attachments. See {@code doc/design-preset-role-materialization.md}.
+     *
+     * <p>Activation is resolved by an <b>authorization-scoped latest-wins</b> over the
+     * {@code (preset, resource)} pair, NOT {@code npx:invalidates} (§3): the candidate set
+     * for the {@code MAX(dct:created)} comparison is restricted to assignments whose
+     * publisher is also a validated admin of the target ref, so an unauthorized key's newer
+     * assignment cannot shadow an admin's activation (the #113-class anti-hijack rule).
+     */
+    static String presetAttachmentValidationUpdate(IRI graph, long lastProcessed) {
+        // Ref-keyed like attachmentValidationUpdate: the assignment names a bare resource
+        // IRI; it is validated per-ref for every Space ref of that IRI whose admin set
+        // contains the publisher. The inserted subject is minted per (assignment, ref, role)
+        // — one assignment fans out to N roles and N refs. Non-Space targets resolve no
+        // ?targetRef and so insert nothing (correct no-op; maintained-resource / individual
+        // targets are future work, see design doc §2). TRANSITIONAL-DUAL-EMIT (Phase 4:
+        // remove): forSpace kept alongside forSpaceRef so the non-admin tiers can probe the
+        // IRI-keyed instantiations and pre-ref read queries keep functioning.
+        return """
+                PREFIX npa:  <%1$s>
+                PREFIX gen:  <%2$s>
+                INSERT { GRAPH <%3$s> {
+                  ?ra2 a gen:RoleAssignment ;
+                       npa:forSpaceRef ?targetRef ;
+                       npa:forSpace    ?resource ;
+                       gen:hasRole     ?role ;
+                       npa:viaNanopub  ?assignNp ;
+                       npa:derivedFromPreset ?assignNp .
+                } }
+                WHERE {
+                  # 1. Anchor: active preset assignments in the extraction graph.
+                  GRAPH <%4$s> {
+                    ?pa a npa:PresetAssignment ;
+                        npa:ofPreset    ?preset ;
+                        npa:forResource ?resource ;
+                        npa:isActivated true ;
+                        npa:pubkeyHash  ?pkh ;
+                        npa:viaNanopub  ?assignNp ;
+                        <http://purl.org/dc/terms/created> ?created .
+                  }
+                  # 2. Load-number filter on the assignment nanopub.
+                  GRAPH <%7$s> {
+                    ?assignNp npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
+                  }
+                  # 3. Resolve publisher pkh -> agent via the mirrored trust-approved row.
+                  GRAPH <%3$s> {
+                    ?acct a npa:AccountState ;
+                          npa:agent  ?publisher ;
+                          npa:pubkey ?pkh .
+                  }
+                  # 4. Target must be a Space ref the publisher admins. ?targetRef = that ref.
+                  GRAPH <%4$s> { ?targetRef npa:spaceIri ?resource . }
+                  GRAPH <%3$s> {
+                    ?adminRI a gen:RoleInstantiation ;
+                             npa:forSpaceRef ?targetRef ;
+                             npa:inverseProperty gen:hasAdmin ;
+                             npa:forAgent ?publisher .
+                  }
+                  # 5. Resolve the assignment's referenced preset IRI (node or kind) to its
+                  #    canonical kind, mirroring how Nanodash views key on dct:isVersionOf
+                  #    (ViewDisplay.getViewKindIri). Every declaration carries npa:ofPreset for
+                  #    both its node IRI and kind, so either reference maps to the same ?kind.
+                  GRAPH <%4$s> {
+                    ?pdMap a npa:PresetDeclaration ;
+                           npa:ofPreset   ?preset ;
+                           npa:presetKind ?kind .
+                  }
+                  # 5a. Roles come from the LATEST live declaration of that kind, restricted to
+                  #     Space-targeted presets — so a superseded preset version's roles never leak
+                  #     (the per-view-kind latest-wins, ported to materialization).
+                  GRAPH <%4$s> {
+                    ?pd a npa:PresetDeclaration ;
+                        npa:presetKind           ?kind ;
+                        npa:presetRole           ?role ;
+                        npa:appliesToInstancesOf gen:Space ;
+                        npa:viaNanopub           ?pdNp ;
+                        <http://purl.org/dc/terms/created> ?pdCreated .
+                  }
+                  # 5b. Latest-declaration-per-kind: reject if a newer LIVE declaration of the
+                  #     same kind exists (tiebreak on subject IRI for equal timestamps).
+                  FILTER NOT EXISTS {
+                    GRAPH <%4$s> {
+                      ?pdNewer a npa:PresetDeclaration ;
+                               npa:presetKind ?kind ;
+                               npa:viaNanopub ?pdNpNewer ;
+                               <http://purl.org/dc/terms/created> ?pdCreatedNewer .
+                      FILTER (?pdCreatedNewer > ?pdCreated
+                              || (?pdCreatedNewer = ?pdCreated && STR(?pdNewer) > STR(?pd)))
+                    }
+                    %8$s
+                  }
+                  # 5c. The chosen declaration must itself be live (not superseded/retracted).
+                  %9$s
+                  # 6. Mint the per (assignment, ref, role) subject.
+                  BIND(IRI(CONCAT(STR(?pa), "__", ENCODE_FOR_URI(STR(?targetRef)),
+                                  "__", ENCODE_FOR_URI(STR(?role)))) AS ?ra2)
+                  # 7. Authorization-scoped latest-wins (anti-hijack, design doc §3): reject
+                  #    if a newer same-(preset,resource) assignment exists whose publisher is
+                  #    ALSO a validated admin of ?targetRef. Filtering the shadowing candidate
+                  #    to admin-authored rows BEFORE taking the latest is what stops an
+                  #    unauthorized key from suppressing an admin's activation. Placed after
+                  #    the main vars are bound so the planner defers it (RDF4J quirk).
+                  FILTER NOT EXISTS {
+                    GRAPH <%4$s> {
+                      ?paNewer a npa:PresetAssignment ;
+                               npa:ofPreset    ?preset ;
+                               npa:forResource ?resource ;
+                               npa:pubkeyHash  ?pkhNewer ;
+                               <http://purl.org/dc/terms/created> ?createdNewer .
+                      FILTER (?createdNewer > ?created
+                              || (?createdNewer = ?created && STR(?paNewer) > STR(?pa)))
+                    }
+                    GRAPH <%3$s> {
+                      ?acctNewer a npa:AccountState ;
+                                 npa:agent  ?publisherNewer ;
+                                 npa:pubkey ?pkhNewer .
+                      ?adminRINewer a gen:RoleInstantiation ;
+                                    npa:forSpaceRef ?targetRef ;
+                                    npa:inverseProperty gen:hasAdmin ;
+                                    npa:forAgent ?publisherNewer .
+                    }
+                  }
+                  # 8. Defensive: drop if the assignment nanopub itself was hard-retracted.
+                  %6$s
+                  # 9. Dedup last — keyed on (ref, role).
+                  FILTER NOT EXISTS { GRAPH <%3$s> {
+                    ?existing a gen:RoleAssignment ;
+                              npa:forSpaceRef ?targetRef ;
+                              gen:hasRole ?role .
+                  } }
+                }
+                """.formatted(
+                NPA.NAMESPACE,
+                GEN.NAMESPACE,
+                graph,
+                SpacesVocab.SPACES_GRAPH,
+                lastProcessed,
+                invalidationFilter("assignNp"),
+                NPA.GRAPH,
+                invalidationFilter("pdNpNewer"),
+                invalidationFilter("pdNp"));
     }
 
     /**
@@ -1730,6 +1934,81 @@ public final class AuthorityResolver {
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
                 aliasInvalidationCheckWhere(graph, lastProcessed));
+    }
+
+    /**
+     * WHERE clause shared by the preset-deactivation ASK precheck and the matching DELETE
+     * (Nanodash issue #302). Binds {@code ?ra} = a materialized preset-derived
+     * {@code gen:RoleAssignment} ({@code npa:derivedFromPreset}) for which a <em>newer,
+     * admin-authored</em> same-{@code (preset, resource)} assignment exists by
+     * {@code dct:created} (load number in {@code (lastProcessed, ∞)}). This is NOT an
+     * {@code npx:invalidates} check — preset activation is latest-wins by timestamp.
+     *
+     * <p>Authorization-scoped (anti-hijack, design doc §3/§4.4): the newer assignment's
+     * publisher must itself be a validated admin of the row's {@code npa:forSpaceRef}, so an
+     * unauthorized key's newer assignment can neither delete nor shadow an admin's
+     * materialized role. {@code dct:created} is written as a full IRI (not a {@code dct:}
+     * prefix) because {@link #wouldInvalidate}'s ASK wrapper only declares {@code npa:} /
+     * {@code gen:}.
+     */
+    static String presetDeactivationCheckWhere(IRI graph, long lastProcessed) {
+        return String.format("""
+                  GRAPH <%1$s> {
+                    ?ra a gen:RoleAssignment ;
+                        npa:derivedFromPreset ?assignNp ;
+                        npa:forSpaceRef ?targetRef .
+                  }
+                  GRAPH <%2$s> {
+                    ?pa a npa:PresetAssignment ;
+                        npa:viaNanopub  ?assignNp ;
+                        npa:ofPreset    ?preset ;
+                        npa:forResource ?resource ;
+                        <http://purl.org/dc/terms/created> ?created .
+                    ?paNewer a npa:PresetAssignment ;
+                             npa:ofPreset    ?preset ;
+                             npa:forResource ?resource ;
+                             npa:pubkeyHash  ?pkhNewer ;
+                             npa:viaNanopub  ?assignNpNewer ;
+                             <http://purl.org/dc/terms/created> ?createdNewer .
+                    FILTER (?createdNewer > ?created
+                            || (?createdNewer = ?created && STR(?paNewer) > STR(?pa)))
+                  }
+                  GRAPH <%3$s> {
+                    ?assignNpNewer npa:hasLoadNumber ?lnNewer .
+                    FILTER (?lnNewer > %4$d)
+                  }
+                  GRAPH <%1$s> {
+                    ?acctNewer a npa:AccountState ;
+                               npa:agent  ?publisherNewer ;
+                               npa:pubkey ?pkhNewer .
+                    ?adminRINewer a gen:RoleInstantiation ;
+                                  npa:forSpaceRef ?targetRef ;
+                                  npa:inverseProperty gen:hasAdmin ;
+                                  npa:forAgent ?publisherNewer .
+                  }
+                """, graph, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed);
+    }
+
+    /**
+     * DELETE template for preset-derived {@code gen:RoleAssignment} rows superseded by a
+     * newer admin-authored same-pair assignment (issue #302). Removes the whole row by
+     * subject; scoped via {@code npa:derivedFromPreset} so directly-published attachments
+     * are never touched. The {@link #presetAttachmentValidationUpdate} re-INSERT in the
+     * same cycle re-materializes the pair iff the newest assignment is still active.
+     */
+    static String presetDeactivationDelete(IRI graph, long lastProcessed) {
+        return String.format("""
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                DELETE { GRAPH <%3$s> {
+                  ?ra ?p ?o .
+                } }
+                WHERE {
+                  GRAPH <%3$s> { ?ra ?p ?o . }
+                %4$s
+                }
+                """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
+                presetDeactivationCheckWhere(graph, lastProcessed));
     }
 
     /** Wraps an ASK by joining the shared prefixes. */

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -68,6 +68,8 @@ public final class SpacesExtractor {
         s.add(GEN.IS_SUB_SPACE_OF);
         s.add(GEN.MAINTAINED_RESOURCE);
         s.add(GEN.IS_MAINTAINED_BY);
+        s.add(GEN.PRESET);
+        s.add(GEN.PRESET_ASSIGNMENT);
         s.addAll(BackcompatRolePredicates.ALL);
         TRIGGER_TYPES = Collections.unmodifiableSet(s);
     }
@@ -133,6 +135,12 @@ public final class SpacesExtractor {
         // same <r> gen:isMaintainedBy <s> triple in the assertion.
         boolean isMaintainedResource = types.contains(GEN.MAINTAINED_RESOURCE)
                                        || types.contains(GEN.IS_MAINTAINED_BY);
+        // Presets (Nanodash issue #302). A preset-defining nanopub is typed gen:Preset;
+        // an assignment is typed gen:PresetAssignment (plus gen:Activated/Deactivated).
+        // Both shapes are single-subject assertions, so NanopubUtils.getTypes promotes
+        // the assertion type even without a pubinfo npx:hasNanopubType marker.
+        boolean isPreset = types.contains(GEN.PRESET);
+        boolean isPresetAssignment = types.contains(GEN.PRESET_ASSIGNMENT);
 
         if (isSpace) {
             extractSpace(np, ctx, out);
@@ -151,6 +159,12 @@ public final class SpacesExtractor {
         }
         if (isMaintainedResource) {
             extractIsMaintainedBy(np, ctx, out);
+        }
+        if (isPreset) {
+            extractPreset(np, ctx, out);
+        }
+        if (isPresetAssignment) {
+            extractPresetAssignment(np, ctx, out);
         }
 
         return out;
@@ -728,6 +742,163 @@ public final class SpacesExtractor {
         out.add(vf.createStatement(subject, SpacesVocab.MAINTAINER_SPACE, spaceIri, GRAPH));
         out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, np.getUri(), GRAPH));
         addProvenance(subject, ctx, out);
+    }
+
+    // ---------------- gen:Preset (preset declaration) ----------------
+
+    /**
+     * A {@code gen:Preset} nanopub bundles default views and roles. We extract only the
+     * role half (views stay read-time in Nanodash; see
+     * {@code doc/design-preset-role-materialization.md}): one
+     * {@code npa:PresetDeclaration} carrying every {@code gen:hasRole} as
+     * {@code npa:presetRole}, the {@code gen:appliesToInstancesOf} target(s), and the
+     * preset's identity as {@code npa:ofPreset}.
+     *
+     * <p>Join robustness: the assignment's {@code gen:isAssignmentOfPreset} may name the
+     * versioned preset node or the version-independent {@code dct:isVersionOf} kind
+     * (Nanodash treats the kind as the canonical reference). We emit {@code npa:ofPreset}
+     * for <em>both</em> so an assignment naming either joins to this declaration.
+     */
+    private static void extractPreset(Nanopub np, Context ctx, List<Statement> out) {
+        // The preset IRI is embedded in this nanopub: <preset> rdf:type gen:Preset where
+        // <preset> starts with the nanopub IRI (valid embedded mint), mirroring the
+        // gen:SpaceMemberRole role-declaration rule.
+        IRI presetIri = null;
+        for (Statement st : np.getAssertion()) {
+            if (!st.getPredicate().equals(RDF.TYPE)) {
+                continue;
+            }
+            if (!GEN.PRESET.equals(st.getObject())) {
+                continue;
+            }
+            if (!(st.getSubject() instanceof IRI candidate)) {
+                continue;
+            }
+            if (!candidate.stringValue().startsWith(np.getUri().stringValue())) {
+                continue;
+            }
+            presetIri = candidate;
+            break;
+        }
+        if (presetIri == null) {
+            return;
+        }
+
+        List<IRI> roles = collectObjects(np, presetIri, GEN.HAS_ROLE);
+        List<IRI> appliesTo = collectObjects(np, presetIri, GEN.APPLIES_TO_INSTANCES_OF);
+        List<IRI> kinds = collectObjects(np, presetIri, DCTERMS.IS_VERSION_OF);
+        // Canonical kind: the dct:isVersionOf target, or the node IRI as fallback when the
+        // preset declares no kind — same rule as Nanodash ViewDisplay.getViewKindIri().
+        IRI presetKind = kinds.isEmpty() ? presetIri : kinds.get(0);
+
+        IRI subject = SpacesVocab.forPresetDeclaration(ctx.artifactCode());
+        out.add(vf.createStatement(subject, RDF.TYPE, SpacesVocab.PRESET_DECLARATION, GRAPH));
+        // Canonical version-independent grouping key (latest-declaration-per-kind resolution).
+        out.add(vf.createStatement(subject, SpacesVocab.PRESET_KIND, presetKind, GRAPH));
+        // Lookup keys: the preset's own node IRI plus its version-independent kind, so an
+        // assignment naming either is mapped to this declaration's canonical kind.
+        out.add(vf.createStatement(subject, SpacesVocab.OF_PRESET, presetIri, GRAPH));
+        for (IRI kind : kinds) {
+            out.add(vf.createStatement(subject, SpacesVocab.OF_PRESET, kind, GRAPH));
+        }
+        for (IRI role : roles) {
+            out.add(vf.createStatement(subject, SpacesVocab.PRESET_ROLE, role, GRAPH));
+        }
+        for (IRI type : appliesTo) {
+            out.add(vf.createStatement(subject, SpacesVocab.APPLIES_TO_INSTANCES_OF, type, GRAPH));
+        }
+        out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, np.getUri(), GRAPH));
+        addProvenance(subject, ctx, out);
+    }
+
+    // ---------------- gen:PresetAssignment ----------------
+
+    /**
+     * A {@code gen:PresetAssignment} nanopub assigns a preset to a resource. Emits one
+     * {@code npa:PresetAssignment} row recording the {@code (preset, resource)} pair and
+     * its activation state. Activation is <em>active-by-default</em>: active unless the
+     * assignment node is explicitly typed {@code gen:DeactivatedPresetAssignment} —
+     * matching Nanodash's {@code PresetAssignment.isActive()}.
+     *
+     * <p>The {@code dct:created} timestamp emitted by {@link #addProvenance} is the
+     * latest-wins key the validator uses to resolve same-pair assignments; it must be
+     * present for the materialization to converge.
+     */
+    private static void extractPresetAssignment(Nanopub np, Context ctx, List<Statement> out) {
+        // The assignment node is the subject of the gen:isAssignmentOfPreset triple.
+        IRI assignmentNode = null;
+        IRI presetIri = null;
+        for (Statement st : np.getAssertion()) {
+            if (!st.getPredicate().equals(GEN.IS_ASSIGNMENT_OF_PRESET)) {
+                continue;
+            }
+            if (!(st.getSubject() instanceof IRI subj)) {
+                continue;
+            }
+            if (!(st.getObject() instanceof IRI preset)) {
+                continue;
+            }
+            assignmentNode = subj;
+            presetIri = preset;
+            break;
+        }
+        if (assignmentNode == null) {
+            return;
+        }
+
+        IRI resource = null;
+        for (Statement st : np.getAssertion()) {
+            if (!assignmentNode.equals(st.getSubject())) {
+                continue;
+            }
+            if (!st.getPredicate().equals(GEN.IS_ASSIGNMENT_FOR)) {
+                continue;
+            }
+            if (st.getObject() instanceof IRI res) {
+                resource = res;
+                break;
+            }
+        }
+        if (resource == null) {
+            logger.warn("Ignoring preset assignment in {}: no gen:isAssignmentFor resource", np.getUri());
+            return;
+        }
+
+        // Active-by-default: deactivated only if explicitly typed.
+        boolean deactivated = false;
+        for (Statement st : np.getAssertion()) {
+            if (assignmentNode.equals(st.getSubject())
+                && st.getPredicate().equals(RDF.TYPE)
+                && GEN.DEACTIVATED_PRESET_ASSIGNMENT.equals(st.getObject())) {
+                deactivated = true;
+                break;
+            }
+        }
+
+        IRI subject = SpacesVocab.forPresetAssignment(ctx.artifactCode());
+        out.add(vf.createStatement(subject, RDF.TYPE, SpacesVocab.PRESET_ASSIGNMENT, GRAPH));
+        out.add(vf.createStatement(subject, SpacesVocab.OF_PRESET, presetIri, GRAPH));
+        out.add(vf.createStatement(subject, SpacesVocab.FOR_RESOURCE, resource, GRAPH));
+        out.add(vf.createStatement(subject, SpacesVocab.IS_ACTIVATED, vf.createLiteral(!deactivated), GRAPH));
+        out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, np.getUri(), GRAPH));
+        addProvenance(subject, ctx, out);
+    }
+
+    /** Collects all IRI objects of {@code subject predicate ?o} triples in the assertion. */
+    private static List<IRI> collectObjects(Nanopub np, IRI subject, IRI predicate) {
+        List<IRI> out = new ArrayList<>();
+        for (Statement st : np.getAssertion()) {
+            if (!subject.equals(st.getSubject())) {
+                continue;
+            }
+            if (!predicate.equals(st.getPredicate())) {
+                continue;
+            }
+            if (st.getObject() instanceof IRI obj) {
+                out.add(obj);
+            }
+        }
+        return out;
     }
 
     // ---------------- owl:sameAs (space aliases) ----------------

--- a/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
@@ -101,6 +101,47 @@ public class GEN {
      */
     public static final IRI MAINTAINED_RESOURCE = VocabUtils.createIRI(NAMESPACE, "MaintainedResource");
 
+    // ---------------- Presets (Nanodash issue #302) ----------------
+
+    /**
+     * Class IRI for a preset definition: a reusable bundle of default views and
+     * {@link #HAS_ROLE roles}, assigned to a resource through a
+     * {@link #PRESET_ASSIGNMENT}. Only the role half is materialized server-side
+     * (views stay read-time in Nanodash); see
+     * {@code doc/design-preset-role-materialization.md}.
+     */
+    public static final IRI PRESET = VocabUtils.createIRI(NAMESPACE, "Preset");
+
+    /**
+     * Class IRI for a preset assignment: states that a resource should use a given
+     * preset. Activation state is an identity on the {@code (preset, resource)} pair
+     * (latest-wins by {@code dct:created}), not an {@code npx:invalidates} link.
+     */
+    public static final IRI PRESET_ASSIGNMENT = VocabUtils.createIRI(NAMESPACE, "PresetAssignment");
+
+    /** Marks a {@link #PRESET_ASSIGNMENT} as active. Active is the default (see {@link #DEACTIVATED_PRESET_ASSIGNMENT}). */
+    public static final IRI ACTIVATED_PRESET_ASSIGNMENT = VocabUtils.createIRI(NAMESPACE, "ActivatedPresetAssignment");
+
+    /**
+     * Marks a {@link #PRESET_ASSIGNMENT} as deactivated. An assignment is active
+     * <em>unless</em> explicitly typed with this class — matching Nanodash's
+     * {@code PresetAssignment.isActive()}.
+     */
+    public static final IRI DEACTIVATED_PRESET_ASSIGNMENT = VocabUtils.createIRI(NAMESPACE, "DeactivatedPresetAssignment");
+
+    /** Predicate linking a {@link #PRESET_ASSIGNMENT} to the preset it assigns. */
+    public static final IRI IS_ASSIGNMENT_OF_PRESET = VocabUtils.createIRI(NAMESPACE, "isAssignmentOfPreset");
+
+    /** Predicate linking a {@link #PRESET_ASSIGNMENT} to the resource it targets. */
+    public static final IRI IS_ASSIGNMENT_FOR = VocabUtils.createIRI(NAMESPACE, "isAssignmentFor");
+
+    /**
+     * Predicate declaring which resource type(s) a {@link #PRESET} applies to
+     * (e.g. {@link #SPACE}). Role materialization only acts on {@code gen:Space}
+     * targets; other values are extracted but not acted on.
+     */
+    public static final IRI APPLIES_TO_INSTANCES_OF = VocabUtils.createIRI(NAMESPACE, "appliesToInstancesOf");
+
     private GEN() {
     }
 

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
@@ -46,6 +46,10 @@ public final class SpacesVocab {
     public static final String NPAMRD_NAMESPACE = "http://purl.org/nanopub/admin/maintainedresource/";
     /** Namespace for space-alias-declaration entries ({@code npaalias:<artifactCode>_<aliasHash>}). */
     public static final String NPAALIAS_NAMESPACE = "http://purl.org/nanopub/admin/spacealias/";
+    /** Namespace for preset-assignment entries ({@code npapa:<artifactCode>}). */
+    public static final String NPAPA_NAMESPACE = "http://purl.org/nanopub/admin/presetassign/";
+    /** Namespace for preset-declaration entries ({@code npapd:<artifactCode>}). */
+    public static final String NPAPD_NAMESPACE = "http://purl.org/nanopub/admin/presetdecl/";
     /** Namespace for space-state graph IRIs ({@code npass:<trustStateHash>_<loadCounter>}). */
     public static final String NPASS_NAMESPACE = "http://purl.org/nanopub/admin/spacestate/";
 
@@ -68,6 +72,12 @@ public final class SpacesVocab {
 
     /** RDF type for a space-alias-declaration extraction entry (from {@code owl:sameAs} in a {@code gen:Space} nanopub). */
     public static final IRI SPACE_ALIAS_DECLARATION = vf.createIRI(NPA.NAMESPACE, "SpaceAliasDeclaration");
+
+    /** RDF type for a preset-assignment extraction entry (from a {@code gen:PresetAssignment} nanopub). */
+    public static final IRI PRESET_ASSIGNMENT = vf.createIRI(NPA.NAMESPACE, "PresetAssignment");
+
+    /** RDF type for a preset-declaration extraction entry (from a {@code gen:Preset} nanopub). */
+    public static final IRI PRESET_DECLARATION = vf.createIRI(NPA.NAMESPACE, "PresetDeclaration");
 
     // -------- Properties on extraction entries --------
 
@@ -127,6 +137,45 @@ public final class SpacesVocab {
 
     /** Links a {@link #SPACE_ALIAS_DECLARATION} to the alias Space IRI (the {@code owl:sameAs} object). */
     public static final IRI ALIAS_SPACE = vf.createIRI(NPA.NAMESPACE, "aliasSpace");
+
+    // -------- Preset extraction-entry properties (Nanodash issue #302) --------
+
+    /**
+     * Join key linking a {@link #PRESET_ASSIGNMENT} (its assigned preset) and a
+     * {@link #PRESET_DECLARATION} (its own identity). A declaration emits this for
+     * <em>both</em> the {@code gen:Preset}-typed node IRI and its
+     * {@code dct:isVersionOf} kind, so an assignment referencing either joins.
+     */
+    public static final IRI OF_PRESET = vf.createIRI(NPA.NAMESPACE, "ofPreset");
+
+    /** Links a {@link #PRESET_ASSIGNMENT} to the resource it targets ({@code gen:isAssignmentFor}). */
+    public static final IRI FOR_RESOURCE = vf.createIRI(NPA.NAMESPACE, "forResource");
+
+    /** Boolean literal on a {@link #PRESET_ASSIGNMENT}: active (true) unless explicitly deactivated. */
+    public static final IRI IS_ACTIVATED = vf.createIRI(NPA.NAMESPACE, "isActivated");
+
+    /**
+     * Canonical version-independent identity of a {@link #PRESET_DECLARATION}: its
+     * {@code dct:isVersionOf} kind, or the {@code gen:Preset} node IRI when the preset
+     * declares no kind (same fallback as Nanodash {@code ViewDisplay.getViewKindIri()}).
+     * Roles are resolved from the <em>latest</em> declaration per kind, mirroring the
+     * per-view-kind latest-wins in Nanodash's {@code get-view-displays} expansion.
+     */
+    public static final IRI PRESET_KIND = vf.createIRI(NPA.NAMESPACE, "presetKind");
+
+    /** Links a {@link #PRESET_DECLARATION} to each role IRI the preset bundles ({@code gen:hasRole}). */
+    public static final IRI PRESET_ROLE = vf.createIRI(NPA.NAMESPACE, "presetRole");
+
+    /** Resource type(s) a {@link #PRESET_DECLARATION} applies to ({@code gen:appliesToInstancesOf}). */
+    public static final IRI APPLIES_TO_INSTANCES_OF = vf.createIRI(NPA.NAMESPACE, "appliesToInstancesOf");
+
+    /**
+     * Marker on a materialized {@code gen:RoleAssignment} that was derived from a preset
+     * assignment (its value is the assignment nanopub). Scopes the preset-deactivation
+     * delete and the read-side from-preset marking; keeps both clear of
+     * directly-published attachments.
+     */
+    public static final IRI DERIVED_FROM_PRESET = vf.createIRI(NPA.NAMESPACE, "derivedFromPreset");
 
     /**
      * Validated alias edge written into the space-state graph: {@code <alias> npa:sameAsSpace <canonical>}.
@@ -236,6 +285,16 @@ public final class SpacesVocab {
      */
     public static IRI forSpaceAliasDeclaration(String artifactCode, String aliasHash) {
         return vf.createIRI(NPAALIAS_NAMESPACE, artifactCode + "_" + aliasHash);
+    }
+
+    /** Mints {@code npapa:<artifactCode>} for a preset-assignment entry. */
+    public static IRI forPresetAssignment(String artifactCode) {
+        return vf.createIRI(NPAPA_NAMESPACE, artifactCode);
+    }
+
+    /** Mints {@code npapd:<artifactCode>} for a preset-declaration entry. */
+    public static IRI forPresetDeclaration(String artifactCode) {
+        return vf.createIRI(NPAPD_NAMESPACE, artifactCode);
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -573,4 +573,93 @@ class AuthorityResolverTest {
                 "the alias edge is not part of the DELETE — sticky until rebuild");
     }
 
+    // ---------------- Preset-role materialization (issue #302) ----------------
+
+    @Test
+    void presetAttachmentValidationUpdate_materializesRoleAssignmentFromActivePreset() {
+        String sparql = AuthorityResolver.presetAttachmentValidationUpdate(TEST_GRAPH, 5);
+        assertTrue(sparql.contains("INSERT"), "INSERT clause");
+        assertTrue(sparql.contains("gen:RoleAssignment"),
+                "materializes a gen:RoleAssignment, just like a direct attachment");
+        assertTrue(sparql.contains("npa:derivedFromPreset"),
+                "carries the from-preset marker for scoped deletes / read-side marking");
+        assertTrue(sparql.contains("npa:PresetAssignment") && sparql.contains("npa:isActivated true"),
+                "anchors on active preset assignments");
+        assertTrue(sparql.contains("npa:presetRole"),
+                "joins the preset declaration's bundled roles");
+        assertTrue(sparql.contains("npa:presetKind"),
+                "keys on the canonical preset kind (consistent with view-kind)");
+        assertTrue(sparql.contains("npa:appliesToInstancesOf gen:Space"),
+                "restricted to Space-targeted presets");
+        assertTrue(sparql.contains("npa:inverseProperty gen:hasAdmin"),
+                "publisher must be a validated admin of the target ref");
+        assertTrue(sparql.contains("FILTER (?ln > 5)"),
+                "delta filter on the assignment nanopub");
+    }
+
+    @Test
+    void presetAttachmentValidationUpdate_latestWinsCandidateIsAdminScoped() {
+        // Anti-hijack (design doc §3): the latest-wins FILTER NOT EXISTS candidate must
+        // itself be admin-authored, so an unauthorized key's newer assignment cannot
+        // shadow an admin's activation. Activation is keyed on dct:created, NOT
+        // npx:invalidates.
+        String sparql = AuthorityResolver.presetAttachmentValidationUpdate(TEST_GRAPH, 0);
+        assertTrue(sparql.contains("http://purl.org/dc/terms/created"),
+                "latest-wins keyed on dct:created");
+        assertTrue(sparql.contains("?createdNewer > ?created"),
+                "latest-wins compares the candidate's timestamp");
+        // The shadowing candidate repeats the publisher-admin probe on the SAME target ref.
+        assertTrue(sparql.contains("?paNewer"),
+                "latest-wins inspects a newer same-pair assignment");
+        java.util.regex.Pattern adminScoped = java.util.regex.Pattern.compile(
+                "\\?paNewer[\\s\\S]*?\\?adminRINewer[\\s\\S]*?npa:forSpaceRef\\s+\\?targetRef"
+                        + "[\\s\\S]*?npa:inverseProperty\\s+gen:hasAdmin"
+                        + "[\\s\\S]*?npa:forAgent\\s+\\?publisherNewer");
+        assertTrue(adminScoped.matcher(sparql).find(),
+                "the newer-assignment candidate is filtered to admins of the target ref");
+    }
+
+    @Test
+    void presetAttachmentValidationUpdate_resolvesLatestDeclarationPerKind() {
+        // Consistency with views (AbstractResourceWithProfile.getViewDisplays per-view-kind
+        // latest-wins): roles come from the latest LIVE declaration of the preset's kind, so
+        // a superseded version's roles don't leak. Assignment's referenced IRI (node or kind)
+        // is mapped to the canonical kind first.
+        String sparql = AuthorityResolver.presetAttachmentValidationUpdate(TEST_GRAPH, 0);
+        // node-or-kind -> kind mapping via a declaration carrying npa:ofPreset + npa:presetKind.
+        java.util.regex.Pattern map = java.util.regex.Pattern.compile(
+                "\\?pdMap[\\s\\S]*?npa:ofPreset\\s+\\?preset[\\s\\S]*?npa:presetKind\\s+\\?kind");
+        assertTrue(map.matcher(sparql).find(),
+                "maps the assignment's referenced preset IRI to its canonical kind");
+        // latest-per-kind: a newer same-kind declaration (by dct:created) blocks the older one.
+        assertTrue(sparql.contains("?pdNewer") && sparql.contains("npa:presetKind ?kind"),
+                "inspects newer declarations of the same kind");
+        assertTrue(sparql.contains("?pdCreatedNewer > ?pdCreated"),
+                "latest-declaration-per-kind keyed on dct:created");
+        // both the chosen and the newer declarations are gated to LIVE (non-invalidated) rows.
+        assertTrue(sparql.contains("?_inv_pdNp") && sparql.contains("?_inv_pdNpNewer"),
+                "chosen and newer declarations both filtered to live (non-superseded) rows");
+    }
+
+    @Test
+    void presetDeactivationDelete_scopedToDerivedFromPresetAndLatestWins() {
+        String sparql = AuthorityResolver.presetDeactivationDelete(TEST_GRAPH, 5);
+        assertTrue(sparql.contains("DELETE"), "DELETE clause");
+        assertTrue(sparql.contains("npa:derivedFromPreset"),
+                "scoped to preset-derived RAs — never touches directly-published attachments");
+        assertTrue(sparql.contains("?createdNewer > ?created"),
+                "removal driven by latest-wins on dct:created, not npx:invalidates");
+        assertFalse(sparql.contains("invalidates"),
+                "preset deactivation is NOT an npx:invalidates check");
+        assertTrue(sparql.contains("FILTER (?ln") || sparql.contains("?lnNewer > 5"),
+                "delta filter on the superseding assignment's load number");
+        // Admin-scoped: the superseding assignment's publisher must be admin of the ref.
+        java.util.regex.Pattern adminScoped = java.util.regex.Pattern.compile(
+                "\\?adminRINewer[\\s\\S]*?npa:forSpaceRef\\s+\\?targetRef"
+                        + "[\\s\\S]*?npa:inverseProperty\\s+gen:hasAdmin"
+                        + "[\\s\\S]*?npa:forAgent\\s+\\?publisherNewer");
+        assertTrue(adminScoped.matcher(sparql).find(),
+                "deletion gated on an admin-authored superseding assignment");
+    }
+
 }

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -6,6 +6,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.junit.jupiter.api.AfterEach;
@@ -667,6 +668,154 @@ class SpacesExtractorTest {
         assertDoesNotContain(out, rejectedSubject, RDF.TYPE, MAINTAINED_RESOURCE_DECLARATION);
     }
 
+    // ---------------- gen:Preset / gen:PresetAssignment (issue #302) ----------------
+
+    @Test
+    void extract_preset_emitsPresetDeclaration() throws Exception {
+        // Embedded preset node (starts with the nanopub URI), version-of a stable kind.
+        IRI presetIri = vf.createIRI(NP_BASE + "/preset");
+        IRI presetKind = vf.createIRI("https://example.org/presets/nano-session");
+        IRI role = vf.createIRI("https://w3id.org/np/RA-defAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/maintainer");
+
+        Nanopub np = creator()
+                .type(GEN.PRESET)
+                .assertion(presetIri, RDF.TYPE, GEN.PRESET)
+                .assertion(presetIri, DCTERMS.IS_VERSION_OF, presetKind)
+                .assertion(presetIri, GEN.APPLIES_TO_INSTANCES_OF, GEN.SPACE)
+                .assertion(presetIri, GEN.HAS_ROLE, role)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forPresetDeclaration(ARTIFACT_CODE);
+
+        assertAllInSpacesGraph(out);
+        assertContains(out, subject, RDF.TYPE, PRESET_DECLARATION);
+        // Canonical kind = the dct:isVersionOf target.
+        assertContains(out, subject, PRESET_KIND, presetKind);
+        // Lookup key emitted for BOTH the node IRI and the version-independent kind, so an
+        // assignment naming either maps to the canonical kind.
+        assertContains(out, subject, OF_PRESET, presetIri);
+        assertContains(out, subject, OF_PRESET, presetKind);
+        assertContains(out, subject, PRESET_ROLE, role);
+        assertContains(out, subject, APPLIES_TO_INSTANCES_OF, GEN.SPACE);
+        assertContains(out, subject, VIA_NANOPUB, NP_URI);
+        assertContains(out, subject, NPX.SIGNED_BY, SIGNER_AGENT);
+    }
+
+    @Test
+    void extract_preset_noVersionOf_kindFallsBackToNodeIri() throws Exception {
+        // No dct:isVersionOf: the canonical kind falls back to the preset node IRI,
+        // matching Nanodash ViewDisplay.getViewKindIri()'s fallback.
+        IRI presetIri = vf.createIRI(NP_BASE + "/preset");
+        IRI role = vf.createIRI("https://w3id.org/np/RA-defAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/maintainer");
+
+        Nanopub np = creator()
+                .type(GEN.PRESET)
+                .assertion(presetIri, RDF.TYPE, GEN.PRESET)
+                .assertion(presetIri, GEN.APPLIES_TO_INSTANCES_OF, GEN.SPACE)
+                .assertion(presetIri, GEN.HAS_ROLE, role)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forPresetDeclaration(ARTIFACT_CODE);
+        assertContains(out, subject, PRESET_KIND, presetIri);
+        assertContains(out, subject, OF_PRESET, presetIri);
+    }
+
+    @Test
+    void extract_preset_nonEmbeddedPreset_emitsNothing() throws Exception {
+        // Preset IRI outside the nanopub's namespace — ignored (mirrors role-declaration).
+        IRI externalPreset = vf.createIRI("https://some.other.site/preset");
+        Nanopub np = creator()
+                .type(GEN.PRESET)
+                .assertion(externalPreset, RDF.TYPE, GEN.PRESET)
+                .assertion(externalPreset, GEN.HAS_ROLE,
+                        vf.createIRI("https://some.other.site/role"))
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        assertTrue(out.isEmpty(),
+                "Extractor should ignore preset IRIs outside the nanopub's namespace, got: " + out);
+    }
+
+    @Test
+    void extract_presetAssignment_active_emitsActivatedRow() throws Exception {
+        IRI assignment = vf.createIRI(NP_BASE + "/assignment");
+        IRI preset = vf.createIRI("https://example.org/presets/nano-session");
+
+        Nanopub np = creator()
+                .type(GEN.PRESET_ASSIGNMENT)
+                .assertion(assignment, RDF.TYPE, GEN.PRESET_ASSIGNMENT)
+                .assertion(assignment, RDF.TYPE, GEN.ACTIVATED_PRESET_ASSIGNMENT)
+                .assertion(assignment, GEN.IS_ASSIGNMENT_OF_PRESET, preset)
+                .assertion(assignment, GEN.IS_ASSIGNMENT_FOR, SPACE_IRI_1)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forPresetAssignment(ARTIFACT_CODE);
+
+        assertAllInSpacesGraph(out);
+        assertContains(out, subject, RDF.TYPE, PRESET_ASSIGNMENT);
+        assertContains(out, subject, OF_PRESET, preset);
+        assertContains(out, subject, FOR_RESOURCE, SPACE_IRI_1);
+        assertContains(out, subject, IS_ACTIVATED, vf.createLiteral(true));
+        assertContains(out, subject, VIA_NANOPUB, NP_URI);
+        // dct:created is the latest-wins key — must be present.
+        assertContains(out, subject, DCTERMS.CREATED, vf.createLiteral(new Date(1_700_000_000_000L)));
+    }
+
+    @Test
+    void extract_presetAssignment_deactivated_isActivatedFalse() throws Exception {
+        IRI assignment = vf.createIRI(NP_BASE + "/assignment");
+        IRI preset = vf.createIRI("https://example.org/presets/nano-session");
+
+        Nanopub np = creator()
+                .type(GEN.PRESET_ASSIGNMENT)
+                .assertion(assignment, RDF.TYPE, GEN.PRESET_ASSIGNMENT)
+                .assertion(assignment, RDF.TYPE, GEN.DEACTIVATED_PRESET_ASSIGNMENT)
+                .assertion(assignment, GEN.IS_ASSIGNMENT_OF_PRESET, preset)
+                .assertion(assignment, GEN.IS_ASSIGNMENT_FOR, SPACE_IRI_1)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forPresetAssignment(ARTIFACT_CODE);
+        assertContains(out, subject, IS_ACTIVATED, vf.createLiteral(false));
+    }
+
+    @Test
+    void extract_presetAssignment_noActivationType_defaultsActive() throws Exception {
+        // Active-by-default: an assignment typed only gen:PresetAssignment (no explicit
+        // Activated/Deactivated) is active, matching Nanodash's PresetAssignment.isActive().
+        IRI assignment = vf.createIRI(NP_BASE + "/assignment");
+        IRI preset = vf.createIRI("https://example.org/presets/nano-session");
+
+        Nanopub np = creator()
+                .type(GEN.PRESET_ASSIGNMENT)
+                .assertion(assignment, RDF.TYPE, GEN.PRESET_ASSIGNMENT)
+                .assertion(assignment, GEN.IS_ASSIGNMENT_OF_PRESET, preset)
+                .assertion(assignment, GEN.IS_ASSIGNMENT_FOR, SPACE_IRI_1)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forPresetAssignment(ARTIFACT_CODE);
+        assertContains(out, subject, IS_ACTIVATED, vf.createLiteral(true));
+    }
+
+    @Test
+    void extract_presetAssignment_missingResource_emitsNothing() throws Exception {
+        IRI assignment = vf.createIRI(NP_BASE + "/assignment");
+        IRI preset = vf.createIRI("https://example.org/presets/nano-session");
+
+        Nanopub np = creator()
+                .type(GEN.PRESET_ASSIGNMENT)
+                .assertion(assignment, RDF.TYPE, GEN.PRESET_ASSIGNMENT)
+                .assertion(assignment, GEN.IS_ASSIGNMENT_OF_PRESET, preset)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        assertDoesNotContain(out, forPresetAssignment(ARTIFACT_CODE), RDF.TYPE, PRESET_ASSIGNMENT);
+    }
+
     // ---------------- HAS_ID_PREFIX (regression coverage) ----------------
 
     @Test
@@ -754,6 +903,8 @@ class SpacesExtractorTest {
         assertTrue(SpacesExtractor.TRIGGER_TYPES.contains(GEN.IS_SUB_SPACE_OF));
         assertTrue(SpacesExtractor.TRIGGER_TYPES.contains(GEN.MAINTAINED_RESOURCE));
         assertTrue(SpacesExtractor.TRIGGER_TYPES.contains(GEN.IS_MAINTAINED_BY));
+        assertTrue(SpacesExtractor.TRIGGER_TYPES.contains(GEN.PRESET));
+        assertTrue(SpacesExtractor.TRIGGER_TYPES.contains(GEN.PRESET_ASSIGNMENT));
         for (IRI p : com.knowledgepixels.query.vocabulary.BackcompatRolePredicates.ALL) {
             assertTrue(SpacesExtractor.TRIGGER_TYPES.contains(p),
                     "backcompat role predicate missing from TRIGGER_TYPES: " + p);


### PR DESCRIPTION
Implements `doc/design-preset-role-materialization.md` (Nanodash presets, issue #302 "point 1").

## What

Active, admin-authored `gen:PresetAssignment`s targeting a `gen:Space` now materialize one validated `gen:RoleAssignment` per role the preset bundles — exactly as if `<space> gen:hasRole <role>` had been published by the assignment's publisher. Preset-conferred roles become first-class: listed by `GET_SPACE_ROLES`, grantable, and grants validate — through the **existing** read path, with no Nanodash change.

Why server-side (not read-time like preset *views*): the non-admin grant validator anchors on a validated `gen:RoleAssignment` attachment, so without a real attachment a grant never materializes.

## Changes

- **Vocabulary** — `GEN`: `Preset`, `PresetAssignment`, `Activated`/`DeactivatedPresetAssignment`, `isAssignmentOfPreset`, `isAssignmentFor`, `appliesToInstancesOf`. `SpacesVocab`: `npa:PresetAssignment`/`PresetDeclaration` types; `ofPreset`, `forResource`, `isActivated`, `presetKind`, `presetRole`, `appliesToInstancesOf`, `derivedFromPreset`; two minters.
- **Extraction** (`SpacesExtractor`) — `GEN.PRESET`/`PRESET_ASSIGNMENT` added to the single `TRIGGER_TYPES` gate; `extractPreset` + `extractPresetAssignment`.
- **Validation** (`AuthorityResolver`) — `presetAttachmentValidationUpdate` wired immediately before the attachment tier (main + late-arrival sweep); `presetDeactivationCheckWhere`/`Delete` in `applyInvalidations` (structural → `needsFullRebuild`); `newPresetAssignmentsArrived`.

## Three correctness points beyond the original design

All verified against Nanodash source and recorded in the design doc's Implementation Notes:

1. **Authorization-scoped latest-wins (anti-hijack, #113-class).** The `MAX(dct:created)` candidate set — on both the activation gate and the deactivation delete — is restricted to admin-authored assignments, so an unauthorized key cannot shadow or deactivate an admin's materialized role. Activation is latest-wins by `dct:created`, **not** `npx:invalidates`.
2. **Active-by-default activation** — matches `PresetAssignment.isActive()` (`!deactivated`); the design's "skip if neither type" would have dropped valid assignments.
3. **Kind-canonical join + latest-declaration-per-kind** — mirrors how Nanodash views key on `dct:isVersionOf` and resolve to the latest head (`ViewDisplay.getViewKindIri()` / `AbstractResourceWithProfile.getViewDisplays()`), so a superseded preset version's roles never leak.

## Gate summary

Only assignments whose signing key resolves (via the trust-approved `AccountState` mirror) to an agent who is a validated **admin of the target space ref** materialize anything; the same admin gate applies to the shadowing/superseding side.

## Deploy

**Full re-ingest** (not `FORCE_RESYNC`): pre-existing presets/assignments were never "space-relevant", so only a full re-ingest re-evaluates relevance with the new `TRIGGER_TYPES`.

## Tests

`SpacesExtractorTest` + `AuthorityResolverTest` preset cases (extraction shapes, active-by-default, kind fallback, auth-scoped latest-wins, latest-per-kind, deactivation scoping). Full suite green (254).

## Known limitation

Version-head resolution uses `MAX(dct:created)` among non-invalidated declarations rather than the view query's full supersedes-head walk — equivalent in the common case; flag if exotic multi-head/backdated-supersedes presets appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)