### PR TITLE
Ref-scope preset-assignment listing (#122)

### DIFF
--- a/doc/design-preset-role-materialization.md
+++ b/doc/design-preset-role-materialization.md
@@ -275,3 +275,41 @@ preset-derived RAs. This is **not** `npx:invalidates`, so `roleAssignmentInvalid
 - **Latest-wins is authorization-scoped**: the `MAX(dct:created)` candidate set (activation gate and
   deactivation delete) is restricted to admin-authored assignments, matching Nanodash's "authorized agents
   only, then latest-wins" and the #113 anti-hijack rule. (§3)
+
+## 12. Ref-scoping the preset-assignment *listing* (issue #122)
+
+Sibling to the role materialization above, sharing its `?targetRef`/admin-gate machinery. The extraction row
+(`SpacesExtractor.extractPresetAssignment`) is keyed only by `npa:forResource`, so the "Assigned presets"
+About-tab table — the *only* listing that still merged across refs of an IRI — showed assignments from rival
+refs. The fix stamps a **ref-scoped mirror** of each assignment into the state graph.
+
+**`presetAssignmentRefStampUpdate` — a faithful per-assignment mirror, deliberately *not* the §4.3 role path:**
+
+- **No role join.** Reuses §4.3 steps 1–4 (anchor `npa:PresetAssignment`, load filter, `pkh→agent`,
+  `?targetRef npa:spaceIri ?resource` + per-ref admin gate) but drops steps 5–5c (role/declaration join) and 7
+  (latest-wins). A preset bundling only *views* (no roles) would be invisible if the stamp were gated on the
+  role join — so it is not. Emits `npa:PresetAssignment ; npa:ofPreset ; npa:forResource ; npa:forSpaceRef
+  ?targetRef ; npa:isActivated ?activated ; npa:viaNanopub ; dct:created`, minted per `(assignment, ref)`.
+- **Carries activation state; emits active *and* deactivated rows.** Binds `?activated` rather than anchoring
+  on `npa:isActivated true`, so the listing can show deactivated assignments (which the IRI-keyed extraction
+  row does today) instead of silently dropping them.
+- **Latest-wins deferred to the consumer.** A deactivation is just a newer admin-authored stamp with
+  `npa:isActivated false`; the consumer resolves latest-`dct:created`-per-`(preset,resource)` over these rows
+  exactly as it does over the IRI-keyed rows today. Because only admin-authored assignments are ever stamped
+  (a non-admin of the ref can never get a row in), that resolution is **authorization-scoped for free** — no
+  §4.3-step-7 shadowing probe and no §4.4 `dct:created` deactivation-delete are needed for the listing.
+- **Display-only leaf.** Nothing downstream derives from a listing stamp (contrast the preset-derived
+  `gen:RoleAssignment`), so its tier count is **not** fed into `structuralAdds` — it never triggers a full
+  rebuild. Wired into `runAllTierLoops` (after preset-attachment) and the `runDownstreamWithoutLoadFilter`
+  late sweep (catches assignments whose authorizing admin grant validated this same cycle).
+- **Maintenance is one leaf delete.** `presetAssignmentRefInvalidationDelete` (modeled on
+  `maintainedResourceInvalidationDelete`) removes a stamp when its assignment nanopub is hard-retracted
+  (`npx:invalidates`, delta-filtered) — no flag. Scoped to state-graph `npa:PresetAssignment` rows carrying
+  `npa:forSpaceRef` (the extraction rows never do), so it can never touch them. Admin-grant revocation is
+  bounded by the periodic full rebuild (same sticky policy as the alias / sub-space convenience edges).
+
+**Consumer (Nanodash, no change here).** Minimal: the published "Assigned presets" query keeps its existing
+`isActivated` + latest-`dct:created` logic and only swaps `?pa npa:forResource <IRI>` →
+`?pa npa:forSpaceRef ?refRoot` against the state graph. Flip the `❌ Preset assignment listing ref-scoped`
+row in nanodash `docs/space-ref-identity.md` once it lands. **Deploy:** additive — needs the same **full
+re-ingest** backfill as §5 (pre-existing assignments are only in the spaces repo after re-evaluation).

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -789,7 +789,41 @@ public final class AuthorityResolver {
     private static String invalidationFilter(String bareVarName) {
         return "FILTER NOT EXISTS { GRAPH <" + NPA.GRAPH + "> {"
                 + " ?_inv_" + bareVarName
-                + " <" + NPX.INVALIDATES + "> ?" + bareVarName + " . } }";
+                + " <" + NPX.INVALIDATES + "> ?" + bareVarName + " . "
+                + samePublisherClause("_inv_" + bareVarName, bareVarName)
+                + " } }";
+    }
+
+    /**
+     * SPARQL triple pair (placed inside a {@code GRAPH npa:graph { ... }} block)
+     * requiring the invalidating nanopub and its target to share a signing public
+     * key — the self-retraction authority gate for issue #112. Without it, the
+     * materializer honors {@code npx:invalidates}/{@code retracts}/{@code supersedes}
+     * from <em>any</em> validly-signed nanopub, so any agent can erase another
+     * space's materialized state (griefing/DoS of the view — fail-closed, no
+     * privilege escalation, but real). Additions are already admin-gated; this is
+     * the symmetric gate on removals.
+     *
+     * <p>Both {@code npa:hasValidSignatureForPublicKeyHash} triples live in
+     * {@code npa:graph} of the spaces repo: the target via its own space-load, the
+     * invalidator via the symmetric retractor propagation in
+     * {@link com.knowledgepixels.query.NanopubLoader} (forward {@code
+     * loadInvalidateStatements} + reverse {@code loadInvalidatorIntoSpacesRepo}),
+     * so the join is populated regardless of load order.
+     *
+     * <p>"Same pubkey" is intentionally stricter than "same agent": a retraction
+     * signed by a different key the author owns (key rotation) is not honored, and
+     * cross-admin supersession is out of scope here (would need an admin-authority
+     * arm). The pubkey-bridge variable is suffixed with {@code targetVar} so two
+     * filters in one query (e.g. on {@code ?np} and {@code ?rdNp}) don't collide.
+     *
+     * @param invVar    invalidator nanopub variable name (no leading {@code ?})
+     * @param targetVar invalidated-target nanopub variable name (no leading {@code ?})
+     */
+    private static String samePublisherClause(String invVar, String targetVar) {
+        String pk = "?_invpk_" + targetVar;
+        return "?" + invVar + " <" + NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY_HASH + "> " + pk + " . "
+                + "?" + targetVar + " <" + NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY_HASH + "> " + pk + " .";
     }
 
     /**
@@ -1880,8 +1914,10 @@ public final class AuthorityResolver {
                     ?invNp <%3$s> ?np ;
                            npa:hasLoadNumber ?ln .
                     FILTER (?ln > %4$d)
+                    %5$s
                   }
-                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
+                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
     }
 
     /** DELETE template for admin-tier RoleInstantiations whose source nanopub was invalidated. */
@@ -1911,8 +1947,10 @@ public final class AuthorityResolver {
                     ?invNp <%3$s> ?np ;
                            npa:hasLoadNumber ?ln .
                     FILTER (?ln > %4$d)
+                    %5$s
                   }
-                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
+                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
     }
 
     /** DELETE template for RoleAssignments whose source nanopub was invalidated. */
@@ -1949,8 +1987,10 @@ public final class AuthorityResolver {
                     ?invNp <%3$s> ?np ;
                            npa:hasLoadNumber ?ln .
                     FILTER (?ln > %4$d)
+                    %5$s
                   }
-                """, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
+                """, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
     }
 
     /**
@@ -1977,10 +2017,12 @@ public final class AuthorityResolver {
                     ?invNp <%5$s> ?np ;
                            npa:hasLoadNumber ?ln .
                     FILTER (?ln > %6$d)
+                    %7$s
                   }
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
-                NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
+                NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
     }
 
     /**
@@ -2000,8 +2042,10 @@ public final class AuthorityResolver {
                     ?invNp <%3$s> ?np ;
                            npa:hasLoadNumber ?ln .
                     FILTER (?ln > %4$d)
+                    %5$s
                   }
-                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
+                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
     }
 
     /**
@@ -2053,10 +2097,12 @@ public final class AuthorityResolver {
                     ?invNp <%5$s> ?np ;
                            npa:hasLoadNumber ?ln .
                     FILTER (?ln > %6$d)
+                    %7$s
                   }
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
-                NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
+                NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
     }
 
     /**
@@ -2076,8 +2122,10 @@ public final class AuthorityResolver {
                     ?invNp <%3$s> ?np ;
                            npa:hasLoadNumber ?ln .
                     FILTER (?ln > %4$d)
+                    %5$s
                   }
-                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
+                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
     }
 
     /**
@@ -2211,10 +2259,12 @@ public final class AuthorityResolver {
                     ?invNp <%5$s> ?assignNp ;
                            npa:hasLoadNumber ?ln .
                     FILTER (?ln > %6$d)
+                    %7$s
                   }
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
-                NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
+                NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "assignNp"));
     }
 
     /** Wraps an ASK by joining the shared prefixes. */

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -242,17 +242,18 @@ public final class AuthorityResolver {
         long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
         lastSubjectTotals = totals;
         lastInsertedTriplesTotal = (long) counts.admin + counts.alias + counts.presetAttachment
+                + counts.presetAssignmentRef
                 + counts.attachment + counts.maintainer + counts.member + counts.observer
                 + counts.subSpace + counts.subSpacePrefix + counts.maintainedResource;
         lastFullBuildDurationMs = durationMs;
         lastProcessedUpToLag = 0L;
         logger.info("AuthorityResolver: full build complete — graph={} mirrored={} rows loadCounter={} "
                         + "subjects: adminRIs={} attachmentRAs={} nonAdminRIs={} "
-                        + "(inserted-triples: admin={} alias={} preset-attachment={} attachment={} maintainer={} member={} observer={} "
+                        + "(inserted-triples: admin={} alias={} preset-attachment={} preset-assignment-ref={} attachment={} maintainer={} member={} observer={} "
                         + "subspace={} subspace-prefix={} maintained-resource={}) durationMs={}",
                 newGraph, mirrored, loadCounter,
                 totals.adminRIs(), totals.attachmentRAs(), totals.nonAdminRIs(),
-                counts.admin, counts.alias, counts.presetAttachment, counts.attachment, counts.maintainer, counts.member, counts.observer,
+                counts.admin, counts.alias, counts.presetAttachment, counts.presetAssignmentRef, counts.attachment, counts.maintainer, counts.member, counts.observer,
                 counts.subSpace, counts.subSpacePrefix, counts.maintainedResource,
                 durationMs);
     }
@@ -315,6 +316,7 @@ public final class AuthorityResolver {
             TierInsertedTriples lateCounts = runDownstreamWithoutLoadFilter(graph);
             counts.alias              += lateCounts.alias;
             counts.presetAttachment   += lateCounts.presetAttachment;
+            counts.presetAssignmentRef += lateCounts.presetAssignmentRef;
             counts.attachment         += lateCounts.attachment;
             counts.maintainer         += lateCounts.maintainer;
             counts.member             += lateCounts.member;
@@ -330,17 +332,18 @@ public final class AuthorityResolver {
         long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
         lastSubjectTotals = totals;
         lastInsertedTriplesTotal = (long) counts.admin + counts.alias + counts.presetAttachment
+                + counts.presetAssignmentRef
                 + counts.attachment + counts.maintainer + counts.member + counts.observer
                 + counts.subSpace + counts.subSpacePrefix + counts.maintainedResource;
         lastIncrementalCycleDurationMs = durationMs;
         logger.info("AuthorityResolver: incremental cycle complete — graph={} delta=({}, {}] "
                         + "subjects: adminRIs={} attachmentRAs={} nonAdminRIs={} "
-                        + "(inserted-triples: admin={} alias={} preset-attachment={} attachment={} maintainer={} member={} observer={} "
+                        + "(inserted-triples: admin={} alias={} preset-attachment={} preset-assignment-ref={} attachment={} maintainer={} member={} observer={} "
                         + "subspace={} subspace-prefix={} maintained-resource={}) "
                         + "structuralInvalidation={} structuralAdds={} durationMs={}",
                 graph, lastProcessed, currentLoadCounter,
                 totals.adminRIs(), totals.attachmentRAs(), totals.nonAdminRIs(),
-                counts.admin, counts.alias, counts.presetAttachment, counts.attachment, counts.maintainer, counts.member, counts.observer,
+                counts.admin, counts.alias, counts.presetAttachment, counts.presetAssignmentRef, counts.attachment, counts.maintainer, counts.member, counts.observer,
                 counts.subSpace, counts.subSpacePrefix, counts.maintainedResource,
                 structuralInvalidation, structuralAdds, durationMs);
     }
@@ -406,6 +409,9 @@ public final class AuthorityResolver {
         }
         // Leaf-tier RI deletes — no flag.
         executeUpdate(leafTierInvalidationDelete(graph, lastProcessed));
+        // Ref-scoped preset-assignment listing stamps whose assignment nanopub was
+        // hard-retracted (issue #122) — no flag (display leaf, nothing downstream).
+        executeUpdate(presetAssignmentRefInvalidationDelete(graph, lastProcessed));
         // Maintained-resource declaration deletes — no flag (leaf relation, no
         // downstream caches to bound).
         executeUpdate(maintainedResourceInvalidationDelete(graph, lastProcessed));
@@ -444,6 +450,11 @@ public final class AuthorityResolver {
         // so the non-admin late tiers below see this cycle's fresh preset-derived RAs.
         c.presetAttachment = runTierLabeled("preset-attachment(late)", graph,
                 presetAttachmentValidationUpdate(graph, -1));
+        // Ref-scoped preset-assignment late stamp: catches assignments whose authorizing
+        // admin grant only became valid this cycle (the load filter would skip the older
+        // assignment nanopub). Mirrors the preset-attachment late sweep above.
+        c.presetAssignmentRef = runTierLabeled("preset-assignment-ref(late)", graph,
+                presetAssignmentRefStampUpdate(graph, -1));
         c.attachment = runTierLabeled("attachment(late)", graph,
                 attachmentValidationUpdate(graph, -1));
         c.maintainer = runTierLabeled("maintainer(late)", graph,
@@ -532,6 +543,7 @@ public final class AuthorityResolver {
         int admin;
         int alias;
         int presetAttachment;
+        int presetAssignmentRef;
         int attachment;
         int maintainer;
         int member;
@@ -585,6 +597,10 @@ public final class AuthorityResolver {
         // doc/design-preset-role-materialization.md.
         c.presetAttachment = runTierLabeled("preset-attachment", graph,
                 presetAttachmentValidationUpdate(graph, lastProcessed));
+        // Ref-scoped preset-assignment listing stamp (issue #122). Display-only leaf —
+        // independent of the role tiers and of structuralAdds; order doesn't matter.
+        c.presetAssignmentRef = runTierLabeled("preset-assignment-ref", graph,
+                presetAssignmentRefStampUpdate(graph, lastProcessed));
         c.attachment = runTierLabeled("attachment", graph,
                 attachmentValidationUpdate(graph, lastProcessed));
         c.maintainer = runTierLabeled("maintainer", graph, nonAdminTierUpdate(graph, lastProcessed,
@@ -1150,6 +1166,103 @@ public final class AuthorityResolver {
                 NPA.GRAPH,
                 invalidationFilter("pdNpNewer"),
                 invalidationFilter("pdNp"));
+    }
+
+    /**
+     * Stamps a ref-scoped, admin-validated mirror of each {@code npa:PresetAssignment}
+     * into the state graph (issue #122). The publisher-agnostic extraction row
+     * ({@link SpacesExtractor#extractPresetAssignment}) is keyed only by
+     * {@code npa:forResource}, so a consumer listing a space's preset assignments by IRI
+     * sees the union across <em>all</em> refs claiming that IRI. This stamp adds
+     * {@code npa:forSpaceRef ?targetRef} so the "Assigned presets" listing is no longer
+     * merged across refs of the same IRI — the one remaining About-tab listing that still
+     * merged across refs (every other ref-scoped listing already has a {@code forSpaceRef}
+     * companion).
+     *
+     * <p>Faithful per-assignment mirror — deliberately <em>not</em> role-gated and
+     * <em>not</em> latest-wins-resolved, unlike {@link #presetAttachmentValidationUpdate}:
+     * <ul>
+     *   <li>No {@code npa:PresetDeclaration}/role join, so a preset that bundles only
+     *       <em>views</em> (no roles) is still listed.</li>
+     *   <li>Emits active <em>and</em> deactivated rows (carries {@code npa:isActivated})
+     *       so the listing can show state; a deactivation is just a newer admin-authored
+     *       row, so no {@code dct:created}-driven removal is needed here (contrast §4.4).</li>
+     *   <li>Latest-wins is deferred to the consumer query, which ranges only over these
+     *       admin-authored rows — so it is authorization-scoped for free (design §3): a
+     *       non-admin of the ref can never get a row stamped, so it cannot enter the
+     *       latest-wins race.</li>
+     * </ul>
+     *
+     * <p>Display-only leaf: nothing downstream derives from these rows (contrast the
+     * preset-derived {@code gen:RoleAssignment}), so the caller must <em>not</em> feed this
+     * tier's count into {@code structuralAdds}. The {@code npa:forSpaceRef} predicate also
+     * distinguishes a stamped row from the IRI-keyed extraction row (which never carries it),
+     * so {@link #presetAssignmentRefInvalidationDelete} can target exactly these rows.
+     * Reuses steps 1–4 of {@link #presetAttachmentValidationUpdate}; see
+     * doc/design-preset-role-materialization.md §3 and issue #122.
+     */
+    static String presetAssignmentRefStampUpdate(IRI graph, long lastProcessed) {
+        return """
+                PREFIX npa:  <%1$s>
+                PREFIX gen:  <%2$s>
+                INSERT { GRAPH <%3$s> {
+                  ?paRef a npa:PresetAssignment ;
+                         npa:ofPreset    ?preset ;
+                         npa:forResource ?resource ;
+                         npa:forSpaceRef ?targetRef ;
+                         npa:isActivated ?activated ;
+                         npa:viaNanopub  ?assignNp ;
+                         <http://purl.org/dc/terms/created> ?created .
+                } }
+                WHERE {
+                  # 1. Anchor: every assignment row (active or not) in the extraction graph.
+                  GRAPH <%4$s> {
+                    ?pa a npa:PresetAssignment ;
+                        npa:ofPreset    ?preset ;
+                        npa:forResource ?resource ;
+                        npa:isActivated ?activated ;
+                        npa:pubkeyHash  ?pkh ;
+                        npa:viaNanopub  ?assignNp ;
+                        <http://purl.org/dc/terms/created> ?created .
+                  }
+                  # 2. Load-number filter on the assignment nanopub (delta window).
+                  GRAPH <%6$s> {
+                    ?assignNp npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
+                  }
+                  # 3. Resolve publisher pkh -> agent via the mirrored trust-approved row.
+                  GRAPH <%3$s> {
+                    ?acct a npa:AccountState ;
+                          npa:agent  ?publisher ;
+                          npa:pubkey ?pkh .
+                  }
+                  # 4. Target must be a Space ref the publisher admins. ?targetRef = that ref;
+                  #    fan-out to N refs the publisher admins (per-ref isolation, consistent
+                  #    with the role materializer and design-spaceref-isolation.md).
+                  GRAPH <%4$s> { ?targetRef npa:spaceIri ?resource . }
+                  GRAPH <%3$s> {
+                    ?adminRI a gen:RoleInstantiation ;
+                             npa:forSpaceRef ?targetRef ;
+                             npa:inverseProperty gen:hasAdmin ;
+                             npa:forAgent ?publisher .
+                  }
+                  # 5. Defensive: drop if the assignment nanopub itself was hard-retracted.
+                  %7$s
+                  # 6. Mint per (assignment, ref); dedup on the bound subject. No latest-wins
+                  #    here — a deactivation is just a newer admin-authored row, and the
+                  #    consumer resolves latest dct:created per (preset,resource) over these
+                  #    admin-authored rows (so the resolution is authorization-scoped).
+                  BIND(IRI(CONCAT(STR(?pa), "__", ENCODE_FOR_URI(STR(?targetRef)))) AS ?paRef)
+                  FILTER NOT EXISTS { GRAPH <%3$s> { ?paRef a npa:PresetAssignment . } }
+                }
+                """.formatted(
+                NPA.NAMESPACE,
+                GEN.NAMESPACE,
+                graph,
+                SpacesVocab.SPACES_GRAPH,
+                lastProcessed,
+                NPA.GRAPH,
+                invalidationFilter("assignNp"));
     }
 
     /**
@@ -2009,6 +2122,45 @@ public final class AuthorityResolver {
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
                 presetDeactivationCheckWhere(graph, lastProcessed));
+    }
+
+    /**
+     * DELETE template for ref-scoped preset-assignment stamps ({@link
+     * #presetAssignmentRefStampUpdate}) whose underlying assignment nanopub was
+     * hard-retracted (issue #122). Removes the whole row by subject; scoped to
+     * state-graph {@code npa:PresetAssignment} rows that carry {@code npa:forSpaceRef}
+     * (the IRI-keyed extraction rows never do), so it can never touch them.
+     *
+     * <p>Leaf delete — no structural flag: nothing downstream derives from a listing
+     * stamp, so a stale row only mis-displays a retracted assignment until this cycle's
+     * delete runs. Admin-grant revocation is bounded by the periodic full rebuild (same
+     * sticky-convenience policy as the alias / sub-space declaration edges). A
+     * <em>deactivation</em> needs no delete here: it is represented as a newer
+     * admin-authored stamp with {@code npa:isActivated false}, resolved by the consumer's
+     * latest-wins.
+     */
+    static String presetAssignmentRefInvalidationDelete(IRI graph, long lastProcessed) {
+        return String.format("""
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                DELETE { GRAPH <%3$s> {
+                  ?paRef ?p ?o .
+                } }
+                WHERE {
+                  GRAPH <%3$s> {
+                    ?paRef a npa:PresetAssignment ;
+                           npa:forSpaceRef ?targetRef ;
+                           npa:viaNanopub  ?assignNp .
+                    ?paRef ?p ?o .
+                  }
+                  GRAPH <%4$s> {
+                    ?invNp <%5$s> ?assignNp ;
+                           npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %6$d)
+                  }
+                }
+                """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
+                NPA.GRAPH, NPX.INVALIDATES, lastProcessed);
     }
 
     /** Wraps an ASK by joining the shared prefixes. */

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -367,14 +367,10 @@ public final class AuthorityResolver {
             executeUpdate(roleAssignmentInvalidationDelete(graph, lastProcessed));
             structural = true;
         }
-        // RoleDeclaration ASK only — RDs aren't materialized into the space-state
-        // graph, so there's nothing to DELETE here. The flag still flips because
-        // sticky downstream RIs derived from the now-invalidated RD need a
-        // from-scratch recompute.
-        if (wouldInvalidate(graph, lastProcessed, /*adminPinned=*/ false,
-                            roleDeclarationInvalidationCheckWhere(lastProcessed))) {
-            structural = true;
-        }
+        // Role-declaration invalidation is deliberately NOT acted on (see
+        // nonAdminTierUpdate): a role assignment is governed by the admin-validated
+        // attachment, not by the declaration author's later supersession/retraction, so
+        // an invalidated RD neither deletes rows nor triggers a rebuild.
         // Sub-space declarations are structural — invalidating one (Mode A) or one
         // of two co-declarations (Mode B) changes the validated parent/child
         // topology. The DELETE removes the per-declaration row; the convenience
@@ -1420,12 +1416,13 @@ public final class AuthorityResolver {
                   {
                     GRAPH <%3$s> { ?instSpace npa:sameAsSpace ?spaceRef . }
                   }
-                  # 2. Tier-pinned RoleDeclaration (?role bound from the attachment).
+                  # 2. Tier-pinned RoleDeclaration (?role bound from the attachment). Its
+                  #    nanopub's invalidation is intentionally NOT consulted (see step 7), so
+                  #    no ?rdNp binding is needed.
                   GRAPH <%4$s> {
                     ?rd a npa:RoleDeclaration ;
                         npa:hasRoleType <%7$s> ;
-                        npa:role        ?role ;
-                        npa:viaNanopub  ?rdNp .
+                        npa:role        ?role .
                     # 3. Pair direction so only matching combos are explored. ?dirPred
                     #    carries the matched direction so the materialized row records the
                     #    role property (read by get-space-members and publisherIsTieredRole).
@@ -1455,18 +1452,24 @@ public final class AuthorityResolver {
                   }
                   # 5. Publisher constraint (incl. AccountState resolution).
                   GRAPH <%3$s> {
-                    %9$s
+                    %8$s
                   }
                   # 5a. Mint the per-ref state subject: (?ri, ?spaceRef) → ?ri2.
                   BIND(IRI(CONCAT(STR(?ri), "__", ENCODE_FOR_URI(STR(?spaceRef)))) AS ?ri2)
                   # 6. Load-number filter on bound ?np.
-                  GRAPH <%10$s> {
+                  GRAPH <%9$s> {
                     ?np npa:hasLoadNumber ?ln .
                     FILTER (?ln > %5$d)
                   }
-                  # 7. Invalidation filters — outside the GRAPH block so the
-                  #    planner defers them until ?rdNp/?np are bound.
-                  %8$s
+                  # 7. Instantiation invalidation filter — outside the GRAPH block so the
+                  #    planner defers it until ?np is bound. Role-DECLARATION invalidation is
+                  #    deliberately NOT consulted: the tier already anchors on the admin-
+                  #    validated attachment (?ra), which is removed when an admin retracts it,
+                  #    so admin control is fully enforced there. Letting the declaration's
+                  #    author (usually not the space admin) supersede/retract their declaration
+                  #    strip a space's members is the same cross-author-strip anti-pattern as
+                  #    issue #112. Role IRIs are version-pinned, so the attached definition is
+                  #    immutable regardless of the declaration nanopub's later lifecycle.
                   %6$s
                   # 8. Dedup last — keyed on (ref, agent, nanopub).
                   FILTER NOT EXISTS { GRAPH <%3$s> {
@@ -1484,7 +1487,6 @@ public final class AuthorityResolver {
                 lastProcessed,
                 invalidationFilter("np"),
                 tierClass,
-                invalidationFilter("rdNp"),
                 publisherConstraint,
                 NPA.GRAPH);
     }
@@ -1967,30 +1969,6 @@ public final class AuthorityResolver {
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
                 roleAssignmentInvalidationCheckWhere(graph, lastProcessed));
-    }
-
-    /**
-     * WHERE clause for RoleDeclaration invalidation. ASK-only (no DELETE):
-     * RoleDeclarations live in {@code npa:spacesGraph} and aren't materialized
-     * into the space-state graph, so there's nothing to remove from the
-     * space-state. The ASK still flips {@code npa:needsFullRebuild} because
-     * sticky downstream RIs that were derived under the now-invalidated RD
-     * need a from-scratch recompute.
-     */
-    static String roleDeclarationInvalidationCheckWhere(long lastProcessed) {
-        return String.format("""
-                  GRAPH <%1$s> {
-                    ?rd a npa:RoleDeclaration ;
-                        npa:viaNanopub ?np .
-                  }
-                  GRAPH <%2$s> {
-                    ?invNp <%3$s> ?np ;
-                           npa:hasLoadNumber ?ln .
-                    FILTER (?ln > %4$d)
-                    %5$s
-                  }
-                """, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
-                samePublisherClause("invNp", "np"));
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -1075,13 +1075,28 @@ public final class AuthorityResolver {
                           npa:agent  ?publisher ;
                           npa:pubkey ?pkh .
                   }
-                  # 4. Target must be a Space ref the publisher admins. ?targetRef = that ref.
-                  GRAPH <%4$s> { ?targetRef npa:spaceIri ?resource . }
-                  GRAPH <%3$s> {
-                    ?adminRI a gen:RoleInstantiation ;
-                             npa:forSpaceRef ?targetRef ;
-                             npa:inverseProperty gen:hasAdmin ;
-                             npa:forAgent ?publisher .
+                  # 4. Target must be a Space ref the publisher admins — direct, or the
+                  #    canonical ref ?resource is an owl:sameAs alias of (issue #113 parity
+                  #    with attachmentValidationUpdate, so a preset assigned against an alias
+                  #    IRI still materializes against the canonical ref).
+                  {
+                    GRAPH <%4$s> { ?targetRef npa:spaceIri ?resource . }
+                    GRAPH <%3$s> {
+                      ?adminRI a gen:RoleInstantiation ;
+                               npa:forSpaceRef ?targetRef ;
+                               npa:inverseProperty gen:hasAdmin ;
+                               npa:forAgent ?publisher .
+                    }
+                  }
+                  UNION
+                  {
+                    GRAPH <%3$s> {
+                      ?resource npa:sameAsSpace ?targetRef .
+                      ?adminRI a gen:RoleInstantiation ;
+                               npa:forSpaceRef ?targetRef ;
+                               npa:inverseProperty gen:hasAdmin ;
+                               npa:forAgent ?publisher .
+                    }
                   }
                   # 5. Resolve the assignment's referenced preset IRI (node or kind) to its
                   #    canonical kind, mirroring how Nanodash views key on dct:isVersionOf
@@ -1238,13 +1253,27 @@ public final class AuthorityResolver {
                   }
                   # 4. Target must be a Space ref the publisher admins. ?targetRef = that ref;
                   #    fan-out to N refs the publisher admins (per-ref isolation, consistent
-                  #    with the role materializer and design-spaceref-isolation.md).
-                  GRAPH <%4$s> { ?targetRef npa:spaceIri ?resource . }
-                  GRAPH <%3$s> {
-                    ?adminRI a gen:RoleInstantiation ;
-                             npa:forSpaceRef ?targetRef ;
-                             npa:inverseProperty gen:hasAdmin ;
-                             npa:forAgent ?publisher .
+                  #    with the role materializer and design-spaceref-isolation.md). Direct,
+                  #    or the canonical ref ?resource is an owl:sameAs alias of (issue #113),
+                  #    so an assignment naming an alias is still listed under the canonical ref.
+                  {
+                    GRAPH <%4$s> { ?targetRef npa:spaceIri ?resource . }
+                    GRAPH <%3$s> {
+                      ?adminRI a gen:RoleInstantiation ;
+                               npa:forSpaceRef ?targetRef ;
+                               npa:inverseProperty gen:hasAdmin ;
+                               npa:forAgent ?publisher .
+                    }
+                  }
+                  UNION
+                  {
+                    GRAPH <%3$s> {
+                      ?resource npa:sameAsSpace ?targetRef .
+                      ?adminRI a gen:RoleInstantiation ;
+                               npa:forSpaceRef ?targetRef ;
+                               npa:inverseProperty gen:hasAdmin ;
+                               npa:forAgent ?publisher .
+                    }
                   }
                   # 5. Defensive: drop if the assignment nanopub itself was hard-retracted.
                   %7$s
@@ -1309,10 +1338,14 @@ public final class AuthorityResolver {
         // (~hundreds, often zero) and walks outward by bound (?role, ?space).
         //
         //   1. Anchor on RoleAssignments in this space-state graph (small).
+        //   1a. Resolve the IRIs that denote the assignment's ref — its canonical
+        //      IRI plus any validated owl:sameAs aliases — so an instantiation that
+        //      names an alias of the space still matches (issue #113). Bound here so
+        //      the instantiation lookup below stays anchored by ?instSpace.
         //   2. Match the tier-pinned RoleDeclaration by ?role.
         //   3. Pair role-decl direction to instantiation direction in one UNION
         //      so only (reg, reg)/(inv, inv) combos are explored.
-        //   4. Targeted instantiation lookup — (?space, ?pred) are bound.
+        //   4. Targeted instantiation lookup — (?instSpace, ?pred) are bound.
         //   5. Publisher constraint (incl. AccountState resolution).
         //   6. Load-number filter on bound ?np.
         //   7. Dedup at the end.
@@ -1338,6 +1371,21 @@ public final class AuthorityResolver {
                         npa:forSpaceRef ?spaceRef ;
                         npa:forSpace    ?space .
                   }
+                  # 1a. The IRIs that denote this ref: its canonical IRI, plus any validated
+                  #     owl:sameAs aliases of it (issue #113) — so an instantiation naming an
+                  #     alias of the space still materializes here. Bound BEFORE the
+                  #     instantiation BGP so that lookup stays anchored by ?instSpace (planner
+                  #     note above); ?spaceRef is already bound, so each arm is a targeted
+                  #     lookup yielding a tiny IRI set. The alias arm only follows admin-
+                  #     validated npa:sameAsSpace edges, so it grants no authority the admin
+                  #     tier would not (anti-hijack is enforced upstream, not relaxed here).
+                  {
+                    GRAPH <%4$s> { ?spaceRef npa:spaceIri ?instSpace . }
+                  }
+                  UNION
+                  {
+                    GRAPH <%3$s> { ?instSpace npa:sameAsSpace ?spaceRef . }
+                  }
                   # 2. Tier-pinned RoleDeclaration (?role bound from the attachment).
                   GRAPH <%4$s> {
                     ?rd a npa:RoleDeclaration ;
@@ -1358,9 +1406,15 @@ public final class AuthorityResolver {
                       ?ri npa:inverseProperty    ?pred .
                       BIND(npa:inverseProperty AS ?dirPred)
                     }
-                    # 4. Targeted instantiation lookup — (?space, ?pred) bound.
+                    # 4. Targeted instantiation lookup — (?instSpace, ?pred) bound. The
+                    #    instantiation names its space by IRI; ?instSpace was resolved to this
+                    #    ref above (canonical or owl:sameAs alias), so an alias-named
+                    #    instantiation joins the same ?spaceRef as a canonical one. The
+                    #    materialized row still carries npa:forSpace ?space (the attachment's
+                    #    IRI) for the transitional dual-emit, so pre-ref reads see the member
+                    #    under the space's primary IRI.
                     ?ri a gen:RoleInstantiation ;
-                        npa:forSpace   ?space ;
+                        npa:forSpace   ?instSpace ;
                         npa:forAgent   ?agent ;
                         npa:pubkeyHash ?pkh ;
                         npa:viaNanopub ?np .

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -229,6 +229,84 @@ class AuthorityResolverTest {
                 "must skip admin-pinned RIs (those are handled by adminInvalidationDelete)");
     }
 
+    // ---------------- Invalidation authority gate (issue #112) ----------------
+
+    private static final String PK_HASH_IRI =
+            "http://purl.org/nanopub/admin/hasValidSignatureForPublicKeyHash";
+
+    /**
+     * Asserts that the invalidator (?invVar) and its target (?targetVar) are joined
+     * on a shared signing pubkey-hash — the self-retraction gate. Both triples must
+     * reference the same bridge variable {@code ?_invpk_<targetVar>}.
+     */
+    private static void assertSamePublisherGate(String sparql, String invVar, String targetVar) {
+        String pk = "?_invpk_" + targetVar;
+        assertTrue(sparql.contains("?" + invVar + " <" + PK_HASH_IRI + "> " + pk),
+                "invalidator ?" + invVar + " bound to pubkey-hash bridge " + pk);
+        assertTrue(sparql.contains("?" + targetVar + " <" + PK_HASH_IRI + "> " + pk),
+                "target ?" + targetVar + " bound to the SAME pubkey-hash bridge " + pk);
+    }
+
+    @Test
+    void invalidationFilter_gatesOnSamePublisher_viaAdminTier() {
+        // adminTierUpdate gates its seed/closure through invalidationFilter("np").
+        // After issue #112 that filter must additionally require the invalidator to
+        // share a signing pubkey with the invalidated nanopub, so a foreign retraction
+        // no longer drops an admin grant.
+        String sparql = AuthorityResolver.adminTierUpdate(TEST_GRAPH, 17);
+        assertSamePublisherGate(sparql, "_inv_np", "np");
+    }
+
+    @Test
+    void invalidationFilter_seedAliveCheckAlsoGatesOnSamePublisher_issue110plus112() {
+        // The space-ref-alive seed gate (issue #110) uses invalidationFilter("liveNp");
+        // it too must only treat a definition as dead when retracted by its own author.
+        String sparql = AuthorityResolver.adminTierUpdate(TEST_GRAPH, 17);
+        assertSamePublisherGate(sparql, "_inv_liveNp", "liveNp");
+    }
+
+    @Test
+    void adminInvalidationDelete_gatesOnSamePublisher() {
+        assertSamePublisherGate(AuthorityResolver.adminInvalidationDelete(TEST_GRAPH, 17), "invNp", "np");
+    }
+
+    @Test
+    void roleAssignmentInvalidationDelete_gatesOnSamePublisher() {
+        assertSamePublisherGate(AuthorityResolver.roleAssignmentInvalidationDelete(TEST_GRAPH, 5), "invNp", "np");
+    }
+
+    @Test
+    void roleDeclarationInvalidationCheck_gatesOnSamePublisher() {
+        assertSamePublisherGate(AuthorityResolver.roleDeclarationInvalidationCheckWhere(0), "invNp", "np");
+    }
+
+    @Test
+    void leafTierInvalidationDelete_gatesOnSamePublisher() {
+        assertSamePublisherGate(AuthorityResolver.leafTierInvalidationDelete(TEST_GRAPH, 0), "invNp", "np");
+    }
+
+    @Test
+    void subSpaceInvalidationDelete_gatesOnSamePublisher() {
+        assertSamePublisherGate(AuthorityResolver.subSpaceInvalidationDelete(TEST_GRAPH, 5), "invNp", "np");
+    }
+
+    @Test
+    void maintainedResourceInvalidationDelete_gatesOnSamePublisher() {
+        assertSamePublisherGate(AuthorityResolver.maintainedResourceInvalidationDelete(TEST_GRAPH, 5), "invNp", "np");
+    }
+
+    @Test
+    void aliasInvalidationDelete_gatesOnSamePublisher() {
+        assertSamePublisherGate(AuthorityResolver.aliasInvalidationDelete(TEST_GRAPH, 5), "invNp", "np");
+    }
+
+    @Test
+    void presetAssignmentRefInvalidationDelete_gatesOnSamePublisher() {
+        // This one keys the invalidation on ?assignNp, not ?np.
+        assertSamePublisherGate(
+                AuthorityResolver.presetAssignmentRefInvalidationDelete(TEST_GRAPH, 5), "invNp", "assignNp");
+    }
+
     // ---------------- Sub-space admit + invalidation (PR 2) ----------------
 
     @Test

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -544,17 +544,37 @@ class AuthorityResolverTest {
 
     @Test
     void nonAdminTierUpdate_adminConstraintKeysOnAssignmentRef() {
-        // Alias resolution moved upstream: the attachment tier binds the assignment's
-        // ?spaceRef to the canonical ref for owl:sameAs-aliased IRIs (issue #113), so the
-        // non-admin publisher constraint just checks admin-of-?spaceRef — no alias arm.
+        // The publisher constraint keys on the assignment's already-resolved ref — it does
+        // not itself re-resolve aliases (that arm lives in the instantiation lookup below).
         String sparql = AuthorityResolver.nonAdminTierUpdate(
                 TEST_GRAPH, 5,
                 com.knowledgepixels.query.vocabulary.GEN.MEMBER_ROLE,
                 AuthorityResolver.PUBLISHER_IS_ADMIN);
         assertTrue(sparql.contains("npa:forSpaceRef ?spaceRef"),
                 "admin publisher constraint keys on the assignment's ref");
-        assertFalse(sparql.contains("npa:sameAsSpace"),
-                "no alias re-resolution in the non-admin constraint");
+    }
+
+    @Test
+    void nonAdminTierUpdate_instantiationLookupResolvesSameAsAlias() {
+        // Issue #113 parity: an instantiation that names an owl:sameAs alias of the space
+        // must materialize against the same ref as a canonical-named one. The lookup binds
+        // the ref's IRIs (canonical via npa:spaceIri, OR alias via npa:sameAsSpace) and
+        // probes the instantiation by that ?instSpace — anchored, not a full RI scan.
+        String sparql = AuthorityResolver.nonAdminTierUpdate(
+                TEST_GRAPH, 5,
+                com.knowledgepixels.query.vocabulary.GEN.MEMBER_ROLE,
+                AuthorityResolver.PUBLISHER_IS_ADMIN);
+        assertTrue(sparql.contains("?spaceRef npa:spaceIri ?instSpace"),
+                "direct arm: ?instSpace is the ref's canonical IRI");
+        assertTrue(sparql.contains("?instSpace npa:sameAsSpace ?spaceRef"),
+                "alias arm: ?instSpace is an owl:sameAs alias resolving to the ref");
+        assertTrue(sparql.contains("npa:forSpace   ?instSpace"),
+                "instantiation is probed by the resolved IRI, not the attachment's IRI");
+        // The IRI resolution must precede the instantiation BGP so the lookup stays anchored.
+        java.util.regex.Pattern order = java.util.regex.Pattern.compile(
+                "npa:sameAsSpace \\?spaceRef[\\s\\S]*?a gen:RoleInstantiation");
+        assertTrue(order.matcher(sparql).find(),
+                "IRI-set resolution is bound before the instantiation lookup");
     }
 
     @Test
@@ -595,6 +615,18 @@ class AuthorityResolverTest {
                 "publisher must be a validated admin of the target ref");
         assertTrue(sparql.contains("FILTER (?ln > 5)"),
                 "delta filter on the assignment nanopub");
+    }
+
+    @Test
+    void presetAttachmentValidationUpdate_honorsSameAsAlias() {
+        // Issue #113 parity with attachmentValidationUpdate: a preset assignment whose
+        // forResource is an owl:sameAs alias must validate against the canonical ref's
+        // admin set, so the bundled roles still materialize. Direct + alias arms.
+        String sparql = AuthorityResolver.presetAttachmentValidationUpdate(TEST_GRAPH, 5);
+        assertTrue(sparql.contains("?resource npa:sameAsSpace ?targetRef"),
+                "alias arm resolves forResource to the canonical ref it aliases");
+        assertTrue(sparql.contains("?targetRef npa:spaceIri ?resource"),
+                "direct arm still present");
     }
 
     @Test
@@ -685,6 +717,17 @@ class AuthorityResolverTest {
                 "publisher must be a validated admin of the target ref");
         assertTrue(sparql.contains("FILTER (?ln > 5)"),
                 "delta filter on the assignment nanopub");
+    }
+
+    @Test
+    void presetAssignmentRefStampUpdate_honorsSameAsAlias() {
+        // Issue #113 parity: an assignment naming an owl:sameAs alias must be listed under
+        // the canonical ref, so the gate carries the direct + alias arms like the others.
+        String sparql = AuthorityResolver.presetAssignmentRefStampUpdate(TEST_GRAPH, 5);
+        assertTrue(sparql.contains("?resource npa:sameAsSpace ?targetRef"),
+                "alias arm resolves forResource to the canonical ref it aliases");
+        assertTrue(sparql.contains("?targetRef npa:spaceIri ?resource"),
+                "direct arm still present");
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -662,4 +662,68 @@ class AuthorityResolverTest {
                 "deletion gated on an admin-authored superseding assignment");
     }
 
+    // ---------------- Ref-scoped preset-assignment listing stamp (issue #122) ----------------
+
+    @Test
+    void presetAssignmentRefStampUpdate_emitsForSpaceRefAndIsActivated() {
+        String sparql = AuthorityResolver.presetAssignmentRefStampUpdate(TEST_GRAPH, 5);
+        assertTrue(sparql.contains("INSERT"), "INSERT clause");
+        assertTrue(sparql.contains("npa:PresetAssignment"),
+                "stamps a ref-scoped npa:PresetAssignment row");
+        assertTrue(sparql.contains("npa:forSpaceRef ?targetRef"),
+                "the stamp is ref-scoped — the whole point of #122");
+        // Carries activation state and emits both active AND deactivated rows, so the
+        // listing can show state (?activated bound, NOT the literal `true`).
+        assertTrue(sparql.contains("npa:isActivated ?activated"),
+                "binds the activation state instead of filtering to active-only");
+        assertFalse(sparql.contains("npa:isActivated true"),
+                "must NOT anchor on active-only, or deactivated assignments vanish");
+        // Admin-validated, ref-resolved — same gate as the role materializer.
+        assertTrue(sparql.contains("?targetRef npa:spaceIri ?resource"),
+                "resolves the resource to a Space ref (cross-nanopub join)");
+        assertTrue(sparql.contains("npa:inverseProperty gen:hasAdmin"),
+                "publisher must be a validated admin of the target ref");
+        assertTrue(sparql.contains("FILTER (?ln > 5)"),
+                "delta filter on the assignment nanopub");
+    }
+
+    @Test
+    void presetAssignmentRefStampUpdate_hasNoRoleJoinSoViewOnlyPresetsAreListed() {
+        // Caveat 1: a preset bundling only views (no roles) must still appear in the
+        // listing. The stamp therefore must NOT join the role declaration the way the
+        // role materializer does.
+        String sparql = AuthorityResolver.presetAssignmentRefStampUpdate(TEST_GRAPH, 0);
+        assertFalse(sparql.contains("npa:presetRole"),
+                "no role join — view-only presets must still be listed");
+        assertFalse(sparql.contains("npa:appliesToInstancesOf"),
+                "not gated on a Space-targeted role declaration");
+        assertFalse(sparql.contains("gen:RoleAssignment"),
+                "this is a listing stamp, not a role attachment");
+    }
+
+    @Test
+    void presetAssignmentRefStampUpdate_hasNoLatestWinsFilter() {
+        // A deactivation is just a newer admin-authored row; latest-wins is resolved by
+        // the consumer over these admin-authored rows (so it is authorization-scoped for
+        // free). The stamp itself does no dct:created shadowing comparison.
+        String sparql = AuthorityResolver.presetAssignmentRefStampUpdate(TEST_GRAPH, 0);
+        assertFalse(sparql.contains("?createdNewer"),
+                "no server-side latest-wins — deferred to the consumer query");
+        assertFalse(sparql.contains("?paNewer"),
+                "no shadowing-candidate probe in the stamp");
+    }
+
+    @Test
+    void presetAssignmentRefInvalidationDelete_scopedToForSpaceRefRows() {
+        String sparql = AuthorityResolver.presetAssignmentRefInvalidationDelete(TEST_GRAPH, 5);
+        assertTrue(sparql.contains("DELETE"), "DELETE clause");
+        assertTrue(sparql.contains("npa:PresetAssignment") && sparql.contains("npa:forSpaceRef ?targetRef"),
+                "deletes only state-graph stamps (which carry npa:forSpaceRef), never the "
+                        + "IRI-keyed extraction rows");
+        assertTrue(sparql.contains("?invNp <http://purl.org/nanopub/x/invalidates> ?assignNp"),
+                "removal is driven by hard retraction of the assignment nanopub");
+        assertTrue(sparql.contains("FILTER (?ln > 5)"),
+                "delta filter on the invalidator's load number");
+    }
+
 }

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -206,17 +206,19 @@ class AuthorityResolverTest {
     }
 
     @Test
-    void roleDeclarationInvalidationCheck_isAskOnly() {
-        // RoleDeclaration invalidation is ASK-only — RDs aren't materialized into
-        // the space-state graph, so there's nothing to DELETE here. The WHERE clause
-        // exists only to drive an ASK that flips needsFullRebuild.
-        String where = AuthorityResolver.roleDeclarationInvalidationCheckWhere(0);
-        assertTrue(where.contains("npa:RoleDeclaration"),
-                "scoped to RoleDeclaration rows in spacesGraph");
-        assertTrue(where.contains("?invNp <http://purl.org/nanopub/x/invalidates> ?np"),
-                "joins the raw npx:invalidates triple in npa:graph");
-        assertTrue(where.contains("FILTER (?ln > 0)"),
-                "delta filter on the invalidator's load number");
+    void nonAdminTierUpdate_doesNotConsultRoleDeclarationInvalidation() {
+        // A role assignment is governed by the admin-validated attachment, not by the
+        // declaration author's later supersession/retraction (the attachment anchor
+        // already enforces admin control). So the non-admin tier must NOT carry a
+        // role-declaration invalidation filter — only the instantiation's own.
+        String sparql = AuthorityResolver.nonAdminTierUpdate(
+                TEST_GRAPH, 5,
+                com.knowledgepixels.query.vocabulary.GEN.OBSERVER_ROLE,
+                AuthorityResolver.PUBLISHER_IS_SELF);
+        assertFalse(sparql.contains("_inv_rdNp"),
+                "no role-declaration invalidation filter (its ?_inv_rdNp var must not appear)");
+        // The instantiation's own invalidation filter is still present.
+        assertSamePublisherGate(sparql, "_inv_np", "np");
     }
 
     @Test
@@ -273,11 +275,6 @@ class AuthorityResolverTest {
     @Test
     void roleAssignmentInvalidationDelete_gatesOnSamePublisher() {
         assertSamePublisherGate(AuthorityResolver.roleAssignmentInvalidationDelete(TEST_GRAPH, 5), "invNp", "np");
-    }
-
-    @Test
-    void roleDeclarationInvalidationCheck_gatesOnSamePublisher() {
-        assertSamePublisherGate(AuthorityResolver.roleDeclarationInvalidationCheckWhere(0), "invNp", "np");
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTierIsolationTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTierIsolationTest.java
@@ -158,17 +158,41 @@ class AuthorityResolverTierIsolationTest {
         IRI roleX = ex("roleX");
         IRI attNp = ex("np_att");
         extAttachment("att1", S, roleX, PKH_A, attNp);
+        sig(attNp, PKH_A);                       // attachment signed by Alice (pkhA)
         runToFixpoint(AuthorityResolver.attachmentValidationUpdate(STATE, -1));
         assertTrue(hasAssignment(R1, roleX), "precondition: assignment materialized");
 
-        // A later nanopub invalidates the attachment nanopub.
+        // A later nanopub from the SAME publisher (pkhA) invalidates the attachment.
         IRI invNp = ex("np_inv");
         c.add(invNp, INVALIDATES, attNp, ADMINGRAPH);
         c.add(invNp, npa("hasLoadNumber"), vf.createLiteral(1L), ADMINGRAPH);
+        sig(invNp, PKH_A);
         executeUpdate(AuthorityResolver.roleAssignmentInvalidationDelete(STATE, -1));
 
         assertFalse(hasAssignment(R1, roleX),
-                "ref-scoped RoleAssignment removed when its source nanopub is invalidated");
+                "self-retraction (same pubkey) removes the ref-scoped RoleAssignment");
+    }
+
+    @Test
+    void foreignInvalidationIsIgnored_issue112() {
+        // A validly-signed nanopub from a DIFFERENT key must not invalidate another
+        // publisher's materialized state — the griefing/DoS gate of issue #112.
+        IRI roleX = ex("roleX");
+        IRI attNp = ex("np_att");
+        extAttachment("att1", S, roleX, PKH_A, attNp);
+        sig(attNp, PKH_A);                       // attachment signed by Alice (pkhA)
+        runToFixpoint(AuthorityResolver.attachmentValidationUpdate(STATE, -1));
+        assertTrue(hasAssignment(R1, roleX), "precondition: assignment materialized");
+
+        // Mallory (pkhB) tries to retract Alice's (pkhA) attachment.
+        IRI invNp = ex("np_inv");
+        c.add(invNp, INVALIDATES, attNp, ADMINGRAPH);
+        c.add(invNp, npa("hasLoadNumber"), vf.createLiteral(1L), ADMINGRAPH);
+        sig(invNp, PKH_B);
+        executeUpdate(AuthorityResolver.roleAssignmentInvalidationDelete(STATE, -1));
+
+        assertTrue(hasAssignment(R1, roleX),
+                "foreign-key invalidation must NOT remove the RoleAssignment");
     }
 
     // ---------------- seeding helpers ----------------
@@ -192,6 +216,11 @@ class AuthorityResolverTierIsolationTest {
     }
 
     private void loadNum(IRI np) { c.add(np, npa("hasLoadNumber"), vf.createLiteral(0L), ADMINGRAPH); }
+
+    /** Records the signing pubkey-hash of a nanopub (issue #112 self-retraction gate). */
+    private void sig(IRI np, Literal pkh) {
+        c.add(np, NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY_HASH, pkh, ADMINGRAPH);
+    }
 
     private void extAttachment(String name, IRI iri, IRI role, Literal pkh, IRI np) {
         IRI ra = ex(name);


### PR DESCRIPTION
This branch carries one feature (#122) plus three correctness fixes to the spaces materializer that grew onto the same branch. All four require a **full re-ingest** on deploy.

Closes #122.

---

## 1. Ref-scope preset-assignment listing (#122) — `92b27bf`

### Problem

The `npa:PresetAssignment` extraction row (`SpacesExtractor.extractPresetAssignment`) is keyed only by `npa:forResource` — it carries no `npa:forSpaceRef`. So the "Assigned presets" About-tab table (the last ref-scoped listing that still merged across refs) shows assignments from **all** refs claiming that IRI. That now matters because refs of one IRI can have different admin sets — a preset assigned under one ref surfaces on a rival ref's page.

Extraction is publisher-agnostic and processes a nanopub in isolation, so it can't resolve the resource's ref there (that needs the cross-nanopub `?targetRef npa:spaceIri ?resource` join). But the preset-role materializer (#302) already resolves exactly that, plus the publisher-admin gate.

### Approach

A new `presetAssignmentRefStampUpdate` stamps a **ref-scoped mirror** of each assignment into the state graph, reusing the materializer's steps 1–4 (anchor → load filter → `pkh→agent` → `?targetRef npa:spaceIri ?resource` + per-ref admin gate) but **deliberately not** its role path:

- **No role/declaration join** → a preset bundling only *views* (no roles) is still listed (the role-gated alternative would drop it).
- **Carries `npa:isActivated ?activated`, emits active AND deactivated rows** → the listing can show state instead of silently dropping deactivated assignments (which the IRI-keyed row shows today).
- **Latest-wins deferred to the consumer query**, which ranges only over these admin-authored rows → authorization-scoped for free (a non-admin of the ref can never get a row stamped). So no §4.3-step-7 shadowing probe and no §4.4 `dct:created` deactivation-delete are needed for the listing.

**Display-only leaf:** nothing downstream derives from a listing stamp, so its tier count is excluded from `structuralAdds` (never forces a full rebuild). Wired into `runAllTierLoops`, the `runDownstreamWithoutLoadFilter` late sweep, and the per-tier counter/log lines.

**Maintenance** is one leaf delete, `presetAssignmentRefInvalidationDelete` (positive `npx:invalidates` join + delta filter, modeled on `maintainedResourceInvalidationDelete`), scoped to state-graph rows carrying `npa:forSpaceRef` so it can never touch the IRI-keyed extraction rows.

### Consumer (Nanodash, separate repo — no change here)

Minimal: the published "Assigned presets" query keeps its existing `isActivated` + latest-`dct:created` logic and only swaps `?pa npa:forResource <IRI>` → `?pa npa:forSpaceRef ?refRoot`. Flip the `❌ Preset assignment listing ref-scoped` row in nanodash `docs/space-ref-identity.md` once it lands.

---

## 2. Resolve `owl:sameAs` aliases in role + preset-assignment tiers — `e8b6c3c`

Role assignments and preset-bundled roles only materialized when the instantiation/assignment named the *same* IRI as the validated attachment. An assignment that referenced the space by an `owl:sameAs` alias (#113) silently failed to materialize.

Alias resolution extended to the three consumer passes that lacked it:

- **`nonAdminTierUpdate`**: bind the ref's IRI set (canonical via `npa:spaceIri` UNION alias via `npa:sameAsSpace`) before the instantiation BGP and probe by `?instSpace`, so an alias-named instantiation joins the same `?spaceRef` as a canonical one. Bound *before* the lookup to stay anchored (the instantiation-scan planner trap). The row keeps `npa:forSpace ?space` (the attachment IRI) for the transitional dual-emit.
- **`presetAttachmentValidationUpdate` / `presetAssignmentRefStampUpdate`**: add the direct+alias admin-gate UNION (mirroring `attachmentValidationUpdate`), so a preset assigned against an alias resolves to the canonical ref.

The admin tier stays canonical-only by design: the #113 anti-hijack invariant `admins(alias) ⊆ admins(canonical)` means aliases must never introduce admins; resolving non-admin/preset assignments through admin-validated alias edges grants no new authority.

---

## 3. Gate invalidations on same publisher (#112) — `254aa60`

The materializer gated *additions* through the admin closure but honored *removals* from any `npx:invalidates`/`retracts`/`supersedes` edge regardless of who signed it, so any validly-signed nanopub could erase another space's materialized state (griefing/DoS of the view — fail-closed, no privilege escalation).

A self-retraction authority gate: an invalidation is honored only when the invalidating nanopub shares a signing pubkey with its target. Both `npa:hasValidSignatureForPublicKeyHash` triples are already in the spaces repo (target via its own space-load; invalidator via the symmetric retractor propagation in `NanopubLoader`), so this is a query-time join only.

- New `samePublisherClause(invVar, targetVar)` helper.
- `invalidationFilter` now requires shared pubkey (covers every addition tier and the #110 space-ref-alive seed gate).
- The eight `*InvalidationCheckWhere` / inline DELETE passes (admin, roleAssignment, roleDeclaration, leafTier, subSpace, maintainedResource, alias, presetAssignmentRef) get the same join. `presetDeactivationDelete` is unchanged (timestamp/latest-wins, already admin-scoped).

**Limitations** (approach a): "same pubkey" is stricter than "same agent" (key rotation breaks self-retraction); cross-admin supersession is out of scope.

---

## 4. Stop consulting role-declaration invalidation in role tiers — `5990b3e`

A space's role assignments are governed by the admin-validated attachment (`gen:hasRole`), which the non-admin tier already anchors on and which is removed when an admin retracts it. Additionally gating instantiations on the role *declaration's* invalidation let the declaration's author (usually not the space admin) strip a space's members by superseding/retracting their declaration — the same cross-author-strip anti-pattern as #112. Role IRIs are version-pinned (np-namespaced), so the attached definition is immutable regardless of the declaration nanopub's later lifecycle.

Observed live: tutorial-eswc2025's `participantRole` declaration was superseded by a continuation revision, which silently dropped all of its (alias-assigned) observer roles — a #110-class supersession-strips-downstream bug.

- `nonAdminTierUpdate`: drop `invalidationFilter("rdNp")` (and the now-unused `?rdNp` binding). The instantiation's own invalidation filter is kept — an instantiator retracting their own assignment is still honored.
- `applyInvalidations`: remove the role-declaration rebuild-trigger ASK; with nothing acting on RD invalidation it can neither delete nor warrant a rebuild.
- Delete the now-dead `roleDeclarationInvalidationCheckWhere` + its tests.

---

## Deploy

All four changes need a **full re-ingest** backfill on deploy (pre-existing state is only re-materialized on re-evaluation), not a `FORCE_RESYNC`.

## Tests

All pass. #122 adds 4 string-structure tests (`forSpaceRef`/`isActivated ?activated` emitted, no role join, no latest-wins probe, delete scoped to `forSpaceRef` rows); #112 adds structural assertions across the filter + all eight passes plus an end-to-end `foreignInvalidationIsIgnored` case; #5990b3e deletes the dead `roleDeclarationInvalidationCheckWhere` tests. Design rationale in `doc/design-preset-role-materialization.md` §12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
