### PR TITLE
fix(spaces): clean up convenience structural edges on invalidation (#125 finding #5)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -373,21 +373,27 @@ public final class AuthorityResolver {
         // an invalidated RD neither deletes rows nor triggers a rebuild.
         // Sub-space declarations are structural — invalidating one (Mode A) or one
         // of two co-declarations (Mode B) changes the validated parent/child
-        // topology. The DELETE removes the per-declaration row; the convenience
-        // direct triples are left sticky and cleaned on the next periodic rebuild.
+        // topology. The DELETE removes the per-declaration row; the convenience-edge
+        // cleanup then drops the now-unbacked direct triples (issue #125 finding #5)
+        // instead of leaving them sticky until the periodic rebuild. The structural
+        // flag still fires so downstream rows derived through a removed edge stay
+        // rebuild-bounded.
         if (wouldInvalidate(graph, lastProcessed, /*adminPinned=*/ false,
                             subSpaceInvalidationCheckWhere(graph, lastProcessed))) {
             executeUpdate(subSpaceInvalidationDelete(graph, lastProcessed));
+            executeUpdate(subSpaceConvenienceEdgeCleanup(graph, lastProcessed));
             structural = true;
         }
         // Space-alias declarations are structural — invalidating one removes an
         // owl:sameAs edge that feeds the admin-authority closure (issue #113). The
-        // DELETE removes the per-declaration row; the convenience npa:sameAsSpace edge
-        // is left sticky and cleaned on the next periodic rebuild (same policy as
-        // sub-space declarations).
+        // DELETE removes the per-declaration row; the convenience-edge cleanup then
+        // drops the now-unbacked npa:sameAsSpace edge (issue #125 finding #5 — the
+        // load-bearing case), so admin authority can no longer outlive a retraction
+        // until the next periodic rebuild.
         if (wouldInvalidate(graph, lastProcessed, /*adminPinned=*/ false,
                             aliasInvalidationCheckWhere(graph, lastProcessed))) {
             executeUpdate(aliasInvalidationDelete(graph, lastProcessed));
+            executeUpdate(aliasConvenienceEdgeCleanup(graph, lastProcessed));
             structural = true;
         }
         // Preset-derived RoleAssignment removal (issue #302). NOT npx:invalidates: a newer
@@ -409,8 +415,15 @@ public final class AuthorityResolver {
         // hard-retracted (issue #122) — no flag (display leaf, nothing downstream).
         executeUpdate(presetAssignmentRefInvalidationDelete(graph, lastProcessed));
         // Maintained-resource declaration deletes — no flag (leaf relation, no
-        // downstream caches to bound).
-        executeUpdate(maintainedResourceInvalidationDelete(graph, lastProcessed));
+        // downstream caches to bound). The per-declaration delete removes the row; the
+        // convenience-edge cleanup drops the now-unbacked isMaintainedBy edges (issue
+        // #125 finding #5). Guarded so the orphan-sweep only scans when something was
+        // actually invalidated (the delete itself was already a no-op otherwise).
+        if (wouldInvalidate(graph, lastProcessed, /*adminPinned=*/ false,
+                            maintainedResourceInvalidationCheckWhere(graph, lastProcessed))) {
+            executeUpdate(maintainedResourceInvalidationDelete(graph, lastProcessed));
+            executeUpdate(maintainedResourceConvenienceEdgeCleanup(graph, lastProcessed));
+        }
         if (structural) setNeedsFullRebuild();
         return structural;
     }
@@ -1563,6 +1576,17 @@ public final class AuthorityResolver {
                      npa:viaNanopub  ?np .
                   ?childRef  npa:isSubSpaceOf ?parentRef .
                   ?parentRef npa:hasSubSpace  ?childRef  .
+                  # Reified per-(nanopub, ref-pair) provenance link (issue #125 finding #5):
+                  # carries npa:viaNanopub plus both the ref and IRI endpoints, so the
+                  # invalidation cleanup can drop the convenience edges below once no
+                  # surviving link backs them — instead of leaving them sticky until the
+                  # next periodic full rebuild.
+                  ?ssLink a npa:SubSpaceLink ;
+                          npa:viaNanopub     ?np ;
+                          npa:childSpaceRef  ?childRef ;
+                          npa:parentSpaceRef ?parentRef ;
+                          npa:childSpace     ?child ;
+                          npa:parentSpace    ?parent .
                   # TRANSITIONAL-DUAL-EMIT (Phase 1.5; remove in Phase 4): IRI-valued
                   # sub-space edge alongside the ref-to-ref one, so pre-ref published
                   # queries that key on the bare Space IRI keep binding on a mixed-version
@@ -1641,9 +1665,14 @@ public final class AuthorityResolver {
                     ?np npa:hasLoadNumber ?ln .
                     FILTER (?ln > %5$d)
                   }
-                  # 6. Dedup last — on the emitted ref-to-ref edge.
+                  # 6. Mint the per-(nanopub, ref-pair) provenance link IRI and dedup on it
+                  #    (not on the bare edge). Keyed on ?np so every backing declaration of
+                  #    the same ref-pair records its own removable link; the convenience
+                  #    edges above are re-asserted idempotently.
+                  BIND(IRI(CONCAT("http://purl.org/nanopub/admin/spacelink/subspace/",
+                                  MD5(CONCAT(STR(?np), "|", STR(?childRef), "|", STR(?parentRef))))) AS ?ssLink)
                   FILTER NOT EXISTS { GRAPH <%3$s> {
-                    ?childRef npa:isSubSpaceOf ?parentRef .
+                    ?ssLink a npa:SubSpaceLink .
                   } }
                 }
                 """.formatted(
@@ -1686,6 +1715,14 @@ public final class AuthorityResolver {
                      npa:viaNanopub      ?np .
                   ?r npa:isMaintainedBy        ?sRef .
                   ?sRef npa:hasMaintainedResource ?r .
+                  # Reified per-(nanopub, resource→ref) provenance link (issue #125 finding
+                  # #5): lets the invalidation cleanup drop the convenience edges below once
+                  # no surviving link backs them, instead of leaving them sticky.
+                  ?mrLink a npa:MaintainedResourceLink ;
+                          npa:viaNanopub         ?np ;
+                          npa:resourceIri        ?r ;
+                          npa:maintainerSpaceRef ?sRef ;
+                          npa:maintainerSpace    ?s .
                   # TRANSITIONAL-DUAL-EMIT (Phase 1.5; remove in Phase 4): IRI-valued
                   # maintained-resource edge alongside the resource→ref one, so pre-ref
                   # published queries (e.g. get-view-displays' maintained hop) keep binding
@@ -1723,9 +1760,13 @@ public final class AuthorityResolver {
                     ?np npa:hasLoadNumber ?ln .
                     FILTER (?ln > %5$d)
                   }
-                  # 6. Dedup last — on the emitted resource → ref edge.
+                  # 6. Mint the per-(nanopub, resource→ref) provenance link IRI and dedup on
+                  #    it (not on the bare edge), so every backing declaration records its own
+                  #    removable link; the convenience edges above are re-asserted idempotently.
+                  BIND(IRI(CONCAT("http://purl.org/nanopub/admin/spacelink/maintained/",
+                                  MD5(CONCAT(STR(?np), "|", STR(?r), "|", STR(?sRef))))) AS ?mrLink)
                   FILTER NOT EXISTS { GRAPH <%3$s> {
-                    ?r npa:isMaintainedBy ?sRef .
+                    ?mrLink a npa:MaintainedResourceLink .
                   } }
                 }
                 """.formatted(
@@ -1785,6 +1826,16 @@ public final class AuthorityResolver {
                      npa:aliasSpace     ?alias ;
                      npa:viaNanopub     ?np .
                   ?alias npa:sameAsSpace ?canonRef .
+                  # Reified per-(nanopub, alias→canonical ref) provenance link (issue #125
+                  # finding #5). The alias edge feeds the admin-authority closure, so this
+                  # is the load-bearing case: the cleanup can now drop the edge when its
+                  # declaration is invalidated, rather than letting admin authority outlive
+                  # a retraction until the next periodic full rebuild.
+                  ?alLink a npa:SpaceAliasLink ;
+                          npa:viaNanopub        ?np ;
+                          npa:aliasSpace        ?alias ;
+                          npa:canonicalSpaceRef ?canonRef ;
+                          npa:canonicalSpace    ?canonical .
                   # TRANSITIONAL-DUAL-EMIT (Phase 1.5; remove in Phase 4): IRI-valued
                   # alias edge alongside the ref-valued one, so pre-ref published queries
                   # that resolve owl:sameAs by bare canonical IRI keep binding on a
@@ -1840,9 +1891,14 @@ public final class AuthorityResolver {
                     ?np npa:hasLoadNumber ?ln .
                     FILTER (?ln > %5$d)
                   }
-                  # 6. Dedup last — on the emitted (alias, canonical ref) edge.
+                  # 6. Mint the per-(nanopub, alias→canonical ref) provenance link IRI and
+                  #    dedup on it (not on the bare edge), so every backing declaration records
+                  #    its own removable link; the convenience edges above are re-asserted
+                  #    idempotently.
+                  BIND(IRI(CONCAT("http://purl.org/nanopub/admin/spacelink/alias/",
+                                  MD5(CONCAT(STR(?np), "|", STR(?alias), "|", STR(?canonRef))))) AS ?alLink)
                   FILTER NOT EXISTS { GRAPH <%3$s> {
-                    ?alias npa:sameAsSpace ?canonRef .
+                    ?alLink a npa:SpaceAliasLink .
                   } }
                 }
                 """.formatted(
@@ -1899,6 +1955,12 @@ public final class AuthorityResolver {
                   ?tagIri a npa:DerivedSubSpaceLink ;
                           npa:childSpace     ?child ;
                           npa:parentSpace    ?parent ;
+                          # Ref endpoints too (issue #125 finding #5), so the sub-space
+                          # orphan-sweep recognizes a prefix-derived ref edge as backed and
+                          # never deletes it. Derived links have no source nanopub, so they
+                          # are never invalidation-deleted; the fallback self-heals each cycle.
+                          npa:childSpaceRef  ?childRef ;
+                          npa:parentSpaceRef ?parentRef ;
                           npa:derivationKind npa:byUrlPrefix .
                 } }
                 WHERE {
@@ -2069,9 +2131,8 @@ public final class AuthorityResolver {
      * DELETE template for validated {@code npa:SubSpaceDeclaration} rows whose
      * source nanopub was invalidated. Removes the per-declaration row by subject;
      * the convenience direct triples ({@code <child> npa:isSubSpaceOf <parent>}
-     * and inverse) are left sticky and cleaned by the next periodic full rebuild
-     * (same staleness policy as admin-RI invalidation — see {@code
-     * doc/design-space-repositories.md} on the structural-rebuild flag).
+     * and inverse) are then dropped by {@link #subSpaceConvenienceEdgeCleanup} in the
+     * same cycle (issue #125 finding #5) once no surviving link backs them.
      */
     static String subSpaceInvalidationDelete(IRI graph, long lastProcessed) {
         return String.format("""
@@ -2092,10 +2153,10 @@ public final class AuthorityResolver {
      * DELETE template for validated {@code npa:MaintainedResourceDeclaration} rows
      * whose source nanopub was invalidated. Removes the per-declaration row by
      * subject; the convenience direct triples ({@code <r> npa:isMaintainedBy <s>}
-     * and inverse) are left sticky and cleaned by the next periodic full rebuild
-     * (same staleness policy as sub-space declaration invalidation, but without
-     * the structural-rebuild flag — maintained-resource is a leaf relation, no
-     * downstream consumers depend on its closure).
+     * and inverse) are then dropped by {@link #maintainedResourceConvenienceEdgeCleanup}
+     * in the same cycle (issue #125 finding #5). No structural-rebuild flag —
+     * maintained-resource is a leaf relation, no downstream consumers depend on its
+     * closure, so the prompt edge cleanup fully resolves its invalidation.
      */
     static String maintainedResourceInvalidationDelete(IRI graph, long lastProcessed) {
         return String.format("""
@@ -2148,10 +2209,11 @@ public final class AuthorityResolver {
     /**
      * DELETE template for validated {@code npa:SpaceAliasDeclaration} rows whose
      * source nanopub was invalidated. Removes the per-declaration row by subject; the
-     * convenience {@code <alias> npa:sameAsSpace <canonical>} edge is left sticky and
-     * cleaned by the next periodic full rebuild (same staleness policy as sub-space
-     * declaration invalidation — the alias feeds the authority closure, so this kind
-     * is structural and flips {@code npa:needsFullRebuild}).
+     * convenience {@code <alias> npa:sameAsSpace <canonical>} edge is then dropped by
+     * {@link #aliasConvenienceEdgeCleanup} in the same cycle (issue #125 finding #5),
+     * so an alias can no longer grant admin authority after its declaration is retracted.
+     * The alias feeds the authority closure, so this kind is still structural and flips
+     * {@code npa:needsFullRebuild} to bound any rows already derived through the edge.
      */
     static String aliasInvalidationDelete(IRI graph, long lastProcessed) {
         return String.format("""
@@ -2166,6 +2228,192 @@ public final class AuthorityResolver {
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
                 aliasInvalidationCheckWhere(graph, lastProcessed));
+    }
+
+    /**
+     * WHERE clause shared by the maintained-resource invalidation ASK precheck and the
+     * matching cleanup. Identifies validated {@code npa:MaintainedResourceDeclaration}
+     * rows in the space-state graph whose {@code npa:viaNanopub} is the target of an
+     * {@code npx:invalidates} triple in {@code npa:graph} whose subject nanopub has a
+     * load number in {@code (lastProcessed, ∞)}.
+     */
+    static String maintainedResourceInvalidationCheckWhere(IRI graph, long lastProcessed) {
+        return String.format("""
+                  GRAPH <%1$s> {
+                    ?d a npa:MaintainedResourceDeclaration ;
+                       npa:viaNanopub ?np .
+                  }
+                  GRAPH <%2$s> {
+                    ?invNp <%3$s> ?np ;
+                           npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %4$d)
+                    %5$s
+                  }
+                """, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
+    }
+
+    /**
+     * Convenience-edge cleanup for invalidated sub-space declarations (issue #125
+     * finding #5). Run after {@link #subSpaceInvalidationDelete} (which removes the
+     * {@code npa:SubSpaceDeclaration} rows). Two phases as one multi-operation update:
+     * <ol>
+     *   <li>delete every {@code npa:SubSpaceLink} provenance link whose
+     *       {@code npa:viaNanopub} was invalidated (same {@code npx:invalidates} +
+     *       same-publisher gate as the declaration delete);</li>
+     *   <li>orphan-sweep: delete the convenience {@code npa:isSubSpaceOf} /
+     *       {@code npa:hasSubSpace} edges (both ref- and IRI-valued) that no surviving
+     *       link backs — neither a {@code npa:SubSpaceLink} (explicit declaration) nor a
+     *       {@code npa:DerivedSubSpaceLink} (URL-prefix fallback).</li>
+     * </ol>
+     * Edges backed by another surviving declaration or by the URL-prefix fallback are
+     * kept. The {@code npa:needsFullRebuild} flag still fires for the structural kind, so
+     * downstream rows derived through a removed edge remain rebuild-bounded; this only
+     * stops the convenience edges themselves from going sticky.
+     */
+    static String subSpaceConvenienceEdgeCleanup(IRI graph, long lastProcessed) {
+        return String.format("""
+                PREFIX npa: <%1$s>
+                # 1. Drop sub-space provenance links whose source nanopub was invalidated.
+                DELETE { GRAPH <%2$s> { ?l ?p ?o . } }
+                WHERE {
+                  GRAPH <%2$s> {
+                    ?l a npa:SubSpaceLink ;
+                       npa:viaNanopub ?np .
+                    ?l ?p ?o .
+                  }
+                  GRAPH <%3$s> {
+                    ?invNp <%4$s> ?np ;
+                           npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
+                    %6$s
+                  }
+                } ;
+                # 2. Orphan-sweep isSubSpaceOf edges (ref- and IRI-valued) with no backing link.
+                DELETE { GRAPH <%2$s> { ?c npa:isSubSpaceOf ?p . } }
+                WHERE {
+                  GRAPH <%2$s> {
+                    ?c npa:isSubSpaceOf ?p .
+                    FILTER NOT EXISTS {
+                      { ?l a npa:SubSpaceLink } UNION { ?l a npa:DerivedSubSpaceLink }
+                      { { ?l npa:childSpaceRef ?c . ?l npa:parentSpaceRef ?p }
+                        UNION
+                        { ?l npa:childSpace ?c . ?l npa:parentSpace ?p } }
+                    }
+                  }
+                } ;
+                # 3. Orphan-sweep the inverse hasSubSpace edges symmetrically.
+                DELETE { GRAPH <%2$s> { ?p npa:hasSubSpace ?c . } }
+                WHERE {
+                  GRAPH <%2$s> {
+                    ?p npa:hasSubSpace ?c .
+                    FILTER NOT EXISTS {
+                      { ?l a npa:SubSpaceLink } UNION { ?l a npa:DerivedSubSpaceLink }
+                      { { ?l npa:childSpaceRef ?c . ?l npa:parentSpaceRef ?p }
+                        UNION
+                        { ?l npa:childSpace ?c . ?l npa:parentSpace ?p } }
+                    }
+                  }
+                }
+                """, NPA.NAMESPACE, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
+    }
+
+    /**
+     * Convenience-edge cleanup for invalidated maintained-resource declarations (issue
+     * #125 finding #5). Run after {@link #maintainedResourceInvalidationDelete}. Deletes
+     * the {@code npa:MaintainedResourceLink} provenance links whose source nanopub was
+     * invalidated, then orphan-sweeps the {@code npa:isMaintainedBy} /
+     * {@code npa:hasMaintainedResource} edges (ref- and IRI-valued) that no surviving link
+     * backs. See {@link #subSpaceConvenienceEdgeCleanup} for the two-phase structure.
+     */
+    static String maintainedResourceConvenienceEdgeCleanup(IRI graph, long lastProcessed) {
+        return String.format("""
+                PREFIX npa: <%1$s>
+                # 1. Drop maintained-resource provenance links whose source nanopub was invalidated.
+                DELETE { GRAPH <%2$s> { ?l ?p ?o . } }
+                WHERE {
+                  GRAPH <%2$s> {
+                    ?l a npa:MaintainedResourceLink ;
+                       npa:viaNanopub ?np .
+                    ?l ?p ?o .
+                  }
+                  GRAPH <%3$s> {
+                    ?invNp <%4$s> ?np ;
+                           npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
+                    %6$s
+                  }
+                } ;
+                # 2. Orphan-sweep isMaintainedBy edges (ref- and IRI-valued) with no backing link.
+                DELETE { GRAPH <%2$s> { ?r npa:isMaintainedBy ?o . } }
+                WHERE {
+                  GRAPH <%2$s> {
+                    ?r npa:isMaintainedBy ?o .
+                    FILTER NOT EXISTS {
+                      ?l a npa:MaintainedResourceLink ;
+                         npa:resourceIri ?r .
+                      { ?l npa:maintainerSpaceRef ?o } UNION { ?l npa:maintainerSpace ?o }
+                    }
+                  }
+                } ;
+                # 3. Orphan-sweep the inverse hasMaintainedResource edges symmetrically.
+                DELETE { GRAPH <%2$s> { ?o npa:hasMaintainedResource ?r . } }
+                WHERE {
+                  GRAPH <%2$s> {
+                    ?o npa:hasMaintainedResource ?r .
+                    FILTER NOT EXISTS {
+                      ?l a npa:MaintainedResourceLink ;
+                         npa:resourceIri ?r .
+                      { ?l npa:maintainerSpaceRef ?o } UNION { ?l npa:maintainerSpace ?o }
+                    }
+                  }
+                }
+                """, NPA.NAMESPACE, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
+    }
+
+    /**
+     * Convenience-edge cleanup for invalidated space-alias declarations (issue #125
+     * finding #5 — the load-bearing case, since the alias edge feeds the admin-authority
+     * closure). Run after {@link #aliasInvalidationDelete}. Deletes the
+     * {@code npa:SpaceAliasLink} provenance links whose source nanopub was invalidated,
+     * then orphan-sweeps the {@code npa:sameAsSpace} edges (ref- and IRI-valued) that no
+     * surviving link backs. See {@link #subSpaceConvenienceEdgeCleanup} for the two-phase
+     * structure.
+     */
+    static String aliasConvenienceEdgeCleanup(IRI graph, long lastProcessed) {
+        return String.format("""
+                PREFIX npa: <%1$s>
+                # 1. Drop alias provenance links whose source nanopub was invalidated.
+                DELETE { GRAPH <%2$s> { ?l ?p ?o . } }
+                WHERE {
+                  GRAPH <%2$s> {
+                    ?l a npa:SpaceAliasLink ;
+                       npa:viaNanopub ?np .
+                    ?l ?p ?o .
+                  }
+                  GRAPH <%3$s> {
+                    ?invNp <%4$s> ?np ;
+                           npa:hasLoadNumber ?ln .
+                    FILTER (?ln > %5$d)
+                    %6$s
+                  }
+                } ;
+                # 2. Orphan-sweep sameAsSpace edges (ref- and IRI-valued) with no backing link.
+                DELETE { GRAPH <%2$s> { ?alias npa:sameAsSpace ?o . } }
+                WHERE {
+                  GRAPH <%2$s> {
+                    ?alias npa:sameAsSpace ?o .
+                    FILTER NOT EXISTS {
+                      ?l a npa:SpaceAliasLink ;
+                         npa:aliasSpace ?alias .
+                      { ?l npa:canonicalSpaceRef ?o } UNION { ?l npa:canonicalSpace ?o }
+                    }
+                  }
+                }
+                """, NPA.NAMESPACE, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
+                samePublisherClause("invNp", "np"));
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverConvenienceEdgeInvalidationTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverConvenienceEdgeInvalidationTest.java
@@ -1,0 +1,273 @@
+package com.knowledgepixels.query;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.vocabulary.NPA;
+
+import com.knowledgepixels.query.vocabulary.GEN;
+import com.knowledgepixels.query.vocabulary.SpacesVocab;
+
+/**
+ * Issue #125 finding #5 — convenience structural edges (sub-space / maintained-resource /
+ * alias) must be dropped when their declaration's source nanopub is invalidated, instead
+ * of going sticky until the next periodic full rebuild.
+ *
+ * <p>Each admit pass now reifies its contribution as a provenance link carrying
+ * {@code npa:viaNanopub}; the {@code *ConvenienceEdgeCleanup} updates delete the links of
+ * invalidated nanopubs and then orphan-sweep any edge no surviving link backs. These tests
+ * drive admit → invalidate → cleanup on an in-memory store and assert: the edge disappears
+ * when its only backer is invalidated; it survives when a second declaration still backs it;
+ * and URL-prefix-derived sub-space edges are never swept.
+ */
+class AuthorityResolverConvenienceEdgeInvalidationTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+    private static final IRI STATE = SpacesVocab.forSpaceState(
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", 1L);
+    private static final IRI SPACES = SpacesVocab.SPACES_GRAPH;
+    private static final IRI INVALIDATES = vf.createIRI("http://purl.org/nanopub/x/invalidates");
+
+    private static IRI npa(String ln) { return vf.createIRI(NPA.NAMESPACE, ln); }
+    private static IRI ex(String ln)  { return vf.createIRI("http://example.org/", ln); }
+
+    private static final IRI S     = ex("space-S");
+    private static final IRI R1    = ex("ref-R1");
+    private static final IRI R2    = ex("ref-R2");
+    private static final IRI ALICE = ex("alice");
+    private static final IRI BOB   = ex("bob");
+    private static final Literal PKH_A = vf.createLiteral("pkhA");
+    private static final Literal PKH_B = vf.createLiteral("pkhB");
+
+    private Repository repo;
+    private RepositoryConnection c;
+
+    @BeforeEach
+    void setUp() {
+        repo = new SailRepository(new MemoryStore());
+        repo.init();
+        c = repo.getConnection();
+        refIri(R1, S);
+        refIri(R2, S);
+        account("acctA", ALICE, PKH_A);
+        account("acctB", BOB, PKH_B);
+        admin("adm_a", R1, S, ALICE);
+        admin("adm_b", R2, S, BOB);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (c != null) c.close();
+        if (repo != null) repo.shutDown();
+    }
+
+    // ---------------- alias (the load-bearing case) ----------------
+
+    @Test
+    void aliasEdgeRemovedWhenSoleDeclarationInvalidated() {
+        IRI aold = ex("space-S-old");
+        IRI np = ex("np_al");
+        extAlias("al1", S, aold, PKH_A, np);
+        runToFixpoint(AuthorityResolver.aliasAdmitUpdate(STATE, -1));
+        assertTrue(edge(aold, npa("sameAsSpace"), R1), "ref-valued alias edge present before invalidation");
+        assertTrue(edge(aold, npa("sameAsSpace"), S), "IRI-valued alias edge present before invalidation");
+
+        invalidate(np, ex("inv_al"), PKH_A);
+        run(AuthorityResolver.aliasConvenienceEdgeCleanup(STATE, -1));
+
+        assertFalse(edge(aold, npa("sameAsSpace"), R1), "ref-valued alias edge swept after invalidation");
+        assertFalse(edge(aold, npa("sameAsSpace"), S), "IRI-valued alias edge swept after invalidation");
+        assertFalse(ask("?l a npa:SpaceAliasLink ."), "alias provenance link removed");
+    }
+
+    @Test
+    void aliasEdgeSurvivesWhileASecondDeclarationStillBacksIt() {
+        IRI aold = ex("space-S-old");
+        IRI np1 = ex("np_al1"), np2 = ex("np_al2");
+        // Two independent admins (Alice on R1, Bob would need to admin canonical too) —
+        // here both declarations come from Alice's key but as distinct nanopubs, both
+        // validly backing the same alias→R1 edge.
+        extAlias("al1", S, aold, PKH_A, np1);
+        extAlias("al2", S, aold, PKH_A, np2);
+        runToFixpoint(AuthorityResolver.aliasAdmitUpdate(STATE, -1));
+        assertTrue(edge(aold, npa("sameAsSpace"), R1), "alias edge present with two backers");
+
+        invalidate(np1, ex("inv_al1"), PKH_A);
+        run(AuthorityResolver.aliasConvenienceEdgeCleanup(STATE, -1));
+
+        assertTrue(edge(aold, npa("sameAsSpace"), R1),
+                "alias edge survives — second declaration still backs it");
+        assertTrue(edge(aold, npa("sameAsSpace"), S), "IRI-valued alias edge likewise survives");
+    }
+
+    // ---------------- maintained-resource ----------------
+
+    @Test
+    void maintainedEdgeRemovedWhenDeclarationInvalidated() {
+        IRI res = ex("resource-1");
+        IRI np = ex("np_mr");
+        extMaintained("mr1", res, S, PKH_A, np);
+        runToFixpoint(AuthorityResolver.maintainedResourceAdmitUpdate(STATE, -1));
+        assertTrue(edge(res, npa("isMaintainedBy"), R1), "resource→ref edge present before invalidation");
+        assertTrue(edge(res, npa("isMaintainedBy"), S), "IRI-valued maintained edge present before invalidation");
+        assertTrue(edge(R1, npa("hasMaintainedResource"), res), "inverse edge present before invalidation");
+
+        invalidate(np, ex("inv_mr"), PKH_A);
+        run(AuthorityResolver.maintainedResourceConvenienceEdgeCleanup(STATE, -1));
+
+        assertFalse(edge(res, npa("isMaintainedBy"), R1), "resource→ref edge swept");
+        assertFalse(edge(res, npa("isMaintainedBy"), S), "IRI-valued maintained edge swept");
+        assertFalse(edge(R1, npa("hasMaintainedResource"), res), "inverse edge swept");
+        assertFalse(ask("?l a npa:MaintainedResourceLink ."), "maintained provenance link removed");
+    }
+
+    // ---------------- sub-space ----------------
+
+    @Test
+    void subSpaceEdgeRemovedWhenDeclarationInvalidated() {
+        IRI sc = ex("child"), sp = ex("parent");
+        IRI rc = ex("ref-child"), rp = ex("ref-parent");
+        IRI np = ex("np_ss");
+        refIri(rc, sc);
+        refIri(rp, sp);
+        admin("adm_ac", rc, sc, ALICE);
+        admin("adm_ap", rp, sp, ALICE);
+        extSubSpace("ss1", sc, sp, PKH_A, np);
+        runToFixpoint(AuthorityResolver.subSpaceAdmitUpdate(STATE, -1));
+        assertTrue(edge(rc, npa("isSubSpaceOf"), rp), "ref-to-ref edge present before invalidation");
+        assertTrue(edge(sc, npa("isSubSpaceOf"), sp), "IRI-valued edge present before invalidation");
+        assertTrue(edge(rp, npa("hasSubSpace"), rc), "inverse ref edge present before invalidation");
+
+        invalidate(np, ex("inv_ss"), PKH_A);
+        run(AuthorityResolver.subSpaceConvenienceEdgeCleanup(STATE, -1));
+
+        assertFalse(edge(rc, npa("isSubSpaceOf"), rp), "ref-to-ref edge swept");
+        assertFalse(edge(sc, npa("isSubSpaceOf"), sp), "IRI-valued edge swept");
+        assertFalse(edge(rp, npa("hasSubSpace"), rc), "inverse ref edge swept");
+        assertFalse(ask("?l a npa:SubSpaceLink ."), "sub-space provenance link removed");
+    }
+
+    @Test
+    void prefixDerivedSubSpaceEdgeNotSweptByCleanup() {
+        // A URL-prefix-derived sub-space edge (no source nanopub) must survive a cleanup
+        // pass, because its DerivedSubSpaceLink — not a declaration — backs it.
+        IRI parent = ex("p");
+        IRI child  = ex("p/sub");
+        IRI rc = ex("ref-pchild"), rp = ex("ref-pparent");
+        c.add(rc, SpacesVocab.SPACE_IRI, child, SPACES);
+        c.add(rc, npa("hasIdPrefix"), parent, SPACES);
+        c.add(rp, SpacesVocab.SPACE_IRI, parent, SPACES);
+        runToFixpoint(AuthorityResolver.subSpacePrefixFallbackUpdate(STATE));
+        assertTrue(edge(rc, npa("isSubSpaceOf"), rp), "derived ref edge present");
+
+        // A cleanup with nothing invalidated must not touch derived edges.
+        run(AuthorityResolver.subSpaceConvenienceEdgeCleanup(STATE, -1));
+
+        assertTrue(edge(rc, npa("isSubSpaceOf"), rp), "derived ref edge survives cleanup");
+        assertTrue(edge(child, npa("isSubSpaceOf"), parent), "derived IRI-valued edge survives cleanup");
+    }
+
+    // ---------------- seeding helpers ----------------
+
+    private void refIri(IRI ref, IRI iri) { c.add(ref, SpacesVocab.SPACE_IRI, iri, SPACES); }
+
+    private void account(String name, IRI agent, Literal pkh) {
+        IRI a = ex(name);
+        c.add(a, RDF.TYPE, npa("AccountState"), STATE);
+        c.add(a, npa("agent"), agent, STATE);
+        c.add(a, npa("pubkey"), pkh, STATE);
+    }
+
+    private void admin(String name, IRI ref, IRI iri, IRI agent) {
+        IRI ri = ex(name);
+        c.add(ri, RDF.TYPE, GEN.ROLE_INSTANTIATION, STATE);
+        c.add(ri, SpacesVocab.FOR_SPACE_REF, ref, STATE);
+        c.add(ri, SpacesVocab.FOR_SPACE, iri, STATE);
+        c.add(ri, SpacesVocab.INVERSE_PROPERTY, GEN.HAS_ADMIN, STATE);
+        c.add(ri, SpacesVocab.FOR_AGENT, agent, STATE);
+    }
+
+    private void loadNum(IRI np) { c.add(np, npa("hasLoadNumber"), vf.createLiteral(0L), NPA.GRAPH); }
+
+    /**
+     * Seeds an invalidation in npa:graph: {@code inv npx:invalidates target}, a load number,
+     * and the same-publisher signature bridge (both nanopubs signed by {@code pkh}).
+     */
+    private void invalidate(IRI target, IRI inv, Literal pkh) {
+        c.add(inv, INVALIDATES, target, NPA.GRAPH);
+        c.add(inv, npa("hasLoadNumber"), vf.createLiteral(0L), NPA.GRAPH);
+        c.add(inv, NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY_HASH, pkh, NPA.GRAPH);
+        c.add(target, NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY_HASH, pkh, NPA.GRAPH);
+    }
+
+    private void extAlias(String name, IRI canonical, IRI alias, Literal pkh, IRI np) {
+        IRI d = ex(name);
+        c.add(d, RDF.TYPE, SpacesVocab.SPACE_ALIAS_DECLARATION, SPACES);
+        c.add(d, SpacesVocab.CANONICAL_SPACE, canonical, SPACES);
+        c.add(d, SpacesVocab.ALIAS_SPACE, alias, SPACES);
+        c.add(d, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(d, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        loadNum(np);
+    }
+
+    private void extSubSpace(String name, IRI child, IRI parent, Literal pkh, IRI np) {
+        IRI d = ex(name);
+        c.add(d, RDF.TYPE, SpacesVocab.SUB_SPACE_DECLARATION, SPACES);
+        c.add(d, SpacesVocab.CHILD_SPACE, child, SPACES);
+        c.add(d, SpacesVocab.PARENT_SPACE, parent, SPACES);
+        c.add(d, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(d, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        loadNum(np);
+    }
+
+    private void extMaintained(String name, IRI resource, IRI space, Literal pkh, IRI np) {
+        IRI d = ex(name);
+        c.add(d, RDF.TYPE, SpacesVocab.MAINTAINED_RESOURCE_DECLARATION, SPACES);
+        c.add(d, SpacesVocab.RESOURCE_IRI, resource, SPACES);
+        c.add(d, SpacesVocab.MAINTAINER_SPACE, space, SPACES);
+        c.add(d, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(d, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        loadNum(np);
+    }
+
+    // ---------------- execution + assertions ----------------
+
+    private void runToFixpoint(String update) {
+        long before = c.size(STATE);
+        while (true) {
+            c.prepareUpdate(QueryLanguage.SPARQL, update).execute();
+            long after = c.size(STATE);
+            if (after <= before) break;
+            before = after;
+        }
+    }
+
+    private void run(String update) {
+        c.prepareUpdate(QueryLanguage.SPARQL, update).execute();
+    }
+
+    private boolean edge(IRI s, IRI p, IRI o) {
+        return ask("<" + s + "> <" + p + "> <" + o + "> .");
+    }
+
+    private boolean ask(String pattern) {
+        return c.prepareBooleanQuery(QueryLanguage.SPARQL, """
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                ASK { GRAPH <%3$s> { %4$s } }
+                """.formatted(NPA.NAMESPACE, GEN.NAMESPACE, STATE, pattern)).evaluate();
+    }
+}

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -310,6 +310,39 @@ class AuthorityResolverTest {
                 AuthorityResolver.presetAssignmentRefInvalidationDelete(TEST_GRAPH, 5), "invNp", "assignNp");
     }
 
+    @Test
+    void subSpaceConvenienceEdgeCleanup_gatesOnSamePublisher() {
+        // The link-delete phase joins npx:invalidates under the same-publisher gate.
+        assertSamePublisherGate(AuthorityResolver.subSpaceConvenienceEdgeCleanup(TEST_GRAPH, 5), "invNp", "np");
+    }
+
+    @Test
+    void maintainedResourceConvenienceEdgeCleanup_gatesOnSamePublisher() {
+        assertSamePublisherGate(
+                AuthorityResolver.maintainedResourceConvenienceEdgeCleanup(TEST_GRAPH, 5), "invNp", "np");
+    }
+
+    @Test
+    void aliasConvenienceEdgeCleanup_gatesOnSamePublisher() {
+        assertSamePublisherGate(AuthorityResolver.aliasConvenienceEdgeCleanup(TEST_GRAPH, 5), "invNp", "np");
+    }
+
+    @Test
+    void convenienceEdgeCleanups_orphanSweepKeepsBackedEdges() {
+        // Each cleanup's orphan-sweep must guard the edge delete with a FILTER NOT EXISTS on
+        // the surviving provenance link, so an edge another declaration still backs is kept.
+        assertTrue(AuthorityResolver.aliasConvenienceEdgeCleanup(TEST_GRAPH, 5)
+                        .contains("FILTER NOT EXISTS"),
+                "alias orphan-sweep guards on surviving SpaceAliasLink");
+        assertTrue(AuthorityResolver.maintainedResourceConvenienceEdgeCleanup(TEST_GRAPH, 5)
+                        .contains("?l a npa:MaintainedResourceLink"),
+                "maintained orphan-sweep checks MaintainedResourceLink backers");
+        // Sub-space orphan-sweep recognizes both explicit and URL-prefix-derived backers.
+        String ss = AuthorityResolver.subSpaceConvenienceEdgeCleanup(TEST_GRAPH, 5);
+        assertTrue(ss.contains("npa:SubSpaceLink") && ss.contains("npa:DerivedSubSpaceLink"),
+                "sub-space orphan-sweep keeps edges backed by a declaration or the prefix fallback");
+    }
+
     // ---------------- Sub-space admit + invalidation (PR 2) ----------------
 
     @Test
@@ -377,12 +410,15 @@ class AuthorityResolverTest {
                 "invalidation filter for primary nanopub");
         assertTrue(sparql.contains("?_inv_np2 "),
                 "invalidation filter for Mode B co-declaration");
-        // Dedup is on the emitted ref-to-ref edge (per-space-ref isolation).
+        // Dedup is on the per-(nanopub, ref-pair) provenance link (issue #125 finding #5),
+        // so every backing declaration records its own removable npa:SubSpaceLink.
         java.util.regex.Pattern dedup = java.util.regex.Pattern.compile(
                 "FILTER\\s+NOT\\s+EXISTS\\s*\\{\\s*GRAPH\\s+<" + java.util.regex.Pattern.quote(TEST_GRAPH.stringValue())
-                        + ">\\s*\\{\\s*\\?childRef\\s+npa:isSubSpaceOf\\s+\\?parentRef");
+                        + ">\\s*\\{\\s*\\?ssLink\\s+a\\s+npa:SubSpaceLink");
         assertTrue(dedup.matcher(sparql).find(),
-                "dedup excludes already-emitted ref-to-ref edges");
+                "dedup excludes ref-pairs already recorded by this nanopub's SubSpaceLink");
+        assertTrue(sparql.contains("?ssLink a npa:SubSpaceLink"),
+                "emits the reified provenance link carrying npa:viaNanopub");
     }
 
     @Test
@@ -529,13 +565,15 @@ class AuthorityResolverTest {
                 "load-number delta filter on the declaration nanopub");
         assertTrue(sparql.contains("?_inv_np "),
                 "invalidation filter for the declaration nanopub");
-        // Dedup is on the emitted resource → ref edge (per-space-ref isolation).
+        // Dedup is on the per-(nanopub, resource→ref) provenance link (issue #125 finding #5).
         java.util.regex.Pattern dedup = java.util.regex.Pattern.compile(
                 "FILTER\\s+NOT\\s+EXISTS\\s*\\{\\s*GRAPH\\s+<"
                         + java.util.regex.Pattern.quote(TEST_GRAPH.stringValue())
-                        + ">\\s*\\{\\s*\\?r\\s+npa:isMaintainedBy\\s+\\?sRef");
+                        + ">\\s*\\{\\s*\\?mrLink\\s+a\\s+npa:MaintainedResourceLink");
         assertTrue(dedup.matcher(sparql).find(),
-                "dedup excludes already-emitted resource→ref edges");
+                "dedup excludes resource→ref pairs already recorded by this nanopub's link");
+        assertTrue(sparql.contains("?mrLink a npa:MaintainedResourceLink"),
+                "emits the reified provenance link carrying npa:viaNanopub");
     }
 
     @Test
@@ -600,9 +638,17 @@ class AuthorityResolverTest {
         // The declaration type appears in the INSERT and the anchor.
         assertTrue(countOccurrences(sparql, "a npa:SpaceAliasDeclaration") >= 2,
                 "declaration type in INSERT + anchor");
-        // Dedup is on the emitted ref-valued edge, so re-runs add each (alias, ref) once.
-        assertTrue(countOccurrences(sparql, "?alias npa:sameAsSpace ?canonRef") >= 2,
-                "edge emitted in INSERT and checked in the dedup FILTER NOT EXISTS");
+        // The ref-valued edge is emitted once in the INSERT.
+        assertTrue(sparql.contains("?alias npa:sameAsSpace ?canonRef"),
+                "ref-valued edge emitted in INSERT");
+        // Dedup is now on the per-(nanopub, alias→ref) provenance link (issue #125 finding #5),
+        // so every backing declaration records its own removable npa:SpaceAliasLink.
+        java.util.regex.Pattern dedup = java.util.regex.Pattern.compile(
+                "FILTER\\s+NOT\\s+EXISTS\\s*\\{\\s*GRAPH\\s+<"
+                        + java.util.regex.Pattern.quote(TEST_GRAPH.stringValue())
+                        + ">\\s*\\{\\s*\\?alLink\\s+a\\s+npa:SpaceAliasLink");
+        assertTrue(dedup.matcher(sparql).find(),
+                "dedup excludes alias→ref pairs already recorded by this nanopub's link");
     }
 
     private static int countOccurrences(String haystack, String needle) {


### PR DESCRIPTION
## What

Fixes **finding #5** of #125: the convenience structural edges (`npa:isSubSpaceOf`, `npa:isMaintainedBy`, `npa:sameAsSpace` — ref- and IRI-valued) were left **sticky** when their declaration's source nanopub was invalidated, only cleaned by the next periodic full rebuild. For the **alias** edge (which feeds the admin-authority closure) this let admin authority **outlive a retraction** within the rebuild window.

## How

- **Reification.** Each admit pass (`subSpaceAdmitUpdate`, `maintainedResourceAdmitUpdate`, `aliasAdmitUpdate`) now emits a per-`(nanopub, edge)` provenance link — `npa:SubSpaceLink` / `npa:MaintainedResourceLink` / `npa:SpaceAliasLink` — carrying `npa:viaNanopub` plus both the ref and IRI endpoints.
- **Dedup is now link-based, not edge-based**, so every backing declaration of a shared edge records its own removable link (avoids the "only the first backer is recorded" bug).
- **New `*ConvenienceEdgeCleanup` updates**, wired into `applyInvalidations` under each relation's `wouldInvalidate` guard (maintained refactored from unconditional → guarded): delete the invalidated nanopub's links, then **orphan-sweep** any edge that no surviving link backs.
- **`DerivedSubSpaceLink`** (URL-prefix fallback) gains ref endpoints so prefix-derived edges are recognized as backed and never swept.

## Safety

- **Concurrency-safe:** only genuinely-orphaned edges are deleted — no valid edge ever transiently disappears for concurrent readers (unlike a wipe-and-rebuild approach).
- `needsFullRebuild` still fires for the structural kinds, so rows derived *through* a removed edge stay rebuild-bounded.
- Multi-backer correctness: an edge backed by a second declaration survives invalidation of the first.

## Tests

- New `AuthorityResolverConvenienceEdgeInvalidationTest` (behavioral, in-memory store): edge removed on sole-backer invalidation; survives with a second backer; URL-prefix-derived edges not swept; all three relations.
- Updated dedup/gate assertions + new same-publisher gate tests in `AuthorityResolverTest`.
- Full suite green (284 tests).

## Deploy note

Requires a **full re-ingest** to backfill the new provenance-link tags onto existing rows (same as the #1 / #127 rollout). Until re-ingested, old edges have no link and would be orphan-swept on invalidation — so re-ingest before relying on the cleanup.

## Scope

This is the only in-repo finding of #125. The others are tracked elsewhere: #2/#3 → knowledgepixels/nanodash#510 (consumer-side), #4 → knowledgepixels/nanopub-registry#117 (upstream prerequisite).

Closes #125 finding #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
