### PR TITLE
feat(spaces): materialize uniform ref-valued hasGoverningSpaceRef edge (#130)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -244,17 +244,18 @@ public final class AuthorityResolver {
         lastInsertedTriplesTotal = (long) counts.admin + counts.alias + counts.presetAttachment
                 + counts.presetAssignmentRef
                 + counts.attachment + counts.maintainer + counts.member + counts.observer
-                + counts.subSpace + counts.subSpacePrefix + counts.maintainedResource;
+                + counts.subSpace + counts.subSpacePrefix + counts.maintainedResource
+                + counts.governingSpaceRef;
         lastFullBuildDurationMs = durationMs;
         lastProcessedUpToLag = 0L;
         logger.info("AuthorityResolver: full build complete — graph={} mirrored={} rows loadCounter={} "
                         + "subjects: adminRIs={} attachmentRAs={} nonAdminRIs={} "
                         + "(inserted-triples: admin={} alias={} preset-attachment={} preset-assignment-ref={} attachment={} maintainer={} member={} observer={} "
-                        + "subspace={} subspace-prefix={} maintained-resource={}) durationMs={}",
+                        + "subspace={} subspace-prefix={} maintained-resource={} governing-space-ref={}) durationMs={}",
                 newGraph, mirrored, loadCounter,
                 totals.adminRIs(), totals.attachmentRAs(), totals.nonAdminRIs(),
                 counts.admin, counts.alias, counts.presetAttachment, counts.presetAssignmentRef, counts.attachment, counts.maintainer, counts.member, counts.observer,
-                counts.subSpace, counts.subSpacePrefix, counts.maintainedResource,
+                counts.subSpace, counts.subSpacePrefix, counts.maintainedResource, counts.governingSpaceRef,
                 durationMs);
     }
 
@@ -323,6 +324,7 @@ public final class AuthorityResolver {
             counts.observer           += lateCounts.observer;
             counts.subSpace           += lateCounts.subSpace;
             counts.subSpacePrefix     += lateCounts.subSpacePrefix;
+            counts.governingSpaceRef  += lateCounts.governingSpaceRef;
             counts.maintainedResource += lateCounts.maintainedResource;
         }
 
@@ -334,17 +336,18 @@ public final class AuthorityResolver {
         lastInsertedTriplesTotal = (long) counts.admin + counts.alias + counts.presetAttachment
                 + counts.presetAssignmentRef
                 + counts.attachment + counts.maintainer + counts.member + counts.observer
-                + counts.subSpace + counts.subSpacePrefix + counts.maintainedResource;
+                + counts.subSpace + counts.subSpacePrefix + counts.maintainedResource
+                + counts.governingSpaceRef;
         lastIncrementalCycleDurationMs = durationMs;
         logger.info("AuthorityResolver: incremental cycle complete — graph={} delta=({}, {}] "
                         + "subjects: adminRIs={} attachmentRAs={} nonAdminRIs={} "
                         + "(inserted-triples: admin={} alias={} preset-attachment={} preset-assignment-ref={} attachment={} maintainer={} member={} observer={} "
-                        + "subspace={} subspace-prefix={} maintained-resource={}) "
+                        + "subspace={} subspace-prefix={} maintained-resource={} governing-space-ref={}) "
                         + "structuralInvalidation={} structuralAdds={} durationMs={}",
                 graph, lastProcessed, currentLoadCounter,
                 totals.adminRIs(), totals.attachmentRAs(), totals.nonAdminRIs(),
                 counts.admin, counts.alias, counts.presetAttachment, counts.presetAssignmentRef, counts.attachment, counts.maintainer, counts.member, counts.observer,
-                counts.subSpace, counts.subSpacePrefix, counts.maintainedResource,
+                counts.subSpace, counts.subSpacePrefix, counts.maintainedResource, counts.governingSpaceRef,
                 structuralInvalidation, structuralAdds, durationMs);
     }
 
