### PR TITLE
fix(spaces): stamp npa:hasRoleType gen:AdminRole on admin RoleInstantiations (#127)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -862,6 +862,10 @@ public final class AuthorityResolver {
                        npa:forSpaceRef ?spaceRef ;
                        npa:forSpace ?space ;
                        npa:inverseProperty gen:hasAdmin ;
+                       # Stamp the admin tier so consumers read tier uniformly across all
+                       # RoleInstantiations (?ri npa:hasRoleType ?tier) with no admin
+                       # special-case — matching the non-admin path (issue #125, #127).
+                       npa:hasRoleType gen:AdminRole ;
                        npa:forAgent ?agent ;
                        npa:viaNanopub ?np .
                 } }


### PR DESCRIPTION
## Summary

Follow-up to #125. That change stamped `npa:hasRoleType` (+ `gen:hasRole`) onto **non-admin** `gen:RoleInstantiation`s (the `nonAdminTierUpdate` path). **Admin** RIs, materialized on the separate `adminTierUpdate` path (`AuthorityResolver.java` ~L860), still carried only `npa:inverseProperty gen:hasAdmin` and **no** tier — verified live (192 admin RIs, 0 with `npa:hasRoleType`).

This emits `npa:hasRoleType gen:AdminRole` alongside the existing `gen:hasAdmin` so **every** RoleInstantiation answers a single uniform `?ri npa:hasRoleType ?tier` read, with no admin special-case, and the `min(tier-rank)` highest-tier logic stays one code path.

## Why it's safe

- **Purely additive** — existing reads ignore the extra triple.
- **Dedup unaffected** — keyed on `(forSpaceRef, forAgent, inverseProperty gen:hasAdmin)`.
- **Admin recursion unaffected** — the closed-over branch matches `?prev` on `gen:hasAdmin`, not tier.
- `gen:AdminRole` is the reserved tier class for the built-in admin role (`GEN.ADMIN_ROLE`).

## Operational

- **Requires a full re-ingest** to backfill the new triple onto existing admin rows (same as #125).

Closes #127. Depends on / extends #125 (merged). Consumer simplification: knowledgepixels/nanodash#498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)