### PR TITLE
fix(spaces): resolve custom role-predicate direction+tier from the role declaration

### DIFF
--- a/doc/design-space-repositories.md
+++ b/doc/design-space-repositories.md
@@ -208,6 +208,22 @@ GRAPH npa:spacesGraph {
 
 Exactly one of `npa:regularProperty` or `npa:inverseProperty` is emitted per instantiation, matching the predicate direction used in the source nanopub's assertion. Consumers JOIN through the corresponding `npa:RoleDeclaration` (via `gen:hasRegularProperty` / `gen:hasInverseProperty`) to resolve the role IRI and tier.
 
+**Custom (unclassified) predicates.** The extractor knows the direction only of `gen:hasAdmin` and the backcompat predicates. A role declared via a `gen:SpaceMemberRole` nanopub may use any predicate (e.g. `gen:hasMaintainer`), whose direction lives in that declaration — a different nanopub the per-nanopub extractor can't see. For a nanopub *explicitly* typed `gen:RoleInstantiation` whose assertion predicate isn't classifiable, the extractor emits a **neutral** binding instead of dropping it: it records the raw triple endpoints without committing to a direction, with a predicate-discriminated subject (`npari:<artifactCode>_<predHash>`):
+
+```turtle
+GRAPH npa:spacesGraph {
+  npari:<artifactCode>_<predHash> a gen:RoleInstantiation ;
+                       npa:rolePredicate   <predIRI> ;   # the raw assertion predicate
+                       npa:bindingSubject  <subj> ;       # raw assertion subject
+                       npa:bindingObject   <obj> ;        # raw assertion object
+                       npa:viaNanopub      <thisNP> ;
+                       npa:pubkeyHash      "<pubkeyHash>" ;
+                       dct:created         "<timestamp>"^^xsd:dateTime .
+}
+```
+
+The materializer resolves these at tier time: it joins `npa:rolePredicate` against the tier-pinned `npa:RoleDeclaration` attached to the space, and the matched `gen:hasInverseProperty` / `gen:hasRegularProperty` fixes both the direction and which raw endpoint is the space vs. the agent (INVERSE = `<space> pred <agent>`; REGULAR = `<agent> pred <space>`). The materialized space-state row is identical to a pre-classified grant — it carries the resolved `npa:inverseProperty` / `npa:regularProperty`, so read-side queries need no special case. (Gating emission on the explicit type avoids minting inert entries for incidental IRI-valued triples in nanopubs that only matched via a backcompat predicate.)
+
 ### Triples added per `gen:isSubSpaceOf` nanopub
 
 Single-triple-assertion dispatch picks up nanopubs whose assertion uses `gen:isSubSpaceOf` as the predicate (the predicate IRI surfaces in the nanopub's type set, the same trick that catches the 14 backcompat role predicates). Every `<childIri> gen:isSubSpaceOf <parentIri>` triple in the assertion emits one `npa:SubSpaceDeclaration` entry — same shape as the embedded path in `gen:Space` extraction. Multi-triple assertions are allowed; one entry per `(child, parent)` pair. Full schema and validation rule live in [Sub-space relations](#sub-space-relations).

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -1423,30 +1423,55 @@ public final class AuthorityResolver {
                     ?rd a npa:RoleDeclaration ;
                         npa:hasRoleType <%7$s> ;
                         npa:role        ?role .
-                    # 3. Pair direction so only matching combos are explored. ?dirPred
-                    #    carries the matched direction so the materialized row records the
-                    #    role property (read by get-space-members and publisherIsTieredRole).
+                    # 3. Pair role-decl direction to the instantiation in one UNION so only
+                    #    matching combos are explored, binding (?instSpace, ?agent) per arm.
+                    #    ?dirPred carries the resolved direction so the materialized row
+                    #    records the role property (read by get-space-members and
+                    #    publisherIsTieredRole) — identical shape whichever arm matched.
+                    #
+                    #    The first two arms handle instantiations the extractor already
+                    #    classified (npa:regularProperty / npa:inverseProperty). The last two
+                    #    resolve a custom predicate the extractor left neutral (npa:rolePredicate
+                    #    with raw npa:bindingSubject / npa:bindingObject): the role declaration
+                    #    supplies the direction, which fixes which raw endpoint is the space vs
+                    #    the agent. INVERSE = <space> pred <agent>; REGULAR = <agent> pred <space>.
                     {
                       ?rd gen:hasRegularProperty ?pred .
-                      ?ri npa:regularProperty    ?pred .
+                      ?ri npa:regularProperty ?pred ;
+                          npa:forSpace ?instSpace ;
+                          npa:forAgent ?agent .
                       BIND(npa:regularProperty AS ?dirPred)
                     }
                     UNION
                     {
                       ?rd gen:hasInverseProperty ?pred .
-                      ?ri npa:inverseProperty    ?pred .
+                      ?ri npa:inverseProperty ?pred ;
+                          npa:forSpace ?instSpace ;
+                          npa:forAgent ?agent .
                       BIND(npa:inverseProperty AS ?dirPred)
                     }
-                    # 4. Targeted instantiation lookup — (?instSpace, ?pred) bound. The
-                    #    instantiation names its space by IRI; ?instSpace was resolved to this
-                    #    ref above (canonical or owl:sameAs alias), so an alias-named
-                    #    instantiation joins the same ?spaceRef as a canonical one. The
-                    #    materialized row still carries npa:forSpace ?space (the attachment's
-                    #    IRI) for the transitional dual-emit, so pre-ref reads see the member
-                    #    under the space's primary IRI.
+                    UNION
+                    {
+                      ?rd gen:hasInverseProperty ?pred .
+                      ?ri npa:rolePredicate   ?pred ;
+                          npa:bindingSubject  ?instSpace ;
+                          npa:bindingObject   ?agent .
+                      BIND(npa:inverseProperty AS ?dirPred)
+                    }
+                    UNION
+                    {
+                      ?rd gen:hasRegularProperty ?pred .
+                      ?ri npa:rolePredicate   ?pred ;
+                          npa:bindingObject   ?instSpace ;
+                          npa:bindingSubject  ?agent .
+                      BIND(npa:regularProperty AS ?dirPred)
+                    }
+                    # 4. Common instantiation columns. ?instSpace was resolved to this ref
+                    #    above (canonical or owl:sameAs alias), so an alias-named instantiation
+                    #    joins the same ?spaceRef as a canonical one. The materialized row still
+                    #    carries npa:forSpace ?space (the attachment's IRI) for the transitional
+                    #    dual-emit, so pre-ref reads see the member under the space's primary IRI.
                     ?ri a gen:RoleInstantiation ;
-                        npa:forSpace   ?instSpace ;
-                        npa:forAgent   ?agent ;
                         npa:pubkeyHash ?pkh ;
                         npa:viaNanopub ?np .
                   }

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -152,7 +152,7 @@ public final class SpacesExtractor {
             extractSpaceMemberRole(np, ctx, out);
         }
         if (isRoleInstantiation) {
-            extractRoleInstantiation(np, ctx, out);
+            extractRoleInstantiation(np, ctx, types.contains(GEN.ROLE_INSTANTIATION), out);
         }
         if (isSubSpaceOf) {
             extractSubSpaceOf(np, ctx, out);
@@ -523,7 +523,8 @@ public final class SpacesExtractor {
 
     // ---------------- gen:RoleInstantiation (and backcompat) ----------------
 
-    private static void extractRoleInstantiation(Nanopub np, Context ctx, List<Statement> out) {
+    private static void extractRoleInstantiation(Nanopub np, Context ctx,
+                                                 boolean explicitRoleInstantiation, List<Statement> out) {
         // Find the assignment triple. Directionality (matches the publisher convention
         // used by gen:hasRegularProperty / gen:hasInverseProperty in role-definition
         // nanopubs):
@@ -531,11 +532,7 @@ public final class SpacesExtractor {
         //   INVERSE: <space> <predicate> <agent>  → npa:inverseProperty.
         // gen:hasAdmin is hardcoded INVERSE (space-centric: <space> hasAdmin <agent>).
         // The 14 backwards-compat predicates are classified in
-        // {@link BackcompatRolePredicates#DIRECTIONS}. User-defined role predicates from
-        // gen:SpaceMemberRole nanopubs aren't resolvable here without the role-declaration
-        // registry; FIXME: the materializer in PR 2 should refine direction for the
-        // typed-but-unknown-predicate case. For now we emit only triples whose predicate
-        // we know the direction of.
+        // {@link BackcompatRolePredicates#DIRECTIONS}.
         for (Statement st : np.getAssertion()) {
             IRI predicate = st.getPredicate();
             BackcompatRolePredicates.Direction direction = directionFor(predicate);
@@ -581,6 +578,42 @@ public final class SpacesExtractor {
             out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, np.getUri(), GRAPH));
             addProvenance(subject, ctx, out);
             return;
+        }
+
+        // No predicate with a known direction. For a nanopub explicitly typed
+        // gen:RoleInstantiation, the assertion still binds an agent to a space via a
+        // custom role predicate declared in a gen:SpaceMemberRole nanopub (e.g.
+        // gen:hasMaintainer). We can't classify its direction here — that lives in the
+        // role declaration, a different nanopub the extractor can't see — so emit a
+        // neutral binding carrying the raw (subject, predicate, object). The materializer
+        // resolves direction + tier by joining the predicate against the role declaration
+        // attached to the space (see AuthorityResolver#nonAdminTierUpdate). Gated on the
+        // explicit type so we don't mint inert entries for incidental IRI-valued triples
+        // in nanopubs that only matched via a backcompat predicate.
+        if (!explicitRoleInstantiation) {
+            return;
+        }
+        for (Statement st : np.getAssertion()) {
+            IRI predicate = st.getPredicate();
+            if (predicate.equals(RDF.TYPE) || directionFor(predicate) != null) {
+                continue;
+            }
+            if (!(st.getSubject() instanceof IRI subjIri)) {
+                continue;
+            }
+            if (!(st.getObject() instanceof IRI objIri)) {
+                continue;
+            }
+            // Discriminate the subject by predicate so multiple custom-predicate triples
+            // in one nanopub don't collide on the artifact-code-derived subject.
+            IRI subject = SpacesVocab.forRoleInstantiation(
+                    ctx.artifactCode(), Utils.createHash(predicate.stringValue()));
+            out.add(vf.createStatement(subject, RDF.TYPE, GEN.ROLE_INSTANTIATION, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.ROLE_PREDICATE, predicate, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.BINDING_SUBJECT, subjIri, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.BINDING_OBJECT, objIri, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, np.getUri(), GRAPH));
+            addProvenance(subject, ctx, out);
         }
     }
 

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
@@ -111,6 +111,25 @@ public final class SpacesVocab {
     /** The "inverse" direction predicate used in the source assertion (agent &rarr; space). */
     public static final IRI INVERSE_PROPERTY = vf.createIRI(NPA.NAMESPACE, "inverseProperty");
 
+    /**
+     * Custom role predicate on an <em>unresolved</em> {@code gen:RoleInstantiation} — one
+     * whose direction the extractor can't classify (not {@code gen:hasAdmin} and not in
+     * {@link com.knowledgepixels.query.vocabulary.BackcompatRolePredicates}). Carries the
+     * raw assertion predicate IRI; the materializer resolves its direction (and hence
+     * tier) by joining it against an {@link #ROLE_DECLARATION}'s
+     * {@code gen:hasRegularProperty} / {@code gen:hasInverseProperty} that is attached to
+     * the target space. Emitted alongside {@link #BINDING_SUBJECT} / {@link #BINDING_OBJECT}
+     * (the raw assertion endpoints) instead of {@link #FOR_SPACE} / {@link #FOR_AGENT},
+     * since which side is the space isn't known until the direction is resolved.
+     */
+    public static final IRI ROLE_PREDICATE = vf.createIRI(NPA.NAMESPACE, "rolePredicate");
+
+    /** Raw assertion subject of an unresolved {@link #ROLE_PREDICATE} binding. */
+    public static final IRI BINDING_SUBJECT = vf.createIRI(NPA.NAMESPACE, "bindingSubject");
+
+    /** Raw assertion object of an unresolved {@link #ROLE_PREDICATE} binding. */
+    public static final IRI BINDING_OBJECT = vf.createIRI(NPA.NAMESPACE, "bindingObject");
+
     /** Literal pubkey hash stamped alongside {@link org.nanopub.vocabulary.NPX#SIGNED_BY}. */
     public static final IRI PUBKEY_HASH = vf.createIRI(NPA.NAMESPACE, "pubkeyHash");
 

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -144,6 +144,12 @@ class AuthorityResolverTest {
                 "tier class is substituted");
         assertTrue(sparql.contains("gen:RoleAssignment"),
                 "attachment gate present");
+        // Also resolves neutral instantiations (custom predicates) by reading the raw
+        // binding endpoints and inferring direction from the role declaration.
+        assertTrue(sparql.contains("npa:rolePredicate"),
+                "neutral custom-predicate instantiations are resolved");
+        assertTrue(sparql.contains("npa:bindingSubject") && sparql.contains("npa:bindingObject"),
+                "raw binding endpoints consumed for direction resolution");
     }
 
     @Test
@@ -643,7 +649,7 @@ class AuthorityResolverTest {
                 "direct arm: ?instSpace is the ref's canonical IRI");
         assertTrue(sparql.contains("?instSpace npa:sameAsSpace ?spaceRef"),
                 "alias arm: ?instSpace is an owl:sameAs alias resolving to the ref");
-        assertTrue(sparql.contains("npa:forSpace   ?instSpace"),
+        assertTrue(sparql.contains("npa:forSpace ?instSpace"),
                 "instantiation is probed by the resolved IRI, not the attachment's IRI");
         // The IRI resolution must precede the instantiation BGP so the lookup stays anchored.
         java.util.regex.Pattern order = java.util.regex.Pattern.compile(

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTierIsolationTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTierIsolationTest.java
@@ -104,6 +104,53 @@ class AuthorityResolverTierIsolationTest {
     }
 
     @Test
+    void customPredicateResolvesDirectionAndTierFromRoleDeclaration() {
+        // A maintainer assignment using a custom predicate (gen:hasMaintainer) the
+        // extractor can't classify, so it emitted a NEUTRAL instantiation
+        // (npa:rolePredicate + raw bindingSubject/bindingObject). The materializer must
+        // resolve its direction (INVERSE here, from the role declaration's
+        // gen:hasInverseProperty) and tier (MaintainerRole), then materialize it exactly
+        // like a pre-classified grant — carrying npa:inverseProperty for the read side.
+        IRI roleX = ex("roleMaint");
+        IRI pred  = ex("hasMaintainer");
+        extAttachment("att1", S, roleX, PKH_A, ex("np_att"));   // Alice attaches the role to S
+        runToFixpoint(AuthorityResolver.attachmentValidationUpdate(STATE, -1));
+        roleDecl("rd1", roleX, GEN.MAINTAINER_ROLE, GEN.HAS_INVERSE_PROPERTY, pred, ex("np_rd"));
+        // INVERSE source shape <space> pred <agent>: bindingSubject=space, bindingObject=agent.
+        extNeutralInstantiation("ri_cm", S, ex("morgan"), pred, PKH_A, ex("np_cm"));
+        runToFixpoint(AuthorityResolver.nonAdminTierUpdate(
+                STATE, -1, GEN.MAINTAINER_ROLE, AuthorityResolver.PUBLISHER_IS_ADMIN));
+
+        assertTrue(memberInRef(R1, ex("morgan")),
+                "custom-predicate maintainer resolved and materialized in R1");
+        assertTrue(memberCarriesProperty(R1, ex("morgan"), pred),
+                "materialized row carries the resolved npa:inverseProperty (read by get-space-members)");
+        assertFalse(memberInRef(R2, ex("morgan")),
+                "must NOT leak into Bob's ref R2");
+    }
+
+    @Test
+    void customPredicateRegularDirectionSwapsSpaceAndAgent() {
+        // Same path, REGULAR direction: role declaration says the predicate is the
+        // gen:hasRegularProperty, so the source shape is <agent> pred <space> —
+        // bindingSubject is the agent, bindingObject is the space.
+        IRI roleX = ex("roleMaintReg");
+        IRI pred  = ex("maintains");
+        extAttachment("att1", S, roleX, PKH_A, ex("np_att"));
+        runToFixpoint(AuthorityResolver.attachmentValidationUpdate(STATE, -1));
+        roleDecl("rd1", roleX, GEN.MAINTAINER_ROLE, GEN.HAS_REGULAR_PROPERTY, pred, ex("np_rd"));
+        // REGULAR source shape <agent> pred <space>: bindingSubject=agent, bindingObject=space.
+        extNeutralInstantiation("ri_cr", ex("morgan"), S, pred, PKH_A, ex("np_cr"));
+        runToFixpoint(AuthorityResolver.nonAdminTierUpdate(
+                STATE, -1, GEN.MAINTAINER_ROLE, AuthorityResolver.PUBLISHER_IS_ADMIN));
+
+        assertTrue(memberInRef(R1, ex("morgan")),
+                "regular-direction custom-predicate maintainer resolved in R1");
+        assertTrue(maintainerCarriesRegularProperty(R1, ex("morgan"), pred),
+                "materialized row carries the resolved npa:regularProperty");
+    }
+
+    @Test
     void aliasEmitsRefValuedEdgeOnlyForTheGovernedCanonicalRef() {
         IRI aold = ex("space-S-old");
         extAlias("al1", S, aold, PKH_A, ex("np_al"));          // Alice: <S> owl:sameAs <aold>
@@ -253,6 +300,23 @@ class AuthorityResolverTierIsolationTest {
         loadNum(np);
     }
 
+    /**
+     * A neutral (unresolved) instantiation as the extractor emits it for a custom role
+     * predicate: raw bindingSubject/bindingObject + npa:rolePredicate, no direction or
+     * forSpace/forAgent. The materializer resolves those from the role declaration.
+     */
+    private void extNeutralInstantiation(String name, IRI bindingSubject, IRI bindingObject,
+                                         IRI pred, Literal pkh, IRI np) {
+        IRI ri = ex(name);
+        c.add(ri, RDF.TYPE, GEN.ROLE_INSTANTIATION, SPACES);
+        c.add(ri, SpacesVocab.ROLE_PREDICATE, pred, SPACES);
+        c.add(ri, SpacesVocab.BINDING_SUBJECT, bindingSubject, SPACES);
+        c.add(ri, SpacesVocab.BINDING_OBJECT, bindingObject, SPACES);
+        c.add(ri, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(ri, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        loadNum(np);
+    }
+
     private void extAlias(String name, IRI canonical, IRI alias, Literal pkh, IRI np) {
         IRI d = ex(name);
         c.add(d, RDF.TYPE, SpacesVocab.SPACE_ALIAS_DECLARATION, SPACES);
@@ -311,6 +375,11 @@ class AuthorityResolverTierIsolationTest {
     private boolean memberCarriesProperty(IRI ref, IRI agent, IRI pred) {
         return ask("?ri a gen:RoleInstantiation ; npa:forSpaceRef <" + ref + "> ; npa:forAgent <" + agent + "> ;"
                 + " npa:inverseProperty <" + pred + "> .");
+    }
+
+    private boolean maintainerCarriesRegularProperty(IRI ref, IRI agent, IRI pred) {
+        return ask("?ri a gen:RoleInstantiation ; npa:forSpaceRef <" + ref + "> ; npa:forAgent <" + agent + "> ;"
+                + " npa:regularProperty <" + pred + "> .");
     }
 
     private boolean sameAsEdge(IRI alias, IRI canonRef) {

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -360,6 +360,54 @@ class SpacesExtractorTest {
         assertDoesNotContain(out, subject, INVERSE_PROPERTY, plansToAttend);
     }
 
+    // ---------------- gen:RoleInstantiation with a custom (unclassified) predicate ----------------
+
+    @Test
+    void extract_customPredicateExplicitlyTyped_emitsNeutralBinding() throws Exception {
+        // gen:hasMaintainer is a user-defined role predicate (declared via a
+        // gen:SpaceMemberRole nanopub's gen:hasInverseProperty); it is neither
+        // gen:hasAdmin nor in BackcompatRolePredicates, so the extractor can't classify
+        // its direction. For a nanopub explicitly typed gen:RoleInstantiation we emit a
+        // neutral binding carrying the raw (subject, predicate, object); the materializer
+        // resolves direction + tier from the role declaration.
+        IRI hasMaintainer = vf.createIRI("https://w3id.org/kpxl/gen/terms/hasMaintainer");
+        Nanopub np = creator()
+                .type(GEN.ROLE_INSTANTIATION)
+                .assertion(SPACE_IRI_1, hasMaintainer, MEMBER_AGENT)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forRoleInstantiation(ARTIFACT_CODE, Utils.createHash(hasMaintainer.stringValue()));
+
+        assertContains(out, subject, RDF.TYPE, GEN.ROLE_INSTANTIATION);
+        assertContains(out, subject, ROLE_PREDICATE, hasMaintainer);
+        assertContains(out, subject, BINDING_SUBJECT, SPACE_IRI_1);
+        assertContains(out, subject, BINDING_OBJECT, MEMBER_AGENT);
+        assertContains(out, subject, VIA_NANOPUB, NP_URI);
+        // No direction was committed: neither the classified split nor regular/inverse.
+        assertDoesNotContain(out, subject, FOR_SPACE, SPACE_IRI_1);
+        assertDoesNotContain(out, subject, FOR_AGENT, MEMBER_AGENT);
+        assertDoesNotContain(out, subject, INVERSE_PROPERTY, hasMaintainer);
+        assertDoesNotContain(out, subject, REGULAR_PROPERTY, hasMaintainer);
+    }
+
+    @Test
+    void extract_customPredicateNotExplicitlyTyped_emitsNothing() throws Exception {
+        // Without an explicit gen:RoleInstantiation type, a single-triple
+        // <space> hasMaintainer <agent> only auto-types as hasMaintainer, which is not a
+        // trigger type — so the nanopub isn't space-relevant and nothing is emitted. (The
+        // neutral path is gated on the explicit type to avoid minting inert entries for
+        // incidental IRI-valued triples in nanopubs matched only via a backcompat predicate.)
+        IRI hasMaintainer = vf.createIRI("https://w3id.org/kpxl/gen/terms/hasMaintainer");
+        Nanopub np = creator()
+                .assertion(SPACE_IRI_1, hasMaintainer, MEMBER_AGENT)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+
+        assertTrue(out.isEmpty(), "Untyped custom-predicate binding must not be space-relevant");
+    }
+
     // ---------------- gen:isSubSpaceOf ----------------
 
     @Test


### PR DESCRIPTION
## Problem

A user→space role assignment using a **custom role predicate** (e.g. `gen:hasMaintainer`, declared via a `gen:SpaceMemberRole` nanopub's `gen:hasInverseProperty`) was silently dropped at extraction. `SpacesExtractor.extractRoleInstantiation` only emitted a `gen:RoleInstantiation` for predicates whose direction it knows — `gen:hasAdmin` plus the `BackcompatRolePredicates` set. `gen:hasMaintainer`/`gen:hasMember` are in neither, so an explicitly `gen:RoleInstantiation`-typed `<space> hasMaintainer <agent>` binding never reached `npa:spacesGraph`, the maintainer tier never materialized, and **Maintainer-tier users never showed up** in a space's about tab — even though the role declaration already carried everything needed to resolve the binding.

This is the deferred FIXME in `extractRoleInstantiation`: *"the materializer in PR 2 should refine direction for the typed-but-unknown-predicate case."*

## Fix

Defer direction inference from extraction-time (per-nanopub, can't see the declaration) to materialization-time (where the role-declaration registry is available):

- **Extractor** — for an explicitly `gen:RoleInstantiation`-typed nanopub whose predicate isn't classifiable, emit a **neutral** binding (`npa:rolePredicate` + raw `npa:bindingSubject`/`npa:bindingObject`, predicate-discriminated subject) instead of dropping it. The known-predicate path is unchanged. Gated on the explicit type so incidental IRI-valued triples don't mint inert rows.
- **Materializer** — `nonAdminTierUpdate`'s direction-pairing UNION gains two branches that join `npa:rolePredicate` against the tier-pinned `npa:RoleDeclaration` attached to the space; the matched `gen:hasInverseProperty`/`gen:hasRegularProperty` fixes both the direction and which raw endpoint is the space vs. agent. The INSERT is untouched, so the materialized state row is identical to a pre-classified grant (carries `npa:inverseProperty`/`npa:regularProperty`) — the read side needs no special case. Applies uniformly to maintainer/member/observer.
- New `SpacesVocab` terms: `npa:rolePredicate`, `npa:bindingSubject`, `npa:bindingObject`.

No hardcoding of `hasMaintainer`; any future user-defined role predicate now works via its declaration. The hardcoded `directionFor` set remains a fallback for predicates without a declaration.

## Tests

- `SpacesExtractorTest`: emits the neutral binding for an explicitly-typed custom predicate; gates it off when the type is absent.
- `AuthorityResolverTierIsolationTest`: end-to-end resolution of both INVERSE and REGULAR custom predicates into the correct ref, carrying the resolved direction property.
- `AuthorityResolverTest`: `nonAdminTierUpdate` SPARQL resolves neutral bindings.
- Full suite: 275 passing.

## Live verification

Verified against `localhost:9393` after a fresh full re-sync: the published binding `RAuAs_L_…` (`<biodiversity> hasMaintainer <orcid>`) now extracts as a neutral RI, materializes into the current state graph with the resolved `npa:inverseProperty gen:hasMaintainer`, and the about-tab read join returns the Maintainer-tier users (3 maintainers across multiple bindings). Admin tier unaffected.

Design doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)