@@ -454,6 +457,10 @@ public final class AuthorityResolver {
         // future inserts) and any newly-orphaned children pick up fallback edges.
         c.subSpacePrefix = runTierLabeled("subspace-prefix(late)", graph,
                 subSpacePrefixFallbackUpdate(graph));
+        // Reflexive governing-space-ref late sweep (issue #130): catches refs whose
+        // SpaceRef aggregate became visible only this cycle. Self-healing dedup.
+        c.governingSpaceRef = runTierLabeled("governing-space-ref(late)", graph,
+                governingSpaceRefReflexiveUpdate(graph));
         // Preset-attachment late-arrival: catches assignments whose preset declaration or
         // admin grant only became valid in this same cycle. Runs before attachment(late)
         // so the non-admin late tiers below see this cycle's fresh preset-derived RAs.
@@ -560,6 +567,7 @@ public final class AuthorityResolver {
         int subSpace;
         int subSpacePrefix;
         int maintainedResource;
+        int governingSpaceRef;
     }
 
     /**
@@ -599,6 +607,12 @@ public final class AuthorityResolver {
         // delta-arrivals; the dedup FILTER NOT EXISTS prevents re-insertion.
         c.subSpacePrefix = runTierLabeled("subspace-prefix", graph,
                 subSpacePrefixFallbackUpdate(graph));
+        // Reflexive governing-space-ref edges (issue #130). Self-healing, no load filter;
+        // runs after the maintained-resource admit so a maintained resource that is itself
+        // a space already has its maintained governing edge by now (the two are independent
+        // anyway — different subjects/objects). Order vs. other tiers doesn't matter.
+        c.governingSpaceRef = runTierLabeled("governing-space-ref", graph,
+                governingSpaceRefReflexiveUpdate(graph));
         // Preset-attachment runs immediately before the regular attachment tier so the
         // gen:RoleAssignment rows it materializes (from active, admin-authored preset
         // assignments) are picked up by the downstream non-admin tiers in the same pass,
@@ -1715,6 +1729,12 @@ public final class AuthorityResolver {
                      npa:viaNanopub      ?np .
                   ?r npa:isMaintainedBy        ?sRef .
                   ?sRef npa:hasMaintainedResource ?r .
+                  # Uniform ref-valued resource→governing-space-ref edge (issue #130). The
+                  # same predicate the reflexive space self-edge uses, so a single consumer
+                  # hop covers both "resource maintained by space S" and "resource IS a space".
+                  # Backed by the same MaintainedResourceLink below, so the invalidation
+                  # cleanup sweeps it alongside isMaintainedBy.
+                  ?r npa:hasGoverningSpaceRef  ?sRef .
                   # Reified per-(nanopub, resource→ref) provenance link (issue #125 finding
                   # #5): lets the invalidation cleanup drop the convenience edges below once
                   # no surviving link backs them, instead of leaving them sticky.
@@ -1990,6 +2010,46 @@ public final class AuthorityResolver {
                       ?tagIri a npa:DerivedSubSpaceLink .
                     }
                   }
+                }
+                """.formatted(
+                NPA.NAMESPACE,
+                graph,
+                SpacesVocab.SPACES_GRAPH);
+    }
+
+    /**
+     * Reflexive governing-space-ref pass (issue #130). For every {@code SpaceRef}
+     * aggregate {@code ?spaceRef} (identified by {@code npa:spaceIri ?space} in the
+     * extraction graph), emits {@code <space> npa:hasGoverningSpaceRef <spaceRef>} into
+     * the space-state graph — the space pointing at its own ref through the same predicate
+     * a maintained resource uses to point at its maintaining space's ref (emitted in
+     * {@link #maintainedResourceAdmitUpdate}).
+     *
+     * <p>This removes the zero-hop special case from consumer authority gates: instead of
+     * {@code ?resource npa:isMaintainedBy? ?space} (a bare-IRI optional path that breaks
+     * once the hop is ref-valued), a consumer does a single mandatory
+     * {@code ?resource npa:hasGoverningSpaceRef ?spaceRef} that binds whether the resource
+     * is a maintained resource or a space itself. A space IRI claimed by several refs emits
+     * one edge per ref — the non-ref consumer variant's merged-across-refs behaviour falls
+     * out naturally; the ref variant pins {@code ?passedRef}.
+     *
+     * <p>Self-healing, like {@link #subSpacePrefixFallbackUpdate}: the edge has no source
+     * nanopub (it follows purely from a {@code SpaceRef} existing), so there is no
+     * invalidation handling and no load-number filter — always full-scan, with the dedup
+     * {@code FILTER NOT EXISTS} on the edge preventing re-insertion. A {@code SpaceRef}
+     * disappearing is itself a structural-rebuild event, which clears its reflexive edge.
+     */
+    static String governingSpaceRefReflexiveUpdate(IRI graph) {
+        return """
+                PREFIX npa: <%1$s>
+                INSERT { GRAPH <%2$s> {
+                  ?space npa:hasGoverningSpaceRef ?spaceRef .
+                } }
+                WHERE {
+                  GRAPH <%3$s> { ?spaceRef npa:spaceIri ?space . }
+                  FILTER NOT EXISTS { GRAPH <%2$s> {
+                    ?space npa:hasGoverningSpaceRef ?spaceRef .
+                  } }
                 }
                 """.formatted(
                 NPA.NAMESPACE,
@@ -2368,9 +2428,26 @@ public final class AuthorityResolver {
                       { ?l npa:maintainerSpaceRef ?o } UNION { ?l npa:maintainerSpace ?o }
                     }
                   }
+                } ;
+                # 4. Orphan-sweep the maintained arm of hasGoverningSpaceRef (issue #130).
+                #    Only the ref-valued maintained edge is removed here — it is backed by a
+                #    MaintainedResourceLink. The reflexive space self-edge (subject = a space
+                #    IRI that has its own SpaceRef) is NOT a maintained edge and is left to the
+                #    self-healing reflexive pass, so the guard keeps any ?r that is itself a space.
+                DELETE { GRAPH <%2$s> { ?r npa:hasGoverningSpaceRef ?o . } }
+                WHERE {
+                  GRAPH <%2$s> {
+                    ?r npa:hasGoverningSpaceRef ?o .
+                    FILTER NOT EXISTS {
+                      ?l a npa:MaintainedResourceLink ;
+                         npa:resourceIri ?r ;
+                         npa:maintainerSpaceRef ?o .
+                    }
+                    FILTER NOT EXISTS { GRAPH <%7$s> { ?o npa:spaceIri ?r . } }
+                  }
                 }
                 """, NPA.NAMESPACE, graph, NPA.GRAPH, NPX.INVALIDATES, lastProcessed,
-                samePublisherClause("invNp", "np"));
+                samePublisherClause("invNp", "np"), SpacesVocab.SPACES_GRAPH);
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverGoverningSpaceRefTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverGoverningSpaceRefTest.java
@@ -1,0 +1,220 @@
+package com.knowledgepixels.query;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.vocabulary.NPA;
+
+import com.knowledgepixels.query.vocabulary.GEN;
+import com.knowledgepixels.query.vocabulary.SpacesVocab;
+
+/**
+ * Issue #130 — uniform ref-valued {@code npa:hasGoverningSpaceRef} edge that collapses the
+ * consumer authority gate and removes the cross-ref bleed.
+ *
+ * <p>The materializer emits, in each per-ref state graph: a reflexive self-edge from every
+ * space IRI to its own {@code SpaceRef} ({@link AuthorityResolver#governingSpaceRefReflexiveUpdate}),
+ * and a resource→maintaining-ref edge for every maintained resource
+ * ({@link AuthorityResolver#maintainedResourceAdmitUpdate}). Both use the same predicate, so a
+ * consumer gate does one mandatory hop whether the subject is a space or a maintained resource.
+ *
+ * <p>These tests assert: the reflexive edge is emitted once per ref (merged-across-refs falls
+ * out); the maintained edge is ref-valued and isolated to the authorizing ref (no bleed to a
+ * rival ref claiming the same space IRI); the simplified consumer gate from the issue resolves
+ * authority for both a space and a maintained resource; and the maintained governing edge is
+ * swept on invalidation while the reflexive self-edge is not.
+ */
+class AuthorityResolverGoverningSpaceRefTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+    private static final IRI STATE = SpacesVocab.forSpaceState(
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", 1L);
+    private static final IRI SPACES = SpacesVocab.SPACES_GRAPH;
+    private static final IRI INVALIDATES = vf.createIRI("http://purl.org/nanopub/x/invalidates");
+
+    private static IRI npa(String ln) { return vf.createIRI(NPA.NAMESPACE, ln); }
+    private static IRI ex(String ln)  { return vf.createIRI("http://example.org/", ln); }
+
+    private static final IRI S     = ex("space-S");
+    private static final IRI R1    = ex("ref-R1");
+    private static final IRI R2    = ex("ref-R2");
+    private static final IRI ALICE = ex("alice");
+    private static final IRI BOB   = ex("bob");
+    private static final Literal PKH_A = vf.createLiteral("pkhA");
+    private static final Literal PKH_B = vf.createLiteral("pkhB");
+
+    private Repository repo;
+    private RepositoryConnection c;
+
+    @BeforeEach
+    void setUp() {
+        repo = new SailRepository(new MemoryStore());
+        repo.init();
+        c = repo.getConnection();
+        // Two refs sharing IRI S; Alice admins R1, Bob admins R2.
+        refIri(R1, S);
+        refIri(R2, S);
+        account("acctA", ALICE, PKH_A);
+        account("acctB", BOB, PKH_B);
+        admin("adm_a", R1, S, ALICE);
+        admin("adm_b", R2, S, BOB);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (c != null) c.close();
+        if (repo != null) repo.shutDown();
+    }
+
+    @Test
+    void reflexiveEdgeEmittedOncePerRef() {
+        runToFixpoint(AuthorityResolver.governingSpaceRefReflexiveUpdate(STATE));
+        assertTrue(edge(S, npa("hasGoverningSpaceRef"), R1), "space → its ref R1");
+        assertTrue(edge(S, npa("hasGoverningSpaceRef"), R2), "space → its ref R2 (claimed by another root)");
+    }
+
+    @Test
+    void maintainedEdgeIsRefValuedAndIsolatedToAuthorizingRef() {
+        IRI res = ex("resource-1");
+        extMaintained("mr1", res, S, PKH_A, ex("np_mr"));   // declared by Alice (admin of R1)
+        runToFixpoint(AuthorityResolver.maintainedResourceAdmitUpdate(STATE, -1));
+
+        assertTrue(edge(res, npa("hasGoverningSpaceRef"), R1),
+                "maintained resource → the authorizing ref R1");
+        assertFalse(edge(res, npa("hasGoverningSpaceRef"), R2),
+                "must NOT bleed to rival ref R2 (no cross-ref authority)");
+        // The legacy ref-valued isMaintainedBy edge is still emitted alongside.
+        assertTrue(edge(res, npa("isMaintainedBy"), R1), "isMaintainedBy ref edge still present");
+    }
+
+    @Test
+    void simplifiedGateResolvesAdminForSpaceViaReflexiveEdge() {
+        runToFixpoint(AuthorityResolver.governingSpaceRefReflexiveUpdate(STATE));
+        // The space itself is the "resource": reflexive edge + admin RI on the ref.
+        assertTrue(gateBinds(S, R1), "admin of S's ref R1 governs the space via the reflexive edge");
+    }
+
+    @Test
+    void simplifiedGateResolvesForMaintainedResourceButNotRivalRef() {
+        IRI res = ex("resource-1");
+        extMaintained("mr1", res, S, PKH_A, ex("np_mr"));
+        runToFixpoint(AuthorityResolver.maintainedResourceAdmitUpdate(STATE, -1));
+        runToFixpoint(AuthorityResolver.governingSpaceRefReflexiveUpdate(STATE));
+
+        assertTrue(gateBinds(res, R1),
+                "admin of the authorizing ref R1 governs the maintained resource");
+        assertFalse(gateBinds(res, R2),
+                "admin of rival ref R2 does NOT govern the maintained resource (cross-ref bleed fixed)");
+    }
+
+    @Test
+    void maintainedGoverningEdgeSweptOnInvalidation_reflexiveKept() {
+        IRI res = ex("resource-1");
+        IRI np = ex("np_mr");
+        extMaintained("mr1", res, S, PKH_A, np);
+        runToFixpoint(AuthorityResolver.maintainedResourceAdmitUpdate(STATE, -1));
+        runToFixpoint(AuthorityResolver.governingSpaceRefReflexiveUpdate(STATE));
+        assertTrue(edge(res, npa("hasGoverningSpaceRef"), R1), "maintained governing edge present before invalidation");
+        assertTrue(edge(S, npa("hasGoverningSpaceRef"), R1), "reflexive governing edge present before invalidation");
+
+        invalidate(np, ex("inv_mr"), PKH_A);
+        run(AuthorityResolver.maintainedResourceConvenienceEdgeCleanup(STATE, -1));
+
+        assertFalse(edge(res, npa("hasGoverningSpaceRef"), R1),
+                "maintained governing edge swept after its declaration is invalidated");
+        assertTrue(edge(S, npa("hasGoverningSpaceRef"), R1),
+                "reflexive self-edge is self-healing and must NOT be swept by the cleanup");
+    }
+
+    // ---------------- seeding helpers ----------------
+
+    private void refIri(IRI ref, IRI iri) { c.add(ref, SpacesVocab.SPACE_IRI, iri, SPACES); }
+
+    private void account(String name, IRI agent, Literal pkh) {
+        IRI a = ex(name);
+        c.add(a, RDF.TYPE, npa("AccountState"), STATE);
+        c.add(a, npa("agent"), agent, STATE);
+        c.add(a, npa("pubkey"), pkh, STATE);
+    }
+
+    /** Admin RoleInstantiation, carrying npa:hasRoleType gen:AdminRole as the materializer now does (#127). */
+    private void admin(String name, IRI ref, IRI iri, IRI agent) {
+        IRI ri = ex(name);
+        c.add(ri, RDF.TYPE, GEN.ROLE_INSTANTIATION, STATE);
+        c.add(ri, SpacesVocab.FOR_SPACE_REF, ref, STATE);
+        c.add(ri, SpacesVocab.FOR_SPACE, iri, STATE);
+        c.add(ri, SpacesVocab.INVERSE_PROPERTY, GEN.HAS_ADMIN, STATE);
+        c.add(ri, SpacesVocab.HAS_ROLE_TYPE, GEN.ADMIN_ROLE, STATE);
+        c.add(ri, SpacesVocab.FOR_AGENT, agent, STATE);
+    }
+
+    private void loadNum(IRI np) { c.add(np, npa("hasLoadNumber"), vf.createLiteral(0L), NPA.GRAPH); }
+
+    private void invalidate(IRI target, IRI inv, Literal pkh) {
+        c.add(inv, INVALIDATES, target, NPA.GRAPH);
+        c.add(inv, npa("hasLoadNumber"), vf.createLiteral(0L), NPA.GRAPH);
+        c.add(inv, NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY_HASH, pkh, NPA.GRAPH);
+        c.add(target, NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY_HASH, pkh, NPA.GRAPH);
+    }
+
+    private void extMaintained(String name, IRI resource, IRI space, Literal pkh, IRI np) {
+        IRI d = ex(name);
+        c.add(d, RDF.TYPE, SpacesVocab.MAINTAINED_RESOURCE_DECLARATION, SPACES);
+        c.add(d, SpacesVocab.RESOURCE_IRI, resource, SPACES);
+        c.add(d, SpacesVocab.MAINTAINER_SPACE, space, SPACES);
+        c.add(d, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(d, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        loadNum(np);
+    }
+
+    // ---------------- execution + assertions ----------------
+
+    private void runToFixpoint(String update) {
+        long before = c.size(STATE);
+        while (true) {
+            c.prepareUpdate(QueryLanguage.SPARQL, update).execute();
+            long after = c.size(STATE);
+            if (after <= before) break;
+            before = after;
+        }
+    }
+
+    private void run(String update) {
+        c.prepareUpdate(QueryLanguage.SPARQL, update).execute();
+    }
+
+    /** The simplified consumer authority gate from issue #130 (admin/maintainer arm). */
+    private boolean gateBinds(IRI resource, IRI passedRef) {
+        return c.prepareBooleanQuery(QueryLanguage.SPARQL, """
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                ASK { GRAPH <%3$s> {
+                  <%4$s> npa:hasGoverningSpaceRef <%5$s> .
+                  ?ri a gen:RoleInstantiation ; npa:forSpaceRef <%5$s> ;
+                      npa:hasRoleType ?rt ; npa:forAgent ?authAgent .
+                  FILTER(?rt = gen:AdminRole || ?rt = gen:MaintainerRole)
+                  ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
+                } }
+                """.formatted(NPA.NAMESPACE, GEN.NAMESPACE, STATE, resource, passedRef)).evaluate();
+    }
+
+    private boolean edge(IRI s, IRI p, IRI o) {
+        return c.prepareBooleanQuery(QueryLanguage.SPARQL, """
+                PREFIX npa: <%1$s>
+                ASK { GRAPH <%2$s> { <%3$s> <%4$s> <%5$s> . } }
+                """.formatted(NPA.NAMESPACE, STATE, s, p, o)).evaluate();
+    }
+}

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverTest.java
@@ -577,6 +577,41 @@ class AuthorityResolverTest {
     }
 
     @Test
+    void maintainedResourceAdmitUpdate_emitsUniformGoverningSpaceRefEdge() {
+        // Issue #130: the maintained resource also gets the uniform ref-valued
+        // resource→governing-space-ref edge, pointing at the same authorizing ref.
+        String sparql = AuthorityResolver.maintainedResourceAdmitUpdate(TEST_GRAPH, 0);
+        assertTrue(sparql.contains("?r npa:hasGoverningSpaceRef  ?sRef"),
+                "emits ref-valued hasGoverningSpaceRef to the authorizing ref");
+    }
+
+    @Test
+    void governingSpaceRefReflexiveUpdate_emitsRefValuedSelfEdgeFromSpaceIri() {
+        // Issue #130: every SpaceRef yields <space> hasGoverningSpaceRef <ref>, keyed on the
+        // extraction-graph spaceIri, deduped on the edge (self-healing, no nanopub).
+        String sparql = AuthorityResolver.governingSpaceRefReflexiveUpdate(TEST_GRAPH);
+        assertTrue(sparql.contains("?space npa:hasGoverningSpaceRef ?spaceRef"),
+                "emits the reflexive space→ref edge");
+        assertTrue(sparql.contains("?spaceRef npa:spaceIri ?space"),
+                "anchors on the SpaceRef's spaceIri in the extraction graph");
+        assertTrue(sparql.contains("FILTER NOT EXISTS"),
+                "deduped on the edge — self-healing, idempotent across cycles");
+        assertFalse(sparql.contains("hasLoadNumber"),
+                "no load-number filter — full-scan, follows purely from SpaceRef existence");
+    }
+
+    @Test
+    void maintainedResourceConvenienceEdgeCleanup_sweepsGoverningRefButKeepsReflexive() {
+        // Issue #130 + #125 #5: the maintained arm of hasGoverningSpaceRef is orphan-swept
+        // (backed by MaintainedResourceLink), while the reflexive self-edge is guarded out.
+        String sparql = AuthorityResolver.maintainedResourceConvenienceEdgeCleanup(TEST_GRAPH, 5);
+        assertTrue(sparql.contains("?r npa:hasGoverningSpaceRef ?o"),
+                "orphan-sweeps the maintained governing edge");
+        assertTrue(sparql.contains("?o npa:spaceIri ?r"),
+                "guard keeps the reflexive self-edge (object ref's spaceIri equals the subject)");
+    }
+
+    @Test
     void maintainedResourceInvalidationDelete_targetsDeclarationRowsOnly() {
         String sparql = AuthorityResolver.maintainedResourceInvalidationDelete(TEST_GRAPH, 5);
         assertTrue(sparql.contains("DELETE"), "DELETE clause");


### PR DESCRIPTION
Implements #130.

## What

Materializes a uniform **ref-valued** `npa:hasGoverningSpaceRef` edge in each per-ref state graph, so consumer authority gates do one mandatory hop (`resource → governing space ref → RoleInstantiation`) whether the subject is a space or a maintained resource — instead of re-deriving the hop, the bare-IRI match, and the broken declaration join in every published query.

- **Reflexive** — `<spaceIRI> npa:hasGoverningSpaceRef <its own SpaceRef>`, via a new self-healing `governingSpaceRefReflexiveUpdate` pass (no source nanopub, no load filter; dedup on the edge). Removes the zero-hop special case (`isMaintainedBy?` zero-length path) that breaks once the hop is ref-valued — a space has no self ref-edge today.
- **Maintained** — `<resourceIRI> npa:hasGoverningSpaceRef <maintaining space's ref>`, emitted inside `maintainedResourceAdmitUpdate` pointing at the ref **whose admin authorized the declaration**. Ref-valued ⇒ no bare-IRI join ⇒ cross-ref bleed gone.

## Invalidation

The maintained arm rides the #125 finding-#5 machinery: it's emitted under the existing `MaintainedResourceLink` reification and orphan-swept by `maintainedResourceConvenienceEdgeCleanup`, extended with a guard (`?o npa:spaceIri ?r`) that keeps the **reflexive** self-edge — which is self-healing and has no nanopub to invalidate.

## Consumer side

Queries collapse to the simplified gate (keyed on `npa:hasRoleType`, materialized since #125):

```sparql
?resource npa:hasGoverningSpaceRef ?ref .         # ref variant pins ?ref = ?passedRef
?ri a gen:RoleInstantiation ; npa:forSpaceRef ?ref ; npa:hasRoleType ?rt ; npa:forAgent ?authAgent .
filter(?rt = gen:AdminRole || ?rt = gen:MaintainerRole)
?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
```

That's the repoint for nanodash#510 (view-displays + preset/role assignments).

## Tests

- New `AuthorityResolverGoverningSpaceRefTest` (behavioral): reflexive per-ref emission; ref-valued maintained edge isolated to the authorizing ref (no bleed to a rival ref claiming the same IRI); the simplified gate resolving a space and a maintained resource but **not** a rival ref; maintained governing edge swept on invalidation while the reflexive self-edge is kept.
- String-contract tests in `AuthorityResolverTest`.
- Full suite green (292 tests).

## Deploy

Requires a **full re-ingest** to backfill `hasGoverningSpaceRef` onto existing rows (rides the same re-ingest as #125 / #131).

## Rollout order

Materializer (this PR) → re-ingest → consumer supersede per affected query (nanodash#510).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
