### PR TITLE
fix(spaces): persist role tier + role IRI on non-admin RoleInstantiation rows (#125)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -1391,6 +1391,16 @@ public final class AuthorityResolver {
                        npa:forSpace ?space ;
                        npa:forAgent ?agent ;
                        ?dirPred ?pred ;
+                       # Persist the tier and role IRI that are already bound at this point —
+                       # the loop's tierClass arg (%7$s) and the anchoring attachment's ?role
+                       # (step 1) — so ref-scoped consumers key on identity rather than
+                       # re-deriving the tier from the bare predicate against GLOBAL
+                       # RoleDeclarations. The bare-predicate re-derivation bleeds tiers
+                       # across spaces that declare the same predicate at different tiers
+                       # (issue #125): consumers should match ?ri2 npa:hasRoleType <tier>
+                       # / gen:hasRole ?role, exactly as the *-roles-ref queries do.
+                       npa:hasRoleType <%7$s> ;
+                       gen:hasRole ?role ;
                        npa:viaNanopub ?np .
                 } }
                 WHERE {


### PR DESCRIPTION
## Summary

Addresses **Finding #1** of #125 (the High-severity, authorization-relevant one that produced the production ucds bug where Observer-tier team members appeared under "Approved Admins/Maintainers/Members").

`nonAdminTierUpdate` validates each instantiation against a **tier-pinned** `RoleDeclaration` but materialized only the bare role predicate — dropping the `tierClass` arg and the anchoring attachment's `?role`, **even though both are bound at INSERT time**. Consumers then re-derive the tier by matching the bare predicate against **global** `RoleDeclaration`s, which bleeds tiers across spaces that declare the same predicate at different tiers.

This change persists the already-bound qualifiers on each materialized row:

```sparql
npa:hasRoleType <%7$s> ;   # the loop's tierClass arg
gen:hasRole ?role ;         # the anchoring attachment's role IRI
```

so ref-scoped consumers can key on **identity**, exactly as the `*-roles-ref` queries already do.

## Why it's safe

- **Purely additive** — existing reads ignore the extra triples.
- **Dedup unaffected** — step 8's `FILTER NOT EXISTS` still keys on `(forSpaceRef, forAgent, viaNanopub)`.
- **`npa:hasRoleType` is functionally single-valued per row** — role IRIs are version-pinned, so one role IRI carries one tier.
- No change to the `.formatted(...)` arg list (arg 7 already existed), so compilation is unaffected.

## ⚠️ Follow-ups required before this fixes anything user-visible

This PR only makes the qualifier **available**. The actual bug fix needs the **published query nanopubs** (not in this repo) repointed to use it:

- `list-space-members-ref`, `list-space-observers-ref-v5`, `list-space-non-approved-ref-v5` → key on `npa:hasRoleType` / `gen:hasRole ?role`

Operational:
- **Requires a full re-ingest** to backfill the new triples onto existing rows.
- **Canary** the consumer query changes against the live fleet before switching state-model + queries over together.

## Not in scope (remaining #125 findings)

- **#2** (maintained-resource auth hop) — consumer-only; ref edge already exists.
- **#3** (view-display maintainer dead arm) — consumer-side, depends on this landing.
- **#4 / #5** — low-priority audit/rebuild-bounded cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)