### PR TITLE
fix(trust): mirror authorizing introNanopub onto AccountState (#125 finding #4)

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -68,6 +68,7 @@ public final class AuthorityResolver {
     private static final IRI NPA_AGENT = vf.createIRI(NPA.NAMESPACE, "agent");
     private static final IRI NPA_PUBKEY = vf.createIRI(NPA.NAMESPACE, "pubkey");
     private static final IRI NPA_TRUST_STATUS = vf.createIRI(NPA.NAMESPACE, "trustStatus");
+    private static final IRI NPA_VIA_NANOPUB = vf.createIRI(NPA.NAMESPACE, "viaNanopub");
     private static final IRI NPA_LOADED = vf.createIRI(NPA.NAMESPACE, "loaded");
     private static final IRI NPA_TO_LOAD = vf.createIRI(NPA.NAMESPACE, "toLoad");
 
@@ -2674,6 +2675,15 @@ public final class AuthorityResolver {
                     spacesConn.add(accountStateIri, NPA_AGENT, agent, newGraph);
                     spacesConn.add(accountStateIri, NPA_PUBKEY, pubkey, newGraph);
                     spacesConn.add(accountStateIri, NPA_TRUST_STATUS, statusIri, newGraph);
+                    // Mirror the authorizing introduction provenance when present (issue #125
+                    // finding #4). Optional: absent for snapshots from registries that predate
+                    // nanopub-registry#117/#118, so consumers (e.g. get-space-members-ref) must
+                    // treat npa:viaNanopub on an AccountState as best-effort, not guaranteed.
+                    Value viaNanopub = trustConn.getStatements(accountStateIri, NPA_VIA_NANOPUB, null, trustStateIri)
+                            .stream().findFirst().map(Statement::getObject).orElse(null);
+                    if (viaNanopub != null) {
+                        spacesConn.add(accountStateIri, NPA_VIA_NANOPUB, viaNanopub, newGraph);
+                    }
                     count++;
                 }
             }

--- a/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateLoader.java
@@ -70,6 +70,7 @@ public class TrustStateLoader {
     private static final IRI NPA_PATH_COUNT = vf.createIRI(NPA.NAMESPACE, "pathCount");
     private static final IRI NPA_RATIO = vf.createIRI(NPA.NAMESPACE, "ratio");
     private static final IRI NPA_QUOTA = vf.createIRI(NPA.NAMESPACE, "quota");
+    private static final IRI NPA_VIA_NANOPUB = vf.createIRI(NPA.NAMESPACE, "viaNanopub");
 
     private static final CloseableHttpClient httpClient =
             HttpClientBuilder.create().setDefaultRequestConfig(Utils.getHttpRequestConfig()).build();
@@ -259,6 +260,14 @@ public class TrustStateLoader {
                 if (a.quota() != null) {
                     conn.add(accountStateIri, NPA_QUOTA,
                             vf.createLiteral(a.quota()), trustStateIri);
+                }
+                // Authorizing introduction nanopub (nanopub-registry#117/#118; issue #125
+                // finding #4). Nullable: absent on snapshots from registries that predate
+                // the field, so only emit when present. createIRI is fine — the registry
+                // produces a nanopub trusty URI here, same as the agent IRI above.
+                if (a.introNanopub() != null && !a.introNanopub().isBlank()) {
+                    conn.add(accountStateIri, NPA_VIA_NANOPUB,
+                            vf.createIRI(a.introNanopub()), trustStateIri);
                 }
             }
 

--- a/src/main/java/com/knowledgepixels/query/TrustStateSnapshot.java
+++ b/src/main/java/com/knowledgepixels/query/TrustStateSnapshot.java
@@ -59,6 +59,11 @@ public record TrustStateSnapshot(
      *                      Used to break ties when multiple intros declare the same {@code (agent, pubkey)};
      *                      consumers picking one canonical name per agent across keys typically use
      *                      {@code MAX(ratio)} with this as a secondary tiebreaker.
+     * @param introNanopub IRI of the authorizing introduction nanopub for this {@code (agent, pubkey)}
+     *                     (the intro carrying the key declaration; nanopub-registry#117/#118), or
+     *                     {@code null} when running against a registry whose snapshot predates the
+     *                     field — additive non-breaking schema, so absence must be tolerated during
+     *                     the fleet rollout. Tracks the same name-winning intro as {@code name}.
      */
     public record AccountEntry(
             String pubkey,
@@ -69,8 +74,20 @@ public record TrustStateSnapshot(
             Double ratio,
             Long quota,
             String name,
-            Instant nameCreatedAt
-    ) {}
+            Instant nameCreatedAt,
+            String introNanopub
+    ) {
+        /**
+         * Back-compat constructor without {@code introNanopub} (defaults to {@code null}) —
+         * the field is additive (nanopub-registry#117/#118). Convenient for call sites that
+         * predate it; production parsing always uses the canonical constructor.
+         */
+        public AccountEntry(String pubkey, String agent, String status, Integer depth,
+                            Integer pathCount, Double ratio, Long quota, String name,
+                            Instant nameCreatedAt) {
+            this(pubkey, agent, status, depth, pathCount, ratio, quota, name, nameCreatedAt, null);
+        }
+    }
 
     /**
      * Parses a {@code /trust-state/<hash>.json} envelope from its JSON
@@ -123,7 +140,8 @@ public record TrustStateSnapshot(
                     a.getDouble("ratio"),
                     unwrapLongNullable(a, "quota"),
                     a.getString("name"),
-                    unwrapDateNullable(a, "nameCreatedAt")
+                    unwrapDateNullable(a, "nameCreatedAt"),
+                    a.getString("introNanopub")
             ));
         }
 

--- a/src/test/java/com/knowledgepixels/query/TrustStateSnapshotTest.java
+++ b/src/test/java/com/knowledgepixels/query/TrustStateSnapshotTest.java
@@ -26,7 +26,8 @@ class TrustStateSnapshotTest {
                   "depth": 1,
                   "pathCount": 1,
                   "ratio": 0.008181818181818182,
-                  "quota": 100000
+                  "quota": 100000,
+                  "introNanopub": "http://purl.org/np/RAn2hFURf8krekyne_hB3hdvF-PB-r4Qvy3uLFXAp1CQ0"
                 },
                 {
                   "pubkey": "1162349fdeaf431e71ab55898cb2a425b971d466150c2aa5b3c1beb498045a37",
@@ -83,6 +84,18 @@ class TrustStateSnapshotTest {
         assertEquals(2, second.depth());
         assertEquals(3, second.pathCount());
         assertEquals(24000L, second.quota());
+    }
+
+    @Test
+    void parse_extractsIntroNanopubWhenPresentAndNullWhenAbsent() {
+        // nanopub-registry#117/#118: the authorizing intro is stamped per account. It is
+        // additive, so a snapshot from a registry that predates it has no field → null.
+        TrustStateSnapshot s = TrustStateSnapshot.parse(FIXTURE);
+        assertEquals("http://purl.org/np/RAn2hFURf8krekyne_hB3hdvF-PB-r4Qvy3uLFXAp1CQ0",
+                s.accounts().getFirst().introNanopub(),
+                "introNanopub extracted when present");
+        assertNull(s.accounts().get(1).introNanopub(),
+                "introNanopub is null when the account row omits it (pre-#118 registry)");
     }
 
     @Test


### PR DESCRIPTION
Closes #125 finding #4 (materializer side), building on the registry field from knowledgepixels/nanopub-registry#118.

## What

The space-state `AccountState` mirror recorded *that* a key is approved but not *which* introduction authorized it. The registry now stamps the authorizing intro on each trust-state account row (registry#117/#118); this wires it end-to-end:

1. **`TrustStateSnapshot.AccountEntry`** gains a **nullable** `introNanopub`, parsed from the snapshot JSON. A back-compat 9-arg constructor defaults it to `null` (keeps existing call sites clean).
2. **`TrustStateLoader.materialize`** emits `npa:viaNanopub <introNp>` on the `AccountState` when present — same optional-field idiom as `depth`/`quota`.
3. **`AuthorityResolver.mirrorTrustState`** copies `npa:viaNanopub` into the space-state graph alongside `agent`/`pubkey`/`status`.

## Nullable-safe by design

Snapshots from registries that predate the field carry no `introNanopub`, so it's emitted/mirrored **only when present**. This matters during the fleet rollout — I verified live that all three registries are on **1.11.0**, but only **registry.nanodash.net** has regenerated its snapshot with the field (769/769); **registry.knowledgepixels.com** (updating) and **registry.petapico.org** still serve pre-field snapshots. A query node attached to those must not break — and now doesn't.

## Tests

`TrustStateSnapshotTest` covers extraction-when-present and null-when-absent. Full suite green (293).

(`materialize`/`mirrorTrustState` have no in-repo TripleStore harness — the wiring is a conditional in the established `if (x != null)` shape, and the data path is verifiable end-to-end against a 1.11.0 registry snapshot once deployed.)

## Consumer side (out of scope, optional)

With `npa:viaNanopub` now on `AccountState`, nanodash queries like `get-space-members-ref` *can* surface which intro authorized an approved key — a separate enhancement, not required to close #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
