### PR TITLE
feat(spaces): revoke & re-assign space roles (authorization-scoped latest-wins) (#129)

### DIFF
--- a/doc/design-role-revocation.md
+++ b/doc/design-role-revocation.md
@@ -1,0 +1,213 @@
+# Design: revoke & re-assign space roles (authorization-scoped latest-wins)
+
+Status: **implemented** (issue [#129]; branch `feat/issue-129-role-revocation`), server side only.
+Scope: this document covers the **nanopub-query** work. The **Nanodash** side needs publishing templates for the
+two new vocabulary terms (see §8) — tracked separately.
+
+## 1. Context & goal
+
+Before this change a granted space role could be revoked **only by the original granter** — the same signing key,
+via `npx:invalidates` gated by `samePublisherClause` (issue #112, `AuthorityResolver.samePublisherClause`). So an
+admin could not revoke a member another admin admitted, and a member could not leave on their own.
+
+The goal is to support **revocation** and **re-assignment** of roles at the *key* level, reusing the
+authorization-scoped latest-wins model already proven for preset assignments (issue #302, see
+`design-preset-role-materialization.md`). `npx:invalidates` stays for *nanopub-level* undo ("this exact statement was
+a mistake"); the new negatives are *key-level* ("the agent no longer holds this role, however it was granted").
+
+**Model.** The state of an `(agent, role, spaceRef)` key (instantiation) or `(role, spaceRef)` key (attachment) is
+the sign of the **latest authorized assertion** by `dct:created`, with a subject-IRI tiebreak, **active-by-default**.
+This mirrors `gen:DeactivatedPresetAssignment` (`GEN.java`): a revocation is just a newer authorized row that happens
+to be negative; re-assignment is a newer positive row; toggling falls out for free.
+
+## 2. Vocabulary (two new, previously-unused terms)
+
+### Instantiation revocation — `gen:RevokedRoleInstantiation`
+
+A typed node, in its own nanopub, keyed on `(space, agent, role)`:
+
+```turtle
+:r a gen:RevokedRoleInstantiation ;
+   gen:forSpace <space> ;
+   gen:forAgent <agent> ;     # whose role is revoked
+   gen:hasRole  <roleIRI> .   # the role revoked (version-pinned, matches the materialized key)
+# pubinfo carries dct:created (the latest-wins key) + the signature (= the revoker)
+```
+
+One form covers every tier. A predicate / back-compat role only materializes via a declared `gen:hasRole`
+attachment, so every non-admin role has a role IRI to key on. **Admin is keyed on `gen:hasRole gen:AdminRole`**
+(decision D1, §6) — the admin tier carries no per-role IRI, so the admin role *type* serves as the role key,
+matching the `npa:hasRoleType gen:AdminRole` the admin tier stamps.
+
+(`GEN.java` also gains the input predicates `gen:forSpace` / `gen:forAgent` used by this node shape.)
+
+### Attachment revocation — `gen:detachedRole`
+
+A single predicate triple, keyed on `(space, role)` — the stative antonym of `gen:hasRole`:
+
+```turtle
+<space> gen:detachedRole <roleIRI> .   # role no longer available in the space; admin-authored
+```
+
+Auto-typed like `gen:hasRole` (single-predicate-assertion). A winning detachment removes the role's availability, so
+direct **and** preset-derived attachments — and the instantiations anchored on them — drop out (the cascade).
+
+### State-side extraction terms (`SpacesVocab.java`)
+
+`npa:RoleRevocation` / `npa:RoleDetachment` (RDF types on extraction rows), `npa:revokedRole` (the role IRI carried),
+and minters `forRoleRevocation(artifactCode, agent⊕role hash)` / `forRoleDetachment(artifactCode, role hash)` in new
+`nparev:` / `npadet:` namespaces (so negatives never collide with the `npari:` / `npara:` positives of the same
+nanopub).
+
+## 3. Authorization matrix — who may publish a *winning* assertion
+
+| Target role | May set the latest (winning) assertion |
+|---|---|
+| **root admin** | **nobody at runtime** — constitutional (§5) |
+| admin | admins |
+| maintainer | admins |
+| member | admins, maintainers |
+| observer | admins, maintainers, members, **+ self** |
+
+- **Self may always *revoke* its own role (leave) at any tier** (`signer == forAgent`), *except* root admins
+  (decision D2, §6). Self may only *assign* at observer (self-attest) — unchanged.
+- Equivalently for the non-admin tiers: **a revoker must hold a tier strictly higher than the target**
+  (admin > maintainer > member > observer), or be the assignee. Admin is the exception (admins revoke admin peers).
+- Forgeability is handled exactly as in #302: the candidate set is filtered to authorized publishers *before*
+  `MAX(dct:created)`, so a postdated nanopub from an unauthorized key cannot win. Among co-equal admins it is
+  "latest *claimed* time wins" — a shared-clock-trust assumption, fine within a mutually-trusting admin set.
+- Authorization is evaluated against the **current** materialized tier sets each cycle (self-healing), matching the
+  preset precedent — it is not frozen at authoring time (decision D-default).
+
+## 4. Implementation (`AuthorityResolver.java`)
+
+Negatives never materialize as final-state rows. Each is consumed where its key is bound, via a pair:
+**(a)** an inline suppression `FILTER NOT EXISTS` in the relevant INSERT tier (prevents (re-)materialization), and
+**(b)** a displacement `DELETE` run every cycle in `applyInvalidations` (removes already-materialized rows when the
+negative arrives in a later cycle). Both are required because the cycle is incremental and the periodic full rebuild
+only runs when `npa:needsFullRebuild` is set.
+
+The latest-wins comparison is `COALESCE(?negCreated, epoch) > COALESCE(?candCreated, epoch)` with a
+`STR()` subject tiebreak (decision D3, §6 — missing `dct:created` sorts as epoch).
+
+| Tier / template | Inline filter | Displacement DELETE | Structural? |
+|---|---|---|---|
+| `nonAdminTierUpdate` (maintainer/member/observer) | `nonAdminRevocationSuppressionFilter(tierClass)` | `roleRevocationDelete` | **Yes** — a revoked maintainer/member is a sub-granting authority (§8) |
+| `adminTierUpdate` | `adminRevocationSuppressionFilter` (+ root exemption) | `adminRevocationDelete` (+ root exemption) | **Yes** — admin RIs feed downstream |
+| `attachmentValidationUpdate` (direct) | `roleDetachmentSuppressionFilter("attCreated","ra")` | `roleDetachmentDelete` | **Yes** — cascade |
+| `presetAttachmentValidationUpdate` (preset-derived) | `roleDetachmentSuppressionFilter("created","pa")` | (same `roleDetachmentDelete`) | **Yes** — cascade |
+
+**Authority arms.** The matrix is encoded **once** in `revocationAuthorityArmsGeneric()` — a UNION of admin / tiered /
+self arms keyed on a bound `?tier` (the target role's tier), each higher-tier arm guarded by a `FILTER` on `?tier`.
+Both paths consume it: the displacement DELETE binds `?tier` from the row's `npa:hasRoleType`; the inline suppression
+filter binds `?tier` to its compile-time `tierClass` (`BIND(<tierClass> AS ?tier)`). One source of truth ⇒ suppression
+and re-materialization can never authorize different revokers and flip-flop a row. **Authority derives from the target
+tier, never from the positive arm's `publisherConstraint`** — otherwise the split `member(admin-pub)` /
+`member(maint-pub)` INSERT arms would each test against only their own publisher class, leaving a hole (the
+"multi-arm hazard").
+
+**Aliases.** The negative's named space is matched against any IRI denoting the ref — its canonical
+`npa:spaceIri` or a validated `npa:sameAsSpace` alias (issue #113) — so an alias-named revocation/detachment is not a
+silent no-op. Revocation does not propagate to sub-spaces (per-ref keying isolates this).
+
+**Detachment cascade.** A winning `gen:detachedRole` deletes the `(ref, role)` `gen:RoleAssignment` rows (direct +
+preset-derived) and sets `needsFullRebuild`; the instantiations anchored on the removed attachment are dropped on the
+next periodic rebuild, where the attachment-tier inline filters keep the role suppressed. Non-sticky (decision
+D5): a newer attachment / preset assignment (newer `dct:created`) out-ranks the detachment and re-attaches.
+
+## 5. Root admins are un-revokable (strict)
+
+Root admins (`npa:hasRootAdmin` in the root `gen:Space` nanopub) are **constitutional**: sourced only from the
+root-def seed (#110), never assignable or revocable at runtime. Implemented by **deriving on demand**, not a stamp —
+both the admin inline filter and `adminRevocationCheckWhere` carry a nested guard:
+
+```sparql
+FILTER NOT EXISTS {
+  GRAPH <spacesGraph> {
+    ?def a npa:SpaceDefinition ; npa:forSpaceRef ?spaceRef ; npa:hasRootAdmin ?agent .
+  }
+}
+```
+
+so any revocation against a root admin is structurally inert. This **overrides self-leave** (decision D2): a root
+admin who wants out must migrate the ref. No re-stamp, no re-ingest, zero consumer impact.
+
+## 6. Decisions
+
+| # | Decision | Resolution |
+|---|---|---|
+| D1 | Admin-revocation shape (admin tier has no `gen:hasRole`) | Carry **`gen:hasRole gen:AdminRole`**; one vocab term, one extraction path; matches the stamped `npa:hasRoleType gen:AdminRole`. Needs a Nanodash template convention (§9). |
+| D2 | Can a root admin self-leave? | **No.** The `hasRootAdmin` exemption overrides self-leave; root admins are permanent for the ref's lifetime. |
+| D3 | Missing `dct:created` (not currently mandatory; `addProvenance` emits it only when present) | **Treat missing as epoch** (sorts oldest). `COALESCE(?c, epoch)` on both sides; a positive without a timestamp always loses, a negative without one is inert. |
+| D6 | Un-revoke via `npx:invalidates`? | **No.** The negative is *not* wrapped in `invalidationFilter`; the only un-revoke path is a newer authorized re-assignment. |
+| D5 | `detachedRole` vs preset re-attach | **Non-sticky** plain latest-wins; a newer `PresetAssignment` re-attaches. Sticky opt-out is a v2 follow-up. |
+
+## 7. Backwards compatibility
+
+Fully back-compat, given the unused negative-assignment vocabulary:
+- **No existing nanopub is reinterpreted** — nothing already published matches the new terms, so all current
+  memberships stay active.
+- **Active-by-default overlay, not a rewrite** — with zero negatives in existing data the latest assertion on every
+  key is always positive → identical to today. `npx:invalidates` keeps working unchanged.
+- **No state-graph shape change** — negatives never materialize as rows; root admins use derive-on-demand. Active
+  rows look as today, no consumer repoint.
+- **No re-ingest** — extractor + resolver changes take effect on the normal periodic rebuild from already-ingested
+  data (a redeploy, not a re-sync).
+- **Mixed-version fleet fails open** — un-upgraded servers ignore the unknown vocab and keep the member; full effect
+  once the fleet is upgraded.
+
+## 8. Known limitations (surfaced by code review — decide before public rollout)
+
+1. **Fail-open resurrection on revoker departure (model-level; shared with #302).** Authorization is evaluated
+   against the *current* materialized role set each cycle. For a *negative* assertion this fails **open**: if the
+   revoker later loses the tier that authorized the revocation, the suppression lifts and the revoked grant
+   re-materializes on the next rebuild. Concretely: admin B grants X, admin A revokes X, A then leaves → X's grant
+   (still authorized by B) reappears, undoing A's revocation. The same property exists in #302 preset deactivation
+   (a deactivating admin who leaves reactivates the preset). The threat model treats admin↔admin churn as low-risk
+   (mutually-trusting admin set). **Accepted as intended behaviour** (issue author, 2026-06-26): such resurrections
+   are fine — no change. Documented here so the property is explicit; revisiting would need sticky-once-applied
+   revocations or authorization snapshotting (historical tier membership).
+2. **Missing `dct:created` ⇒ a re-grant can be wrong-dropped (decision D3 consequence).** A positive lacking a
+   timestamp sorts as epoch and loses to *any* timestamped negative — including an *older* revocation. A legit
+   re-grant published without `dct:created` stays invisible until a newer timestamped grant arrives. Mitigation:
+   **Nanodash must stamp `dct:created` on every role assign/revoke/attach/detach nanopub** (§9). This is the chosen
+   D3 semantics, not a code defect, but it makes the Nanodash stamping requirement load-bearing.
+3. **Stale-authorization window for cascades (consistent with existing structural deletes).** A detachment or admin
+   revocation removes the directly-keyed row in-cycle but the downstream instantiations anchored on it are only
+   dropped on the next periodic full rebuild (`needsFullRebuild`), not immediately. Between the two, those members
+   remain queryable. Identical to the existing preset / alias / sub-space convenience-edge policy; bounded by the
+   rebuild cadence.
+4. **`gen:detachedRole` recognition depends on nanopub typing (same as `gen:hasRole`).** A detachment is dispatched
+   via `NanopubUtils.getTypes` — single-predicate-assertion auto-typing or an explicit
+   `npx:hasNanopubType gen:detachedRole`. A detachment nanopub with extra assertion triples and no explicit type
+   marker would not be recognized. Nanodash templates must publish detachments as single-predicate assertions or with
+   the explicit type marker (§9) — the same convention `gen:hasRole` attachments already rely on.
+
+## 9. Nanodash follow-ups (tracked separately)
+
+- Publishing templates for `gen:RevokedRoleInstantiation` (incl. the **`gen:hasRole gen:AdminRole`** admin
+  convention) and `gen:detachedRole`. Both **must stamp `dct:created`** (the latest-wins key).
+- Canary the role-reading published query nanopubs (`get-space-members` / role listings, the admins listing, the
+  ref-scoped preset listing) before merge — a revoked member/observer/admin (non-root) disappears, a detached role's
+  holders disappear, a root admin sticks. See `canary-checklist-spaceref-1.15.md` and
+  `verify_published_query_consumers`.
+
+## 10. Tests
+
+- `SpacesExtractorTest` — extraction of both negatives (incl. admin `gen:AdminRole`, missing-field no-op,
+  `TRIGGER_TYPES` membership).
+- `AuthorityResolverRevocationTest` — SPARQL string-contract assertions (latest-wins on `dct:created`, epoch
+  fallback, the per-tier authority matrix, the multi-arm hazard, root exemption, no `npx:invalidates`, detachment
+  covering direct + preset-derived).
+- `AuthorityResolverRevocationBehaviorTest` — in-memory runtime behaviour: inline suppression, re-assignment-wins,
+  unauthorized-revoker ignored, maintainer-revokes-member, observer self-leave, displacement delete, detachment
+  displacement, admin revocation with root-admin exemption.
+
+## References
+
+- Issue [#129]. Precedents: #302 / #121 / #122 (preset latest-wins), #112 (granter-only gate, superseded for the key
+  level), #110 (root-admin seed), #113 (alias authority), #125 / #127 (role-type stamp).
+- `design-preset-role-materialization.md`, `design-spaceref-isolation.md`, `design-space-repositories.md`,
+  `canary-checklist-spaceref-1.15.md`, `sparql-quirks.md`.
+
+[#129]: https://github.com/knowledgepixels/nanopub-query/issues/129

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -413,6 +413,37 @@ public final class AuthorityResolver {
             executeUpdate(presetDeactivationDelete(graph, lastProcessed));
             structural = true;
         }
+        // Admin role-instantiation revocation (issue #129). STRUCTURAL — admin RIs feed every
+        // downstream tier, so a removed admin must bound the staleness via a full rebuild
+        // (mirrors adminInvalidationDelete). Root admins are exempt inside the check-where.
+        if (wouldInvalidate(graph, lastProcessed, /*adminPinned=*/ true,
+                            adminRevocationCheckWhere(graph, lastProcessed))) {
+            executeUpdate(adminRevocationDelete(graph, lastProcessed));
+            structural = true;
+        }
+        // Role detachment (issue #129). STRUCTURAL — removing a (ref, role) attachment
+        // (direct or preset-derived) cascades to the instantiations anchored on it, bounded
+        // by the periodic full rebuild. The attachment-tier inline filters then keep the
+        // detached role suppressed until a newer attachment / preset assignment out-ranks it.
+        if (wouldInvalidate(graph, lastProcessed, /*adminPinned=*/ false,
+                            roleDetachmentCheckWhere(graph, lastProcessed))) {
+            executeUpdate(roleDetachmentDelete(graph, lastProcessed));
+            structural = true;
+        }
+        // Non-admin role-instantiation revocation (issue #129), run once per tier so the
+        // authorization arms are the compile-time set for that tier (mirrors the inline
+        // suppression filter). STRUCTURAL: a revoked maintainer or member is a sub-granting
+        // authority — members/observers they granted are validated via the maint-pub /
+        // member-pub arms of nonAdminTierUpdate, so removing the revoked agent's own RI must
+        // schedule a full rebuild to re-evaluate (and drop) those now-unauthorized downstream
+        // grants. The inline suppression filter prevents re-materialization on that rebuild.
+        for (IRI revTier : List.of(GEN.MAINTAINER_ROLE, GEN.MEMBER_ROLE, GEN.OBSERVER_ROLE)) {
+            if (wouldInvalidate(graph, lastProcessed, /*adminPinned=*/ false,
+                                roleRevocationCheckWhere(graph, lastProcessed, revTier))) {
+                executeUpdate(roleRevocationDelete(graph, lastProcessed, revTier));
+                structural = true;
+            }
+        }
         // Leaf-tier RI deletes — no flag.
         executeUpdate(leafTierInvalidationDelete(graph, lastProcessed));
         // Ref-scoped preset-assignment listing stamps whose assignment nanopub was
@@ -680,6 +711,188 @@ public final class AuthorityResolver {
                 """.formatted(tierClass);
     }
 
+    // ---------------- Role revocation / detachment (issue #129) ----------------
+
+    /**
+     * {@code xsd:dateTime} epoch literal — the latest-wins fallback for any assertion that
+     * lacks {@code dct:created}. Per issue #129's "treat missing as epoch": a positive
+     * assertion without a timestamp sorts oldest (always loses), and a negative
+     * (revocation / detachment) without one is inert (can never out-rank a timestamped
+     * positive). Written as a full datatype IRI since the tier templates only declare
+     * {@code npa:} / {@code gen:}.
+     */
+    private static final String EPOCH_DT =
+            "\"1970-01-01T00:00:00.000Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime>";
+
+    /** Inner {@code GRAPH} block matching a revoker who is a validated admin of {@code ?spaceRef}. */
+    private static String revokerAdminGraphBlock(IRI graph) {
+        return String.format("""
+                GRAPH <%1$s> {
+                  ?revAcct a npa:AccountState ; npa:pubkey ?revPkh ; npa:agent ?revAgent .
+                  ?revRI a gen:RoleInstantiation ;
+                         npa:forSpaceRef ?spaceRef ;
+                         npa:inverseProperty gen:hasAdmin ;
+                         npa:forAgent ?revAgent .
+                }""", graph);
+    }
+
+    /** Inner {@code GRAPH} block matching a revoker who holds {@code tier} in {@code ?spaceRef}. */
+    private static String revokerTierGraphBlock(IRI graph, IRI tier) {
+        return String.format("""
+                GRAPH <%1$s> {
+                  ?revAcct a npa:AccountState ; npa:pubkey ?revPkh ; npa:agent ?revAgent .
+                  ?revRI a gen:RoleInstantiation ;
+                         npa:forSpaceRef ?spaceRef ;
+                         npa:forAgent ?revAgent ;
+                         npa:hasRoleType <%2$s> .
+                }""", graph, tier);
+    }
+
+    /** Inner {@code GRAPH} block matching a self-revoke: the revoker's key belongs to {@code ?agent}. */
+    private static String revokerSelfGraphBlock(IRI graph) {
+        return String.format("""
+                GRAPH <%1$s> {
+                  ?revAcct a npa:AccountState ; npa:pubkey ?revPkh ; npa:agent ?agent .
+                }""", graph);
+    }
+
+    /**
+     * Authorization arms for an instantiation revocation targeting a <em>compile-time</em>
+     * tier — issue #129's matrix, the single arm builder used by BOTH the inline suppression
+     * filter and the (per-tier-scoped) displacement DELETE, so the two paths can never
+     * authorize different revokers and flip-flop a row. UNION of only the arms the matrix
+     * permits for {@code targetTier}: admin of {@code ?spaceRef} (revokes any non-admin); a
+     * maintainer (member/observer targets); a member (observer target); plus the assignee
+     * itself (self-leave, any tier). A revoker must hold a tier strictly higher than the
+     * target. Compile-time selection (no runtime {@code ?tier} variable) deliberately avoids
+     * the SPARQL pitfall where a {@code FILTER} inside a {@code UNION} branch cannot see a
+     * {@code ?tier} bound in the enclosing group.
+     */
+    private static String revocationAuthorityArmsForTier(IRI graph, IRI targetTier) {
+        List<String> arms = new ArrayList<>();
+        arms.add("{ " + revokerAdminGraphBlock(graph) + " }");
+        if (GEN.MEMBER_ROLE.equals(targetTier) || GEN.OBSERVER_ROLE.equals(targetTier)) {
+            arms.add("{ " + revokerTierGraphBlock(graph, GEN.MAINTAINER_ROLE) + " }");
+        }
+        if (GEN.OBSERVER_ROLE.equals(targetTier)) {
+            arms.add("{ " + revokerTierGraphBlock(graph, GEN.MEMBER_ROLE) + " }");
+        }
+        arms.add("{ " + revokerSelfGraphBlock(graph) + " }");
+        return String.join("\nUNION\n", arms);
+    }
+
+    /**
+     * Inline suppression filter for {@code nonAdminTierUpdate}: rejects a candidate
+     * instantiation ({@code ?ri}, created {@code ?candCreated}) whose {@code (space, agent,
+     * role)} key has a newer authorized {@code npa:RoleRevocation}, using
+     * {@link #revocationAuthorityArmsForTier} for {@code targetTier} (the loop tier) — the same
+     * builder the displacement DELETE uses, so suppression and re-materialization always agree.
+     * The revocation's named space is matched against any IRI denoting {@code ?spaceRef}
+     * (canonical or validated {@code owl:sameAs} alias, issue #113), so an alias-named
+     * revocation is not a silent no-op. Latest-wins by {@code dct:created} ({@link #EPOCH_DT}
+     * fallback) with an {@code STR()} subject tiebreak. Not wrapped in {@code invalidationFilter}:
+     * per issue #129 the only un-revoke path is a newer positive re-assignment.
+     */
+    private static String nonAdminRevocationSuppressionFilter(IRI graph, IRI targetTier) {
+        return String.format("""
+                FILTER NOT EXISTS {
+                  { GRAPH <%2$s> { ?spaceRef npa:spaceIri ?revSpace . } }
+                  UNION
+                  { GRAPH <%1$s> { ?revSpace npa:sameAsSpace ?spaceRef . } }
+                  GRAPH <%2$s> {
+                    ?rev a npa:RoleRevocation ;
+                         npa:forSpace    ?revSpace ;
+                         npa:forAgent    ?agent ;
+                         npa:revokedRole ?role ;
+                         npa:pubkeyHash  ?revPkh .
+                    OPTIONAL { ?rev <http://purl.org/dc/terms/created> ?revCreatedRaw . }
+                  }
+                  BIND(COALESCE(?revCreatedRaw, %4$s) AS ?revCreated)
+                  FILTER (?revCreated > ?candCreated
+                          || (?revCreated = ?candCreated && STR(?rev) > STR(?ri)))
+                  { %3$s }
+                }""", graph, SpacesVocab.SPACES_GRAPH,
+                revocationAuthorityArmsForTier(graph, targetTier), EPOCH_DT);
+    }
+
+    /**
+     * Inline suppression filter for {@code adminTierUpdate}: rejects an admin instantiation
+     * ({@code ?ri}, created {@code ?candCreated}) whose {@code (ref, agent)} key has a newer
+     * authorized admin {@code npa:RoleRevocation} ({@code revokedRole = gen:AdminRole}) —
+     * authorized by an admin of the ref (admins revoke admins) or by the agent itself
+     * (self-leave). <b>Root admins are exempt</b> (issue #129/#110): a nested
+     * {@code FILTER NOT EXISTS} on {@code npa:hasRootAdmin} makes any revocation against a
+     * root admin structurally inert, overriding self-leave. {@code gen:AdminRole} resolves
+     * via the {@code gen:} prefix the admin-tier template declares.
+     */
+    private static String adminRevocationSuppressionFilter(IRI graph) {
+        return String.format("""
+                FILTER NOT EXISTS {
+                  FILTER NOT EXISTS { GRAPH <%2$s> {
+                    ?rootDef a npa:SpaceDefinition ;
+                             npa:forSpaceRef  ?spaceRef ;
+                             npa:hasRootAdmin ?agent .
+                  } }
+                  { GRAPH <%2$s> { ?spaceRef npa:spaceIri ?revSpace . } }
+                  UNION
+                  { GRAPH <%1$s> { ?revSpace npa:sameAsSpace ?spaceRef . } }
+                  GRAPH <%2$s> {
+                    ?rev a npa:RoleRevocation ;
+                         npa:forSpace    ?revSpace ;
+                         npa:forAgent    ?agent ;
+                         npa:revokedRole gen:AdminRole ;
+                         npa:pubkeyHash  ?revPkh .
+                    OPTIONAL { ?rev <http://purl.org/dc/terms/created> ?revCreatedRaw . }
+                  }
+                  BIND(COALESCE(?revCreatedRaw, %4$s) AS ?revCreated)
+                  FILTER (?revCreated > ?candCreated
+                          || (?revCreated = ?candCreated && STR(?rev) > STR(?ri)))
+                  { %3$s }
+                }""", graph, SpacesVocab.SPACES_GRAPH,
+                "{ " + revokerAdminGraphBlock(graph) + " }\nUNION\n{ "
+                        + revokerSelfGraphBlock(graph) + " }",
+                EPOCH_DT);
+    }
+
+    /**
+     * Inline suppression filter for the attachment tiers ({@code attachmentValidationUpdate}
+     * and {@code presetAttachmentValidationUpdate}): rejects a {@code (targetRef, role)}
+     * attachment whose effective timestamp ({@code ?<createdVar>}) is out-ranked by a newer
+     * admin-authored {@code npa:RoleDetachment} (issue #129). Authority = admin of
+     * {@code ?targetRef} (matching who may attach). Non-sticky latest-wins: a newer
+     * attachment / preset assignment naturally re-attaches because its timestamp beats the
+     * detachment. The detachment's named space is matched against any IRI denoting
+     * {@code ?targetRef} (canonical or {@code owl:sameAs} alias).
+     *
+     * @param createdVar     bare name of the attachment's effective-created variable
+     * @param attachSubjVar  bare name of the attachment subject variable (for the STR tiebreak)
+     */
+    private static String roleDetachmentSuppressionFilter(IRI graph, String createdVar, String attachSubjVar) {
+        return String.format("""
+                FILTER NOT EXISTS {
+                  { GRAPH <%2$s> { ?targetRef npa:spaceIri ?detSpace . } }
+                  UNION
+                  { GRAPH <%1$s> { ?detSpace npa:sameAsSpace ?targetRef . } }
+                  GRAPH <%2$s> {
+                    ?det a npa:RoleDetachment ;
+                         npa:forSpace    ?detSpace ;
+                         npa:revokedRole ?role ;
+                         npa:pubkeyHash  ?detPkh .
+                    OPTIONAL { ?det <http://purl.org/dc/terms/created> ?detCreatedRaw . }
+                  }
+                  BIND(COALESCE(?detCreatedRaw, %5$s) AS ?detCreated)
+                  FILTER (?detCreated > ?%3$s
+                          || (?detCreated = ?%3$s && STR(?det) > STR(?%4$s)))
+                  GRAPH <%1$s> {
+                    ?detAcct a npa:AccountState ; npa:pubkey ?detPkh ; npa:agent ?detAgent .
+                    ?detAdminRI a gen:RoleInstantiation ;
+                                npa:forSpaceRef ?targetRef ;
+                                npa:inverseProperty gen:hasAdmin ;
+                                npa:forAgent ?detAgent .
+                  }
+                }""", graph, SpacesVocab.SPACES_GRAPH, createdVar, attachSubjVar, EPOCH_DT);
+    }
+
     /** Wraps {@link #runTierLoop} with tier-name context for logs/exceptions. */
     private int runTierLabeled(String tier, IRI graph, String sparqlUpdate) {
         try {
@@ -941,7 +1154,10 @@ public final class AuthorityResolver {
                         npa:forAgent        ?agent ;
                         npa:pubkeyHash      ?pkh ;
                         npa:viaNanopub      ?np .
+                    # Candidate grant timestamp for the admin-revocation latest-wins (#129).
+                    OPTIONAL { ?ri <http://purl.org/dc/terms/created> ?candCreatedRaw . }
                   }
+                  BIND(COALESCE(?candCreatedRaw, %9$s) AS ?candCreated)
                   # 3a. Mint the per-ref state subject: (?ri, ?spaceRef) → ?sri.
                   BIND(IRI(CONCAT(STR(?ri), "__", ENCODE_FOR_URI(STR(?spaceRef)))) AS ?sri)
                   %6$s
@@ -950,6 +1166,10 @@ public final class AuthorityResolver {
                     ?np npa:hasLoadNumber ?ln .
                     FILTER (?ln > %5$d)
                   }
+                  # 4a. Admin-revocation latest-wins (issue #129): suppress if a newer
+                  #     authorized admin revocation shadows (ref, agent) — unless ?agent is a
+                  #     root admin (constitutional exemption, overrides self-leave).
+                  %10$s
                   # 5. Dedup last — keyed on (ref, agent).
                   FILTER NOT EXISTS { GRAPH <%3$s> {
                     ?existing a gen:RoleInstantiation ;
@@ -966,7 +1186,9 @@ public final class AuthorityResolver {
                 lastProcessed,
                 invalidationFilter("np"),
                 spaceRefAliveFilter(),
-                NPA.GRAPH);
+                NPA.GRAPH,
+                EPOCH_DT,
+                adminRevocationSuppressionFilter(graph));
     }
 
     /**
@@ -1031,7 +1253,10 @@ public final class AuthorityResolver {
                         gen:hasRole  ?role ;
                         npa:pubkeyHash ?pkh ;
                         npa:viaNanopub ?np .
+                    # Attachment timestamp for the detachment latest-wins (issue #129).
+                    OPTIONAL { ?ra <http://purl.org/dc/terms/created> ?attCreatedRaw . }
                   }
+                  BIND(COALESCE(?attCreatedRaw, %8$s) AS ?attCreated)
                   GRAPH <%7$s> {
                     ?np npa:hasLoadNumber ?ln .
                     FILTER (?ln > %5$d)
@@ -1064,6 +1289,9 @@ public final class AuthorityResolver {
                   }
                   BIND(IRI(CONCAT(STR(?ra), "__", ENCODE_FOR_URI(STR(?targetRef)))) AS ?ra2)
                   %6$s
+                  # Detachment latest-wins (issue #129): suppress if a newer admin-authored
+                  # gen:detachedRole out-ranks this (ref, role) attachment.
+                  %9$s
                   FILTER NOT EXISTS { GRAPH <%3$s> {
                     ?existing a gen:RoleAssignment ;
                               npa:forSpaceRef ?targetRef ;
@@ -1077,7 +1305,9 @@ public final class AuthorityResolver {
                 SpacesVocab.SPACES_GRAPH,
                 lastProcessed,
                 invalidationFilter("np"),
-                NPA.GRAPH);
+                NPA.GRAPH,
+                EPOCH_DT,
+                roleDetachmentSuppressionFilter(graph, "attCreated", "ra"));
     }
 
     /**
@@ -1226,6 +1456,10 @@ public final class AuthorityResolver {
                   }
                   # 8. Defensive: drop if the assignment nanopub itself was hard-retracted.
                   %6$s
+                  # 8a. Detachment latest-wins (issue #129): suppress if a newer admin-authored
+                  #     gen:detachedRole out-ranks this preset-derived (ref, role) attachment.
+                  #     Non-sticky: a newer PresetAssignment (newer ?created) re-attaches.
+                  %10$s
                   # 9. Dedup last — keyed on (ref, role).
                   FILTER NOT EXISTS { GRAPH <%3$s> {
                     ?existing a gen:RoleAssignment ;
@@ -1242,7 +1476,8 @@ public final class AuthorityResolver {
                 invalidationFilter("assignNp"),
                 NPA.GRAPH,
                 invalidationFilter("pdNpNewer"),
-                invalidationFilter("pdNp"));
+                invalidationFilter("pdNp"),
+                roleDetachmentSuppressionFilter(graph, "created", "pa"));
     }
 
     /**
@@ -1516,7 +1751,11 @@ public final class AuthorityResolver {
                     ?ri a gen:RoleInstantiation ;
                         npa:pubkeyHash ?pkh ;
                         npa:viaNanopub ?np .
+                    # Candidate grant timestamp for the revocation latest-wins (issue #129);
+                    # absent ⇒ epoch (always loses).
+                    OPTIONAL { ?ri <http://purl.org/dc/terms/created> ?candCreatedRaw . }
                   }
+                  BIND(COALESCE(?candCreatedRaw, %11$s) AS ?candCreated)
                   # 5. Publisher constraint (incl. AccountState resolution).
                   GRAPH <%3$s> {
                     %8$s
@@ -1538,6 +1777,9 @@ public final class AuthorityResolver {
                   #    issue #112. Role IRIs are version-pinned, so the attached definition is
                   #    immutable regardless of the declaration nanopub's later lifecycle.
                   %6$s
+                  # 7a. Revocation latest-wins (issue #129): suppress if a newer authorized
+                  #     gen:RevokedRoleInstantiation shadows this (space, agent, role) key.
+                  %10$s
                   # 8. Dedup last — keyed on (ref, agent, nanopub).
                   FILTER NOT EXISTS { GRAPH <%3$s> {
                     ?existing a gen:RoleInstantiation ;
@@ -1555,7 +1797,9 @@ public final class AuthorityResolver {
                 invalidationFilter("np"),
                 tierClass,
                 publisherConstraint,
-                NPA.GRAPH);
+                NPA.GRAPH,
+                nonAdminRevocationSuppressionFilter(graph, tierClass),
+                EPOCH_DT);
     }
 
     /**
@@ -2567,6 +2811,228 @@ public final class AuthorityResolver {
                 }
                 """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
                 presetDeactivationCheckWhere(graph, lastProcessed));
+    }
+
+    /**
+     * WHERE clause matching a materialized <em>non-admin</em> {@code gen:RoleInstantiation}
+     * row whose {@code (forSpaceRef, forAgent, gen:hasRole)} key is shadowed by a newer
+     * authorized {@code npa:RoleRevocation} (issue #129). The grant timestamp comes from the
+     * originating instantiation in the extraction graph (the materialized row carries no
+     * {@code dct:created}); the revocation nanopub's load number must be in
+     * {@code (lastProcessed, ∞)} so only revocations new in this cycle trigger a delete.
+     * Authorization is keyed on the row's bound {@code ?tier} (the matrix: a strictly-higher
+     * tier in the ref, or self). Not an {@code npx:invalidates} check.
+     */
+    static String roleRevocationCheckWhere(IRI graph, long lastProcessed, IRI targetTier) {
+        return String.format("""
+                  GRAPH <%1$s> {
+                    ?ri2 a gen:RoleInstantiation ;
+                         npa:forSpaceRef ?spaceRef ;
+                         npa:forAgent    ?agent ;
+                         gen:hasRole     ?role ;
+                         npa:hasRoleType <%7$s> ;
+                         npa:viaNanopub  ?np .
+                  }
+                  OPTIONAL { GRAPH <%2$s> {
+                    ?riSrc npa:viaNanopub ?np ;
+                           <http://purl.org/dc/terms/created> ?candCreatedRaw .
+                  } }
+                  BIND(COALESCE(?candCreatedRaw, %5$s) AS ?candCreated)
+                  { GRAPH <%2$s> { ?spaceRef npa:spaceIri ?revSpace . } }
+                  UNION
+                  { GRAPH <%1$s> { ?revSpace npa:sameAsSpace ?spaceRef . } }
+                  GRAPH <%2$s> {
+                    ?rev a npa:RoleRevocation ;
+                         npa:forSpace    ?revSpace ;
+                         npa:forAgent    ?agent ;
+                         npa:revokedRole ?role ;
+                         npa:pubkeyHash  ?revPkh ;
+                         npa:viaNanopub  ?revNp .
+                    OPTIONAL { ?rev <http://purl.org/dc/terms/created> ?revCreatedRaw . }
+                  }
+                  BIND(COALESCE(?revCreatedRaw, %5$s) AS ?revCreated)
+                  GRAPH <%3$s> {
+                    ?revNp npa:hasLoadNumber ?lnRev .
+                    FILTER (?lnRev > %4$d)
+                  }
+                  FILTER (?revCreated > ?candCreated
+                          || (?revCreated = ?candCreated && STR(?rev) > STR(?ri2)))
+                  { %6$s }
+                """, graph, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed,
+                EPOCH_DT, revocationAuthorityArmsForTier(graph, targetTier), targetTier);
+    }
+
+    /**
+     * DELETE template removing a non-admin {@code gen:RoleInstantiation} row of {@code
+     * targetTier} shadowed by a newer authorized revocation (issue #129). Removes the whole
+     * row by subject. Run once per non-admin tier (maintainer/member/observer) so the
+     * authorization arms are the compile-time set for that tier — matching the inline
+     * suppression filter, no runtime {@code ?tier} (see {@link #revocationAuthorityArmsForTier}).
+     * Caller sets {@code needsFullRebuild} (a revoked maintainer/member is a sub-granting
+     * authority).
+     */
+    static String roleRevocationDelete(IRI graph, long lastProcessed, IRI targetTier) {
+        return String.format("""
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                DELETE { GRAPH <%3$s> {
+                  ?ri2 ?p ?o .
+                } }
+                WHERE {
+                  GRAPH <%3$s> { ?ri2 ?p ?o . }
+                %4$s
+                }
+                """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
+                roleRevocationCheckWhere(graph, lastProcessed, targetTier));
+    }
+
+    /**
+     * WHERE clause matching a materialized <em>admin</em> {@code gen:RoleInstantiation} row
+     * whose {@code (forSpaceRef, forAgent)} key is shadowed by a newer authorized admin
+     * {@code npa:RoleRevocation} ({@code revokedRole = gen:AdminRole}), authorized by an
+     * admin of the ref or by the agent itself. <b>Root admins are exempt</b> (constitutional,
+     * issue #129/#110): the nested {@code FILTER NOT EXISTS} on {@code npa:hasRootAdmin}
+     * makes the revocation inert. The revocation nanopub's load number must be in
+     * {@code (lastProcessed, ∞)}.
+     */
+    static String adminRevocationCheckWhere(IRI graph, long lastProcessed) {
+        return String.format("""
+                  GRAPH <%1$s> {
+                    ?sri a gen:RoleInstantiation ;
+                         npa:forSpaceRef     ?spaceRef ;
+                         npa:inverseProperty gen:hasAdmin ;
+                         npa:forAgent        ?agent ;
+                         npa:viaNanopub      ?np .
+                  }
+                  FILTER NOT EXISTS { GRAPH <%2$s> {
+                    ?rootDef a npa:SpaceDefinition ;
+                             npa:forSpaceRef  ?spaceRef ;
+                             npa:hasRootAdmin ?agent .
+                  } }
+                  OPTIONAL { GRAPH <%2$s> {
+                    ?riSrc npa:viaNanopub ?np ;
+                           <http://purl.org/dc/terms/created> ?candCreatedRaw .
+                  } }
+                  BIND(COALESCE(?candCreatedRaw, %5$s) AS ?candCreated)
+                  { GRAPH <%2$s> { ?spaceRef npa:spaceIri ?revSpace . } }
+                  UNION
+                  { GRAPH <%1$s> { ?revSpace npa:sameAsSpace ?spaceRef . } }
+                  GRAPH <%2$s> {
+                    ?rev a npa:RoleRevocation ;
+                         npa:forSpace    ?revSpace ;
+                         npa:forAgent    ?agent ;
+                         npa:revokedRole gen:AdminRole ;
+                         npa:pubkeyHash  ?revPkh ;
+                         npa:viaNanopub  ?revNp .
+                    OPTIONAL { ?rev <http://purl.org/dc/terms/created> ?revCreatedRaw . }
+                  }
+                  BIND(COALESCE(?revCreatedRaw, %5$s) AS ?revCreated)
+                  GRAPH <%3$s> {
+                    ?revNp npa:hasLoadNumber ?lnRev .
+                    FILTER (?lnRev > %4$d)
+                  }
+                  FILTER (?revCreated > ?candCreated
+                          || (?revCreated = ?candCreated && STR(?rev) > STR(?sri)))
+                  { %6$s }
+                """, graph, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed, EPOCH_DT,
+                "{ " + revokerAdminGraphBlock(graph) + " }\nUNION\n{ "
+                        + revokerSelfGraphBlock(graph) + " }");
+    }
+
+    /**
+     * DELETE template removing an admin {@code gen:RoleInstantiation} row shadowed by a newer
+     * authorized admin revocation (issue #129). Removes the whole row by subject.
+     * <b>Structural</b> — admin RIs feed every downstream tier — so the caller sets
+     * {@code npa:needsFullRebuild} (mirrors {@code adminInvalidationDelete}). The
+     * {@code adminTierUpdate} inline suppression filter prevents re-materialization.
+     */
+    static String adminRevocationDelete(IRI graph, long lastProcessed) {
+        return String.format("""
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                DELETE { GRAPH <%3$s> {
+                  ?sri ?p ?o .
+                } }
+                WHERE {
+                  GRAPH <%3$s> { ?sri ?p ?o . }
+                %4$s
+                }
+                """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
+                adminRevocationCheckWhere(graph, lastProcessed));
+    }
+
+    /**
+     * WHERE clause matching a materialized {@code gen:RoleAssignment} row (direct
+     * <em>or</em> preset-derived) whose {@code (forSpaceRef, gen:hasRole)} key is shadowed by
+     * a newer admin-authored {@code npa:RoleDetachment} (issue #129). The attachment
+     * timestamp comes from whichever extraction row shares the materialized row's
+     * {@code npa:viaNanopub} (a {@code RoleAssignment} for direct attachments, a
+     * {@code PresetAssignment} for preset-derived ones). The detachment nanopub's load number
+     * must be in {@code (lastProcessed, ∞)}; authority = admin of the ref.
+     */
+    static String roleDetachmentCheckWhere(IRI graph, long lastProcessed) {
+        return String.format("""
+                  GRAPH <%1$s> {
+                    ?ra2 a gen:RoleAssignment ;
+                         npa:forSpaceRef ?targetRef ;
+                         gen:hasRole     ?role ;
+                         npa:viaNanopub  ?np .
+                  }
+                  OPTIONAL { GRAPH <%2$s> {
+                    ?attSrc npa:viaNanopub ?np ;
+                            <http://purl.org/dc/terms/created> ?attCreatedRaw .
+                  } }
+                  BIND(COALESCE(?attCreatedRaw, %5$s) AS ?attCreated)
+                  { GRAPH <%2$s> { ?targetRef npa:spaceIri ?detSpace . } }
+                  UNION
+                  { GRAPH <%1$s> { ?detSpace npa:sameAsSpace ?targetRef . } }
+                  GRAPH <%2$s> {
+                    ?det a npa:RoleDetachment ;
+                         npa:forSpace    ?detSpace ;
+                         npa:revokedRole ?role ;
+                         npa:pubkeyHash  ?detPkh ;
+                         npa:viaNanopub  ?detNp .
+                    OPTIONAL { ?det <http://purl.org/dc/terms/created> ?detCreatedRaw . }
+                  }
+                  BIND(COALESCE(?detCreatedRaw, %5$s) AS ?detCreated)
+                  GRAPH <%3$s> {
+                    ?detNp npa:hasLoadNumber ?lnDet .
+                    FILTER (?lnDet > %4$d)
+                  }
+                  FILTER (?detCreated > ?attCreated
+                          || (?detCreated = ?attCreated && STR(?det) > STR(?ra2)))
+                  GRAPH <%1$s> {
+                    ?detAcct a npa:AccountState ; npa:pubkey ?detPkh ; npa:agent ?detAgent .
+                    ?detAdminRI a gen:RoleInstantiation ;
+                                npa:forSpaceRef ?targetRef ;
+                                npa:inverseProperty gen:hasAdmin ;
+                                npa:forAgent ?detAgent .
+                  }
+                """, graph, SpacesVocab.SPACES_GRAPH, NPA.GRAPH, lastProcessed, EPOCH_DT);
+    }
+
+    /**
+     * DELETE template removing a {@code gen:RoleAssignment} row (direct or preset-derived)
+     * shadowed by a newer admin-authored {@code gen:detachedRole} (issue #129). Removes the
+     * whole row by subject. <b>Structural</b> — instantiations anchored on the removed
+     * attachment are bounded by the periodic full rebuild (the cascade), so the caller sets
+     * {@code npa:needsFullRebuild}. The attachment-tier inline filters prevent
+     * re-materialization until a newer attachment / preset assignment out-ranks the detach
+     * (non-sticky).
+     */
+    static String roleDetachmentDelete(IRI graph, long lastProcessed) {
+        return String.format("""
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                DELETE { GRAPH <%3$s> {
+                  ?ra2 ?p ?o .
+                } }
+                WHERE {
+                  GRAPH <%3$s> { ?ra2 ?p ?o . }
+                %4$s
+                }
+                """, NPA.NAMESPACE, GEN.NAMESPACE, graph,
+                roleDetachmentCheckWhere(graph, lastProcessed));
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -70,6 +70,8 @@ public final class SpacesExtractor {
         s.add(GEN.IS_MAINTAINED_BY);
         s.add(GEN.PRESET);
         s.add(GEN.PRESET_ASSIGNMENT);
+        s.add(GEN.REVOKED_ROLE_INSTANTIATION);
+        s.add(GEN.DETACHED_ROLE);
         s.addAll(BackcompatRolePredicates.ALL);
         TRIGGER_TYPES = Collections.unmodifiableSet(s);
     }
@@ -141,6 +143,11 @@ public final class SpacesExtractor {
         // the assertion type even without a pubinfo npx:hasNanopubType marker.
         boolean isPreset = types.contains(GEN.PRESET);
         boolean isPresetAssignment = types.contains(GEN.PRESET_ASSIGNMENT);
+        // Role revocation (issue #129). RevokedRoleInstantiation is a typed node carrying
+        // gen:forSpace/forAgent/hasRole; gen:detachedRole is a single-predicate-assertion
+        // (auto-typed like gen:hasRole). Both emit key-level negatives, never state rows.
+        boolean isRevokedRoleInstantiation = types.contains(GEN.REVOKED_ROLE_INSTANTIATION);
+        boolean isDetachedRole = types.contains(GEN.DETACHED_ROLE);
 
         if (isSpace) {
             extractSpace(np, ctx, out);
@@ -165,6 +172,12 @@ public final class SpacesExtractor {
         }
         if (isPresetAssignment) {
             extractPresetAssignment(np, ctx, out);
+        }
+        if (isRevokedRoleInstantiation) {
+            extractRevokedRoleInstantiation(np, ctx, out);
+        }
+        if (isDetachedRole) {
+            extractDetachedRole(np, ctx, out);
         }
 
         return out;
@@ -915,6 +928,84 @@ public final class SpacesExtractor {
         out.add(vf.createStatement(subject, SpacesVocab.IS_ACTIVATED, vf.createLiteral(!deactivated), GRAPH));
         out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, np.getUri(), GRAPH));
         addProvenance(subject, ctx, out);
+    }
+
+    // ---------------- gen:RevokedRoleInstantiation (role revocation, issue #129) ----------------
+
+    /**
+     * A {@code gen:RevokedRoleInstantiation} nanopub asserts that an agent no longer holds a
+     * role in a space (a key-level negative on {@code (space, agent, role)}). The assertion
+     * shape is a typed node:
+     * <pre>{@code :r a gen:RevokedRoleInstantiation ; gen:forSpace <s> ; gen:forAgent <a> ; gen:hasRole <role> .}</pre>
+     * For an <em>admin</em> revocation the role is {@code gen:AdminRole} (the admin tier carries
+     * no per-role IRI), so the same shape covers every tier. Emits one {@code npa:RoleRevocation}
+     * row per revoked node; the {@code dct:created} from {@link #addProvenance} is the latest-wins
+     * key the materializer uses to decide whether this negative shadows the standing assertion.
+     * This negative never materializes as a state row — it is consumed as a suppression filter /
+     * displacement DELETE in the tier where the key is bound.
+     */
+    private static void extractRevokedRoleInstantiation(Nanopub np, Context ctx, List<Statement> out) {
+        // One pass over the assertion: index IRI-valued (subject -> predicate -> object) and
+        // collect the RevokedRoleInstantiation-typed nodes. Avoids the quadratic re-scan a
+        // per-node singleIriObject lookup would incur on a multi-revocation nanopub.
+        Map<IRI, Map<IRI, IRI>> bySubject = new LinkedHashMap<>();
+        List<IRI> revokedNodes = new ArrayList<>();
+        for (Statement st : np.getAssertion()) {
+            if (!(st.getSubject() instanceof IRI s) || !(st.getObject() instanceof IRI o)) {
+                continue;
+            }
+            bySubject.computeIfAbsent(s, k -> new LinkedHashMap<>()).putIfAbsent(st.getPredicate(), o);
+            if (st.getPredicate().equals(RDF.TYPE) && GEN.REVOKED_ROLE_INSTANTIATION.equals(o)) {
+                revokedNodes.add(s);
+            }
+        }
+        for (IRI node : revokedNodes) {
+            Map<IRI, IRI> props = bySubject.getOrDefault(node, Map.of());
+            IRI space = props.get(GEN.FOR_SPACE);
+            IRI agent = props.get(GEN.FOR_AGENT);
+            IRI role = props.get(GEN.HAS_ROLE);
+            if (space == null || agent == null || role == null) {
+                logger.warn("Ignoring role revocation node {} in {}: missing forSpace/forAgent/hasRole",
+                        node, np.getUri());
+                continue;
+            }
+            // Separator that cannot appear in an IRI (newline) so distinct (agent, role) pairs
+            // in the same nanopub never collide onto one nparev: subject.
+            String discriminator = Utils.createHash(agent.stringValue() + "\n" + role.stringValue());
+            IRI subject = SpacesVocab.forRoleRevocation(ctx.artifactCode(), discriminator);
+            out.add(vf.createStatement(subject, RDF.TYPE, SpacesVocab.ROLE_REVOCATION, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.FOR_SPACE, space, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.FOR_AGENT, agent, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.REVOKED_ROLE, role, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, np.getUri(), GRAPH));
+            addProvenance(subject, ctx, out);
+        }
+    }
+
+    // ---------------- gen:detachedRole (role detachment, issue #129) ----------------
+
+    /**
+     * A {@code gen:detachedRole} nanopub asserts {@code <space> gen:detachedRole <role>} — the
+     * stative antonym of {@code gen:hasRole}, a key-level negative on {@code (space, role)}.
+     * Emits one {@code npa:RoleDetachment} row per triple; latest-wins (by {@code dct:created})
+     * against direct <em>and</em> preset-derived attachments removes the role's availability in
+     * the space, cascading to the instantiations anchored on it. Never materializes as a state row.
+     */
+    private static void extractDetachedRole(Nanopub np, Context ctx, List<Statement> out) {
+        for (Statement st : np.getAssertion()) {
+            if (!st.getPredicate().equals(GEN.DETACHED_ROLE)
+                || !(st.getSubject() instanceof IRI spaceIri)
+                || !(st.getObject() instanceof IRI roleIri)) {
+                continue;
+            }
+            String roleHash = Utils.createHash(roleIri.stringValue());
+            IRI subject = SpacesVocab.forRoleDetachment(ctx.artifactCode(), roleHash);
+            out.add(vf.createStatement(subject, RDF.TYPE, SpacesVocab.ROLE_DETACHMENT, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.FOR_SPACE, spaceIri, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.REVOKED_ROLE, roleIri, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, np.getUri(), GRAPH));
+            addProvenance(subject, ctx, out);
+        }
     }
 
     /** Collects all IRI objects of {@code subject predicate ?o} triples in the assertion. */

--- a/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
@@ -142,6 +142,35 @@ public class GEN {
      */
     public static final IRI APPLIES_TO_INSTANCES_OF = VocabUtils.createIRI(NAMESPACE, "appliesToInstancesOf");
 
+    // ---------------- Role revocation (issue #129) ----------------
+
+    /**
+     * Class IRI for an instantiation revocation: a key-level negative assertion that
+     * an agent no longer holds a role in a space, however it was granted. Mirrors
+     * {@link #DEACTIVATED_PRESET_ASSIGNMENT} — active-by-default, resolved by
+     * authorization-scoped latest-wins on {@code dct:created}, <em>not</em>
+     * {@code npx:invalidates} (which stays for nanopub-level undo). Carries
+     * {@code forSpace}, {@code forAgent}, and {@link #HAS_ROLE} (the version-pinned
+     * role IRI; {@link #ADMIN_ROLE} for admin revocations). See
+     * {@code doc/design-space-repositories.md}.
+     */
+    public static final IRI REVOKED_ROLE_INSTANTIATION = VocabUtils.createIRI(NAMESPACE, "RevokedRoleInstantiation");
+
+    /** Predicate on a {@link #REVOKED_ROLE_INSTANTIATION} naming the space whose role is revoked. */
+    public static final IRI FOR_SPACE = VocabUtils.createIRI(NAMESPACE, "forSpace");
+
+    /** Predicate on a {@link #REVOKED_ROLE_INSTANTIATION} naming the agent whose role is revoked. */
+    public static final IRI FOR_AGENT = VocabUtils.createIRI(NAMESPACE, "forAgent");
+
+    /**
+     * Predicate detaching a role from a space ({@code <space> gen:detachedRole <role>}):
+     * the stative antonym of {@link #HAS_ROLE}, keyed on {@code (space, role)}. A winning
+     * (admin-authored, latest-wins) detachment removes the role's availability, so direct
+     * <em>and</em> preset-derived attachments and the instantiations anchored on them drop
+     * out. Single-predicate-assertion auto-typed like {@code gen:hasRole}.
+     */
+    public static final IRI DETACHED_ROLE = VocabUtils.createIRI(NAMESPACE, "detachedRole");
+
     private GEN() {
     }
 

--- a/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/SpacesVocab.java
@@ -50,6 +50,10 @@ public final class SpacesVocab {
     public static final String NPAPA_NAMESPACE = "http://purl.org/nanopub/admin/presetassign/";
     /** Namespace for preset-declaration entries ({@code npapd:<artifactCode>}). */
     public static final String NPAPD_NAMESPACE = "http://purl.org/nanopub/admin/presetdecl/";
+    /** Namespace for role-revocation entries ({@code nparev:<artifactCode>_<discriminatorHash>}). */
+    public static final String NPAREV_NAMESPACE = "http://purl.org/nanopub/admin/rolerevoc/";
+    /** Namespace for role-detachment entries ({@code npadet:<artifactCode>_<roleHash>}). */
+    public static final String NPADET_NAMESPACE = "http://purl.org/nanopub/admin/roledetach/";
     /** Namespace for space-state graph IRIs ({@code npass:<trustStateHash>_<loadCounter>}). */
     public static final String NPASS_NAMESPACE = "http://purl.org/nanopub/admin/spacestate/";
 
@@ -78,6 +82,21 @@ public final class SpacesVocab {
 
     /** RDF type for a preset-declaration extraction entry (from a {@code gen:Preset} nanopub). */
     public static final IRI PRESET_DECLARATION = vf.createIRI(NPA.NAMESPACE, "PresetDeclaration");
+
+    /**
+     * RDF type for a role-revocation extraction entry (from a {@code gen:RevokedRoleInstantiation}
+     * nanopub). A key-level negative on {@code (forSpace, forAgent, revokedRole)}; never
+     * materializes as a state row — consumed as a suppression filter / displacement DELETE in the
+     * tier where the key is bound. See {@code doc/design-space-repositories.md} (issue #129).
+     */
+    public static final IRI ROLE_REVOCATION = vf.createIRI(NPA.NAMESPACE, "RoleRevocation");
+
+    /**
+     * RDF type for a role-detachment extraction entry (from a {@code gen:detachedRole} triple).
+     * A key-level negative on {@code (forSpace, revokedRole)}; competes against both direct and
+     * preset-derived attachments by latest-wins. See issue #129.
+     */
+    public static final IRI ROLE_DETACHMENT = vf.createIRI(NPA.NAMESPACE, "RoleDetachment");
 
     // -------- Properties on extraction entries --------
 
@@ -138,6 +157,14 @@ public final class SpacesVocab {
 
     /** Tier class of a {@link #ROLE_DECLARATION}: gen:MaintainerRole / MemberRole / ObserverRole. */
     public static final IRI HAS_ROLE_TYPE = vf.createIRI(NPA.NAMESPACE, "hasRoleType");
+
+    /**
+     * The role IRI carried by a {@link #ROLE_REVOCATION} or {@link #ROLE_DETACHMENT} negative
+     * entry — the version-pinned role being revoked/detached ({@code gen:AdminRole} for admin
+     * revocations). Matched against a materialized RI's {@code gen:hasRole} / admin
+     * {@code npa:hasRoleType gen:AdminRole}, or an attachment's {@code gen:hasRole}.
+     */
+    public static final IRI REVOKED_ROLE = vf.createIRI(NPA.NAMESPACE, "revokedRole");
 
     /** Links a {@link #SUB_SPACE_DECLARATION} to the child Space IRI. */
     public static final IRI CHILD_SPACE = vf.createIRI(NPA.NAMESPACE, "childSpace");
@@ -314,6 +341,30 @@ public final class SpacesVocab {
     /** Mints {@code npapd:<artifactCode>} for a preset-declaration entry. */
     public static IRI forPresetDeclaration(String artifactCode) {
         return vf.createIRI(NPAPD_NAMESPACE, artifactCode);
+    }
+
+    /**
+     * Mints {@code nparev:<artifactCode>_<discriminatorHash>} for a role-revocation entry.
+     * Including a discriminator hash (on {@code <agent>+<role>}) lets a single nanopub revoke
+     * multiple {@code (agent, role)} keys without subject collision.
+     *
+     * @param artifactCode     trusty-URI artifact code of the originating nanopub
+     * @param discriminatorHash {@code Utils.createHash(<agentIri> + <roleIri>)}
+     */
+    public static IRI forRoleRevocation(String artifactCode, String discriminatorHash) {
+        return vf.createIRI(NPAREV_NAMESPACE, artifactCode + "_" + discriminatorHash);
+    }
+
+    /**
+     * Mints {@code npadet:<artifactCode>_<roleHash>} for a role-detachment entry.
+     * Including the role-IRI hash lets a single nanopub detach multiple roles without
+     * subject collision.
+     *
+     * @param artifactCode trusty-URI artifact code of the originating nanopub
+     * @param roleHash     {@code Utils.createHash(<roleIri>)}
+     */
+    public static IRI forRoleDetachment(String artifactCode, String roleHash) {
+        return vf.createIRI(NPADET_NAMESPACE, artifactCode + "_" + roleHash);
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverRevocationBehaviorTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverRevocationBehaviorTest.java
@@ -1,0 +1,384 @@
+package com.knowledgepixels.query;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.vocabulary.NPA;
+
+import com.knowledgepixels.query.vocabulary.GEN;
+import com.knowledgepixels.query.vocabulary.SpacesVocab;
+
+/**
+ * End-to-end execution tests for role revocation / detachment (issue #129), run against an
+ * in-memory store the same way {@link AuthorityResolverTierIsolationTest} exercises the
+ * downstream tiers. Validates the runtime SPARQL behaviour the string-contract tests in
+ * {@link AuthorityResolverRevocationTest} can't: the authorization-scoped latest-wins, the
+ * per-tier authority matrix, the root-admin exemption, and the displacement deletes.
+ */
+class AuthorityResolverRevocationBehaviorTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+    private static final IRI STATE = SpacesVocab.forSpaceState(
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", 1L);
+    private static final IRI SPACES = SpacesVocab.SPACES_GRAPH;
+    private static final IRI ADMINGRAPH = NPA.GRAPH;
+
+    private static IRI npa(String ln) { return vf.createIRI(NPA.NAMESPACE, ln); }
+    private static IRI ex(String ln)  { return vf.createIRI("http://example.org/", ln); }
+
+    private static final IRI S      = ex("space-S");
+    private static final IRI R1     = ex("ref-R1");
+    private static final IRI ALICE  = ex("alice");     // admin of R1
+    private static final IRI DAVE   = ex("dave");      // root admin of R1
+    private static final Literal PKH_A = vf.createLiteral("pkhA");   // Alice
+    private static final Literal PKH_D = vf.createLiteral("pkhD");   // Dave (root)
+
+    private static final IRI ROLE_X = ex("roleX");
+    private static final IRI PRED   = ex("hasMember");
+    private static final Date OLD = new Date(1_000_000L);
+    private static final Date NEW = new Date(2_000_000L);
+
+    private Repository repo;
+    private RepositoryConnection c;
+
+    @BeforeEach
+    void setUp() {
+        repo = new SailRepository(new MemoryStore());
+        repo.init();
+        c = repo.getConnection();
+        refIri(R1, S);
+        account("acctA", ALICE, PKH_A);
+        account("acctD", DAVE, PKH_D);
+        admin("adm_a", R1, S, ALICE);
+        // Dave is a root admin (constitutional) AND materialized as an admin RI.
+        admin("adm_d", R1, S, DAVE);
+        c.add(ex("def_R1"), RDF.TYPE, SpacesVocab.SPACE_DEFINITION, SPACES);
+        c.add(ex("def_R1"), SpacesVocab.FOR_SPACE_REF, R1, SPACES);
+        c.add(ex("def_R1"), SpacesVocab.HAS_ROOT_ADMIN, DAVE, SPACES);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (c != null) c.close();
+        if (repo != null) repo.shutDown();
+    }
+
+    // ---------------- non-admin instantiation revocation: inline suppression ----------------
+
+    @Test
+    void memberRevocation_newerThanGrant_isSuppressed() {
+        seedMemberGrant(ex("mallory"), OLD);
+        revocation("rev1", ex("mallory"), ROLE_X, PKH_A, NEW);   // admin-authored, newer
+        runMemberTier();
+        assertFalse(memberInRef(ex("mallory")),
+                "a newer admin-authored revocation suppresses the member grant");
+    }
+
+    @Test
+    void memberReassignment_newerThanRevocation_wins() {
+        seedMemberGrant(ex("mallory"), NEW);                     // grant is the newer assertion
+        revocation("rev1", ex("mallory"), ROLE_X, PKH_A, OLD);   // older revocation loses
+        runMemberTier();
+        assertTrue(memberInRef(ex("mallory")),
+                "a re-assignment newer than the revocation re-grants the role");
+    }
+
+    @Test
+    void memberRevocation_byUnauthorizedKey_isIgnored() {
+        seedMemberGrant(ex("mallory"), OLD);
+        account("acctNobody", ex("nobody"), vf.createLiteral("pkhN"));   // holds no role
+        revocation("rev1", ex("mallory"), ROLE_X, vf.createLiteral("pkhN"), NEW);
+        runMemberTier();
+        assertTrue(memberInRef(ex("mallory")),
+                "a revocation from a key with no qualifying tier does not suppress");
+    }
+
+    @Test
+    void memberRevocation_byMaintainer_isAuthorized() {
+        seedMemberGrant(ex("mallory"), OLD);
+        // A maintainer of R1 (not admin) authors the revocation — allowed for the member tier.
+        account("acctMaint", ex("mona"), vf.createLiteral("pkhM"));
+        tierRI("mri", R1, ex("mona"), GEN.MAINTAINER_ROLE);
+        revocation("rev1", ex("mallory"), ROLE_X, vf.createLiteral("pkhM"), NEW);
+        runMemberTier();
+        assertFalse(memberInRef(ex("mallory")),
+                "a maintainer may revoke a member (matrix), even via the admin-pub arm");
+    }
+
+    @Test
+    void observerSelfLeave_isAuthorized() {
+        // Observer grant for mallory, then mallory revokes their own role (self-leave).
+        seedObserverGrant(ex("mallory"), OLD);
+        account("acctMallory", ex("mallory"), vf.createLiteral("pkhMal"));
+        revocation("rev1", ex("mallory"), ROLE_X, vf.createLiteral("pkhMal"), NEW);
+        runToFixpoint(AuthorityResolver.nonAdminTierUpdate(
+                STATE, -1, GEN.OBSERVER_ROLE, AuthorityResolver.PUBLISHER_IS_ADMIN));
+        assertFalse(memberInRef(ex("mallory")), "an agent may always leave its own role");
+    }
+
+    // ---------------- non-admin instantiation revocation: displacement delete ----------------
+
+    @Test
+    void memberRevocation_displacesAlreadyMaterializedRow() {
+        seedMemberGrant(ex("mallory"), OLD);
+        runMemberTier();
+        assertTrue(memberInRef(ex("mallory")), "precondition: member materialized");
+        // Revocation arrives in a later cycle; the displacement DELETE removes the row.
+        revocation("rev1", ex("mallory"), ROLE_X, PKH_A, NEW);
+        executeUpdate(AuthorityResolver.roleRevocationDelete(STATE, -1, GEN.MEMBER_ROLE));
+        assertFalse(memberInRef(ex("mallory")),
+                "displacement delete removes an already-materialized revoked member");
+    }
+
+    // ---------------- detachment ----------------
+
+    @Test
+    void roleDetachment_displacesAttachment() {
+        extAttachment("att1", S, ROLE_X, PKH_A, ex("np_att"), OLD);
+        runToFixpoint(AuthorityResolver.attachmentValidationUpdate(STATE, -1));
+        assertTrue(hasAssignment(R1, ROLE_X), "precondition: attachment materialized");
+        detachment("det1", ROLE_X, PKH_A, NEW);                  // admin-authored, newer
+        executeUpdate(AuthorityResolver.roleDetachmentDelete(STATE, -1));
+        assertFalse(hasAssignment(R1, ROLE_X),
+                "a newer admin-authored detachment removes the attachment");
+    }
+
+    // ---------------- admin revocation + root-admin exemption ----------------
+
+    @Test
+    void adminRevocation_removesPlainAdmin_butExemptsRootAdmin() {
+        // Carol (a plain admin) revokes both Alice (plain admin) and Dave (root admin). The
+        // seeded admin RIs are given a viaNanopub + extraction-side dct:created so the delete's
+        // candidate-timestamp join resolves. Alice's row is removed; Dave's is exempt (root).
+        IRI carol = ex("carol");
+        Literal pkhC = vf.createLiteral("pkhC");
+        account("acctC", carol, pkhC);
+        admin("adm_c", R1, S, carol);
+        attachAdminSource(ex("adm_a"), "anp_a", OLD);   // Alice's seeded admin RI
+        attachAdminSource(ex("adm_d"), "anp_d", OLD);   // Dave's seeded admin RI
+        adminRevocation("revA", ALICE, pkhC, NEW);      // Carol revokes Alice
+        adminRevocation("revD", DAVE, pkhC, NEW);       // Carol revokes Dave (root)
+        executeUpdate(AuthorityResolver.adminRevocationDelete(STATE, -1));
+
+        assertFalse(adminInRef(ALICE), "a plain admin is removed by a peer admin's revocation");
+        assertTrue(adminInRef(DAVE), "a root admin is constitutional — revocation is inert");
+    }
+
+    // ---------------- read-path canary (published consumer queries) ----------------
+
+    @Test
+    void canary_getSpaceMembers_validatedFlagFlipsFalseOnRevocation() {
+        // The published get-space-members query (knowledgepixels/nanodash, GET_SPACE_MEMBERS)
+        // computes ?validated via EXISTS over the CURRENT space-state graph:
+        //   graph ?g { ?vri a gen:RoleInstantiation ; npa:forSpaceRef ?ref ;
+        //                    npa:forAgent ?member ; npa:viaNanopub ?np }
+        // A revoked member must flip ?validated true -> false (the member still lists from the
+        // raw spacesGraph, but is flagged unvalidated). No query change is needed.
+        seedMemberGrant(ex("mallory"), OLD);
+        runMemberTier();
+        assertTrue(memberValidated(ex("mallory"), ex("np_m")),
+                "precondition: member is validated in the state graph");
+        revocation("rev1", ex("mallory"), ROLE_X, PKH_A, NEW);
+        executeUpdate(AuthorityResolver.roleRevocationDelete(STATE, -1, GEN.MEMBER_ROLE));
+        assertFalse(memberValidated(ex("mallory"), ex("np_m")),
+                "get-space-members ?validated flips to false for a revoked member");
+    }
+
+    @Test
+    void canary_getSpaceRoles_roleDisappearsOnDetachment() {
+        // The published get-space-roles query reads gen:RoleAssignment rows from the current
+        // space-state graph (npa:forSpaceRef ?ref ; gen:hasRole ?role). A detached role must
+        // disappear from that listing. No query change is needed.
+        extAttachment("att1", S, ROLE_X, PKH_A, ex("np_att"), OLD);
+        runToFixpoint(AuthorityResolver.attachmentValidationUpdate(STATE, -1));
+        assertTrue(hasAssignment(R1, ROLE_X), "precondition: role listed for the ref");
+        detachment("det1", ROLE_X, PKH_A, NEW);
+        executeUpdate(AuthorityResolver.roleDetachmentDelete(STATE, -1));
+        assertFalse(hasAssignment(R1, ROLE_X),
+                "get-space-roles no longer lists a detached role");
+    }
+
+    // ---------------- seeding helpers ----------------
+
+    private void refIri(IRI ref, IRI iri) { c.add(ref, SpacesVocab.SPACE_IRI, iri, SPACES); }
+
+    private void account(String name, IRI agent, Literal pkh) {
+        IRI a = ex(name);
+        c.add(a, RDF.TYPE, npa("AccountState"), STATE);
+        c.add(a, npa("agent"), agent, STATE);
+        c.add(a, npa("pubkey"), pkh, STATE);
+    }
+
+    private void admin(String name, IRI ref, IRI iri, IRI agent) {
+        IRI ri = ex(name);
+        c.add(ri, RDF.TYPE, GEN.ROLE_INSTANTIATION, STATE);
+        c.add(ri, SpacesVocab.FOR_SPACE_REF, ref, STATE);
+        c.add(ri, SpacesVocab.FOR_SPACE, iri, STATE);
+        c.add(ri, SpacesVocab.INVERSE_PROPERTY, GEN.HAS_ADMIN, STATE);
+        c.add(ri, SpacesVocab.FOR_AGENT, agent, STATE);
+    }
+
+    /** A materialized non-admin RI carrying npa:hasRoleType (used to qualify a revoker). */
+    private void tierRI(String name, IRI ref, IRI agent, IRI tier) {
+        IRI ri = ex(name);
+        c.add(ri, RDF.TYPE, GEN.ROLE_INSTANTIATION, STATE);
+        c.add(ri, SpacesVocab.FOR_SPACE_REF, ref, STATE);
+        c.add(ri, SpacesVocab.FOR_AGENT, agent, STATE);
+        c.add(ri, SpacesVocab.HAS_ROLE_TYPE, tier, STATE);
+    }
+
+    private void loadNum(IRI np) { c.add(np, npa("hasLoadNumber"), vf.createLiteral(0L), ADMINGRAPH); }
+
+    private void extAttachment(String name, IRI iri, IRI role, Literal pkh, IRI np, Date created) {
+        IRI ra = ex(name);
+        c.add(ra, RDF.TYPE, GEN.ROLE_ASSIGNMENT, SPACES);
+        c.add(ra, SpacesVocab.FOR_SPACE, iri, SPACES);
+        c.add(ra, GEN.HAS_ROLE, role, SPACES);
+        c.add(ra, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(ra, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        c.add(ra, DCTERMS.CREATED, vf.createLiteral(created), SPACES);
+        loadNum(np);
+    }
+
+    private void roleDecl(String name, IRI role, IRI tier, IRI dirDeclProp, IRI pred, IRI np) {
+        IRI rd = ex(name);
+        c.add(rd, RDF.TYPE, SpacesVocab.ROLE_DECLARATION, SPACES);
+        c.add(rd, SpacesVocab.HAS_ROLE_TYPE, tier, SPACES);
+        c.add(rd, SpacesVocab.ROLE, role, SPACES);
+        c.add(rd, dirDeclProp, pred, SPACES);
+        c.add(rd, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        loadNum(np);
+    }
+
+    private void extInstantiation(String name, IRI iri, IRI agent, IRI pred, Literal pkh, IRI np, Date created) {
+        IRI ri = ex(name);
+        c.add(ri, RDF.TYPE, GEN.ROLE_INSTANTIATION, SPACES);
+        c.add(ri, SpacesVocab.FOR_SPACE, iri, SPACES);
+        c.add(ri, SpacesVocab.FOR_AGENT, agent, SPACES);
+        c.add(ri, SpacesVocab.INVERSE_PROPERTY, pred, SPACES);
+        c.add(ri, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(ri, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        c.add(ri, DCTERMS.CREATED, vf.createLiteral(created), SPACES);
+        loadNum(np);
+    }
+
+    /** Seeds a complete admin-authored member grant for {@code agent} (created at {@code d}). */
+    private void seedMemberGrant(IRI agent, Date d) {
+        extAttachment("att1", S, ROLE_X, PKH_A, ex("np_att"), OLD);
+        runToFixpoint(AuthorityResolver.attachmentValidationUpdate(STATE, -1));
+        roleDecl("rd1", ROLE_X, GEN.MEMBER_ROLE, GEN.HAS_INVERSE_PROPERTY, PRED, ex("np_rd"));
+        extInstantiation("ri_m", S, agent, PRED, PKH_A, ex("np_m"), d);
+    }
+
+    private void seedObserverGrant(IRI agent, Date d) {
+        extAttachment("att1", S, ROLE_X, PKH_A, ex("np_att"), OLD);
+        runToFixpoint(AuthorityResolver.attachmentValidationUpdate(STATE, -1));
+        roleDecl("rd1", ROLE_X, GEN.OBSERVER_ROLE, GEN.HAS_INVERSE_PROPERTY, PRED, ex("np_rd"));
+        extInstantiation("ri_o", S, agent, PRED, PKH_A, ex("np_o"), d);
+    }
+
+    private void runMemberTier() {
+        runToFixpoint(AuthorityResolver.nonAdminTierUpdate(
+                STATE, -1, GEN.MEMBER_ROLE, AuthorityResolver.PUBLISHER_IS_ADMIN));
+    }
+
+    private void revocation(String name, IRI agent, IRI role, Literal pkh, Date created) {
+        IRI r = ex(name);
+        IRI np = ex(name + "_np");
+        c.add(r, RDF.TYPE, SpacesVocab.ROLE_REVOCATION, SPACES);
+        c.add(r, SpacesVocab.FOR_SPACE, S, SPACES);
+        c.add(r, SpacesVocab.FOR_AGENT, agent, SPACES);
+        c.add(r, SpacesVocab.REVOKED_ROLE, role, SPACES);
+        c.add(r, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(r, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        c.add(r, DCTERMS.CREATED, vf.createLiteral(created), SPACES);
+        loadNum(np);
+    }
+
+    private void detachment(String name, IRI role, Literal pkh, Date created) {
+        IRI d = ex(name);
+        IRI np = ex(name + "_np");
+        c.add(d, RDF.TYPE, SpacesVocab.ROLE_DETACHMENT, SPACES);
+        c.add(d, SpacesVocab.FOR_SPACE, S, SPACES);
+        c.add(d, SpacesVocab.REVOKED_ROLE, role, SPACES);
+        c.add(d, SpacesVocab.PUBKEY_HASH, pkh, SPACES);
+        c.add(d, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        c.add(d, DCTERMS.CREATED, vf.createLiteral(created), SPACES);
+        loadNum(np);
+    }
+
+    /** Gives an already-seeded admin RI a viaNanopub + an extraction-side dct:created source. */
+    private void attachAdminSource(IRI adminRi, String npName, Date created) {
+        IRI np = ex(npName);
+        c.add(adminRi, SpacesVocab.VIA_NANOPUB, np, STATE);
+        IRI src = ex(npName + "_src");
+        c.add(src, SpacesVocab.VIA_NANOPUB, np, SPACES);
+        c.add(src, DCTERMS.CREATED, vf.createLiteral(created), SPACES);
+        loadNum(np);
+    }
+
+    private void adminRevocation(String name, IRI agent, Literal pkh, Date created) {
+        revocation(name, agent, GEN.ADMIN_ROLE, pkh, created);
+    }
+
+    // ---------------- execution + assertions ----------------
+
+    private void runToFixpoint(String update) {
+        long before = c.size(STATE);
+        while (true) {
+            c.prepareUpdate(QueryLanguage.SPARQL, update).execute();
+            long after = c.size(STATE);
+            if (after <= before) break;
+            before = after;
+        }
+    }
+
+    private void executeUpdate(String update) {
+        c.prepareUpdate(QueryLanguage.SPARQL, update).execute();
+    }
+
+    private boolean hasAssignment(IRI ref, IRI role) {
+        return ask("?ra a gen:RoleAssignment ; npa:forSpaceRef <" + ref + "> ; gen:hasRole <" + role + "> .");
+    }
+
+    private boolean memberInRef(IRI agent) {
+        return ask("?ri a gen:RoleInstantiation ; npa:forSpaceRef <" + R1 + "> ; npa:forAgent <" + agent + "> ."
+                + " FILTER NOT EXISTS { ?ri npa:inverseProperty gen:hasAdmin }");
+    }
+
+    /** The published get-space-members ?validated EXISTS check, against the state graph. */
+    private boolean memberValidated(IRI agent, IRI viaNp) {
+        return ask("?vri a gen:RoleInstantiation ; npa:forSpaceRef <" + R1 + "> ;"
+                + " npa:forAgent <" + agent + "> ; npa:viaNanopub <" + viaNp + "> ."
+                + " FILTER NOT EXISTS { ?vri npa:inverseProperty gen:hasAdmin }");
+    }
+
+    private boolean adminInRef(IRI agent) {
+        return ask("?ri a gen:RoleInstantiation ; npa:forSpaceRef <" + R1 + "> ; npa:forAgent <" + agent + "> ;"
+                + " npa:inverseProperty gen:hasAdmin .");
+    }
+
+    private boolean ask(String pattern) {
+        return c.prepareBooleanQuery(QueryLanguage.SPARQL, """
+                PREFIX npa: <%1$s>
+                PREFIX gen: <%2$s>
+                ASK { GRAPH <%3$s> { %4$s } }
+                """.formatted(NPA.NAMESPACE, GEN.NAMESPACE, STATE, pattern)).evaluate();
+    }
+}

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverRevocationTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverRevocationTest.java
@@ -1,0 +1,201 @@
+package com.knowledgepixels.query;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Pattern;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.junit.jupiter.api.Test;
+
+import com.knowledgepixels.query.vocabulary.GEN;
+import com.knowledgepixels.query.vocabulary.SpacesVocab;
+
+/**
+ * Pure-logic (SPARQL string-contract) tests for role revocation / detachment (issue #129).
+ * Like {@link AuthorityResolverTest}, these assert the structure of the generated SPARQL
+ * templates — the full-cycle behaviour runs against a live deployment (see the test-class
+ * javadoc on {@link AuthorityResolverTest} for why the in-memory store can't exercise
+ * pattern-delete / cross-graph UPDATE here).
+ */
+class AuthorityResolverRevocationTest {
+
+    private static final IRI G = SpacesVocab.forSpaceState(
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", 42L);
+
+    private static final String MAINT = Pattern.quote(GEN.MAINTAINER_ROLE.stringValue());
+    private static final String MEMB = Pattern.quote(GEN.MEMBER_ROLE.stringValue());
+
+    /** Revoker-tier arm: {@code ?revRI ... npa:forAgent ?revAgent ; npa:hasRoleType <tier>}. */
+    private static Pattern revokerTierArm(String tierIriQuoted) {
+        return Pattern.compile("npa:forAgent\\s+\\?revAgent\\s*;\\s*npa:hasRoleType\\s+<" + tierIriQuoted + ">");
+    }
+
+    private static final Pattern ADMIN_REVOKER_ARM = Pattern.compile(
+            "npa:inverseProperty\\s+gen:hasAdmin\\s*;\\s*npa:forAgent\\s+\\?revAgent");
+    private static final Pattern SELF_REVOKER_ARM = Pattern.compile(
+            "npa:pubkey\\s+\\?revPkh\\s*;\\s*npa:agent\\s+\\?agent");
+
+    // ---------------- non-admin instantiation revocation ----------------
+
+    @Test
+    void nonAdminTierUpdate_memberContainsRevocationSuppression() {
+        String sparql = AuthorityResolver.nonAdminTierUpdate(
+                G, 0, GEN.MEMBER_ROLE, AuthorityResolver.PUBLISHER_IS_ADMIN);
+        assertTrue(sparql.contains("npa:RoleRevocation"), "suppresses on a RoleRevocation negative");
+        assertTrue(sparql.contains("npa:revokedRole ?role"), "keyed on the revoked role");
+        assertTrue(sparql.contains("?revCreated > ?candCreated"),
+                "latest-wins on dct:created (revocation vs grant)");
+        assertTrue(sparql.contains("COALESCE(?revCreatedRaw")
+                && sparql.contains("COALESCE(?candCreatedRaw"),
+                "missing dct:created treated as epoch on both sides (decision #3)");
+        assertTrue(sparql.contains("1970-01-01T00:00:00.000Z"), "epoch fallback literal present");
+        assertTrue(ADMIN_REVOKER_ARM.matcher(sparql).find(), "admin may revoke a member");
+        assertTrue(SELF_REVOKER_ARM.matcher(sparql).find(), "self-leave arm present");
+    }
+
+    @Test
+    void nonAdminTierUpdate_revocationIsNotInvalidatable() {
+        // Decision #6: a revocation is NOT wrapped in invalidationFilter — the only un-revoke
+        // path is a newer positive re-assignment. invalidationFilter would mint ?_inv_rev.
+        String sparql = AuthorityResolver.nonAdminTierUpdate(
+                G, 0, GEN.OBSERVER_ROLE, AuthorityResolver.PUBLISHER_IS_ADMIN);
+        assertFalse(sparql.contains("?_inv_rev"),
+                "the revocation negative is not itself invalidatable");
+    }
+
+    @Test
+    void nonAdminTierUpdate_authorityArmsFollowTierMatrix() {
+        // Matrix (issue #129): a revoker must hold a tier strictly higher than the target. The
+        // arms are selected at COMPILE TIME per tier (revocationAuthorityArmsForTier) — no
+        // runtime ?tier FILTER, which would be invisible inside a UNION branch.
+        String maintainer = AuthorityResolver.nonAdminTierUpdate(
+                G, 0, GEN.MAINTAINER_ROLE, AuthorityResolver.PUBLISHER_IS_ADMIN);
+        String member = AuthorityResolver.nonAdminTierUpdate(
+                G, 0, GEN.MEMBER_ROLE, AuthorityResolver.PUBLISHER_IS_ADMIN);
+        String observer = AuthorityResolver.nonAdminTierUpdate(
+                G, 0, GEN.OBSERVER_ROLE, AuthorityResolver.PUBLISHER_IS_ADMIN);
+
+        // maintainer revoked by admins only (+self): no maintainer/member revoker arm.
+        assertFalse(revokerTierArm(MAINT).matcher(maintainer).find(),
+                "maintainer is not revocable by a maintainer");
+        assertFalse(revokerTierArm(MEMB).matcher(maintainer).find(),
+                "maintainer is not revocable by a member");
+        // member revoked by admins + maintainers (+self): maintainer arm, no member arm.
+        assertTrue(revokerTierArm(MAINT).matcher(member).find(),
+                "member is revocable by a maintainer");
+        assertFalse(revokerTierArm(MEMB).matcher(member).find(),
+                "member is not revocable by a peer member");
+        // observer revoked by admins + maintainers + members (+self).
+        assertTrue(revokerTierArm(MAINT).matcher(observer).find(),
+                "observer is revocable by a maintainer");
+        assertTrue(revokerTierArm(MEMB).matcher(observer).find(),
+                "observer is revocable by a member");
+        // admin + self arms present in every non-admin tier.
+        for (String s : new String[]{maintainer, member, observer}) {
+            assertTrue(ADMIN_REVOKER_ARM.matcher(s).find(), "admin-revoker arm present");
+            assertTrue(SELF_REVOKER_ARM.matcher(s).find(), "self-revoke arm present");
+        }
+    }
+
+    @Test
+    void nonAdminTierUpdate_suppressionAuthorityIndependentOfPublisherConstraint() {
+        // Multi-arm hazard: the suppression authority is derived from tierClass, NOT from the
+        // positive arm's publisherConstraint — otherwise the member(admin-pub) arm would never
+        // test against a maintainer-authored revocation. So the maintainer-revoker arm must be
+        // present in the member tier regardless of which publisherConstraint is passed.
+        String adminPub = AuthorityResolver.nonAdminTierUpdate(
+                G, 0, GEN.MEMBER_ROLE, AuthorityResolver.PUBLISHER_IS_ADMIN);
+        String selfPub = AuthorityResolver.nonAdminTierUpdate(
+                G, 0, GEN.MEMBER_ROLE, AuthorityResolver.PUBLISHER_IS_SELF);
+        assertTrue(revokerTierArm(MAINT).matcher(adminPub).find()
+                && revokerTierArm(MAINT).matcher(selfPub).find(),
+                "the maintainer-revoker arm appears regardless of publisherConstraint");
+    }
+
+    @Test
+    void roleRevocationDelete_structureLatestWinsAndPerTierAuthority() {
+        // Member tier: scoped to MemberRole rows; authority = admin + maintainer + self.
+        String sparql = AuthorityResolver.roleRevocationDelete(G, 7, GEN.MEMBER_ROLE);
+        assertTrue(sparql.contains("DELETE"), "DELETE clause");
+        assertTrue(sparql.contains("npa:RoleRevocation"), "matches a RoleRevocation negative");
+        assertTrue(sparql.contains("npa:hasRoleType <" + GEN.MEMBER_ROLE + ">"),
+                "scoped to rows of the target tier (excludes admin rows, which carry AdminRole)");
+        assertTrue(sparql.contains("?lnRev > 7"), "delta filter on the revocation's load number");
+        assertTrue(sparql.contains("?revCreated > ?candCreated"), "latest-wins on dct:created");
+        assertFalse(sparql.contains("?_inv_rev"), "not an npx:invalidates check");
+        assertTrue(revokerTierArm(MAINT).matcher(sparql).find(),
+                "member rows are revocable by a maintainer");
+        assertFalse(revokerTierArm(MEMB).matcher(sparql).find(),
+                "member rows are not revocable by a peer member");
+        // Observer tier: also revocable by a member.
+        String obs = AuthorityResolver.roleRevocationDelete(G, 7, GEN.OBSERVER_ROLE);
+        assertTrue(revokerTierArm(MEMB).matcher(obs).find(),
+                "observer rows are revocable by a member");
+    }
+
+    // ---------------- admin instantiation revocation ----------------
+
+    @Test
+    void adminTierUpdate_containsAdminRevocationWithRootExemption() {
+        String sparql = AuthorityResolver.adminTierUpdate(G, 0);
+        assertTrue(sparql.contains("npa:RoleRevocation"), "admin tier suppresses on a revocation");
+        assertTrue(Pattern.compile("npa:revokedRole\\s+gen:AdminRole").matcher(sparql).find(),
+                "admin revocation keys on gen:AdminRole (decision #1)");
+        assertTrue(Pattern.compile("FILTER NOT EXISTS \\{[\\s\\S]*?npa:hasRootAdmin\\s+\\?agent")
+                        .matcher(sparql).find(),
+                "root admins are exempt — a revocation against a hasRootAdmin agent is inert");
+        assertTrue(ADMIN_REVOKER_ARM.matcher(sparql).find(), "admins revoke admins");
+        assertTrue(SELF_REVOKER_ARM.matcher(sparql).find(), "non-root admins may self-leave");
+        // Admin revocation does NOT enable a maintainer/member to revoke an admin.
+        assertFalse(revokerTierArm(MAINT).matcher(sparql).find(),
+                "an admin is not revocable by a maintainer");
+    }
+
+    @Test
+    void adminRevocationDelete_rootExemptStructuralAndDeltaScoped() {
+        String sparql = AuthorityResolver.adminRevocationDelete(G, 9);
+        assertTrue(sparql.contains("DELETE"), "DELETE clause");
+        assertTrue(Pattern.compile("npa:revokedRole\\s+gen:AdminRole").matcher(sparql).find(),
+                "keyed on gen:AdminRole");
+        assertTrue(sparql.contains("npa:hasRootAdmin ?agent"), "root admins exempt in the delete too");
+        assertTrue(sparql.contains("?lnRev > 9"), "delta filter on the revocation's load number");
+        assertTrue(sparql.contains("npa:inverseProperty gen:hasAdmin"),
+                "matches admin rows (and the admin-authority arm)");
+    }
+
+    // ---------------- detachment ----------------
+
+    @Test
+    void attachmentValidationUpdate_containsDetachmentSuppression() {
+        String sparql = AuthorityResolver.attachmentValidationUpdate(G, 0);
+        assertTrue(sparql.contains("npa:RoleDetachment"), "direct attachments honor a detachment");
+        assertTrue(sparql.contains("?detCreated > ?attCreated"),
+                "non-sticky latest-wins: a newer attachment re-attaches");
+        // Detachment is admin-authored (matching who may attach).
+        assertTrue(Pattern.compile("\\?detAdminRI[\\s\\S]*?npa:inverseProperty\\s+gen:hasAdmin")
+                        .matcher(sparql).find(),
+                "detachment must be authored by an admin of the ref");
+    }
+
+    @Test
+    void presetAttachmentValidationUpdate_containsDetachmentSuppression() {
+        String sparql = AuthorityResolver.presetAttachmentValidationUpdate(G, 0);
+        assertTrue(sparql.contains("npa:RoleDetachment"),
+                "preset-derived attachments honor a detachment too (per-role opt-out)");
+        assertTrue(sparql.contains("?detCreated > ?created"),
+                "compared against the preset assignment's dct:created (non-sticky)");
+    }
+
+    @Test
+    void roleDetachmentDelete_coversDirectAndPresetDerivedAndIsDeltaScoped() {
+        String sparql = AuthorityResolver.roleDetachmentDelete(G, 3);
+        assertTrue(sparql.contains("DELETE"), "DELETE clause");
+        assertTrue(sparql.contains("npa:RoleDetachment"), "matches a detachment negative");
+        // Not scoped to derivedFromPreset — removes BOTH direct and preset-derived attachments.
+        assertFalse(sparql.contains("npa:derivedFromPreset"),
+                "detachment removes direct and preset-derived attachments alike");
+        assertTrue(sparql.contains("?lnDet > 3"), "delta filter on the detachment's load number");
+        assertTrue(sparql.contains("?detCreated > ?attCreated"), "latest-wins on dct:created");
+    }
+}

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -984,6 +984,95 @@ class SpacesExtractorTest {
         assertContainsInContext(out, NPA.THIS_REPO, CURRENT_LOAD_COUNTER, vf.createLiteral(42L), NPA.GRAPH);
     }
 
+    // ---------------- gen:RevokedRoleInstantiation / gen:detachedRole (issue #129) ----------------
+
+    @Test
+    void extract_revokedRoleInstantiation_nonAdmin_emitsRoleRevocationRow() throws Exception {
+        IRI role = vf.createIRI("https://example.org/roles/reviewer");
+        IRI revNode = vf.createIRI(NP_BASE + "#rev");
+        Nanopub np = creator()
+                .type(GEN.REVOKED_ROLE_INSTANTIATION)
+                .assertion(revNode, RDF.TYPE, GEN.REVOKED_ROLE_INSTANTIATION)
+                .assertion(revNode, GEN.FOR_SPACE, SPACE_IRI_1)
+                .assertion(revNode, GEN.FOR_AGENT, MEMBER_AGENT)
+                .assertion(revNode, GEN.HAS_ROLE, role)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forRoleRevocation(ARTIFACT_CODE,
+                Utils.createHash(MEMBER_AGENT.stringValue() + "\n" + role.stringValue()));
+        assertContains(out, subject, RDF.TYPE, ROLE_REVOCATION);
+        assertContains(out, subject, FOR_SPACE, SPACE_IRI_1);
+        assertContains(out, subject, FOR_AGENT, MEMBER_AGENT);
+        assertContains(out, subject, REVOKED_ROLE, role);
+        assertContains(out, subject, VIA_NANOPUB, NP_URI);
+        // dct:created (the latest-wins key) rides along via addProvenance.
+        assertContains(out, subject, DCTERMS.CREATED, vf.createLiteral(new Date(1_700_000_000_000L)));
+    }
+
+    @Test
+    void extract_revokedRoleInstantiation_admin_keysOnAdminRole() throws Exception {
+        // Admin revocation carries gen:hasRole gen:AdminRole (decision #1), so the extractor
+        // keys the negative on gen:AdminRole — matching the npa:hasRoleType gen:AdminRole the
+        // admin tier stamps. One vocab term, one extraction path.
+        IRI revNode = vf.createIRI(NP_BASE + "#rev");
+        Nanopub np = creator()
+                .type(GEN.REVOKED_ROLE_INSTANTIATION)
+                .assertion(revNode, RDF.TYPE, GEN.REVOKED_ROLE_INSTANTIATION)
+                .assertion(revNode, GEN.FOR_SPACE, SPACE_IRI_1)
+                .assertion(revNode, GEN.FOR_AGENT, ADMIN_AGENT_1)
+                .assertion(revNode, GEN.HAS_ROLE, GEN.ADMIN_ROLE)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forRoleRevocation(ARTIFACT_CODE,
+                Utils.createHash(ADMIN_AGENT_1.stringValue() + "\n" + GEN.ADMIN_ROLE.stringValue()));
+        assertContains(out, subject, RDF.TYPE, ROLE_REVOCATION);
+        assertContains(out, subject, FOR_AGENT, ADMIN_AGENT_1);
+        assertContains(out, subject, REVOKED_ROLE, GEN.ADMIN_ROLE);
+    }
+
+    @Test
+    void extract_revokedRoleInstantiation_missingForAgent_emitsNothing() throws Exception {
+        IRI role = vf.createIRI("https://example.org/roles/reviewer");
+        IRI revNode = vf.createIRI(NP_BASE + "#rev");
+        Nanopub np = creator()
+                .type(GEN.REVOKED_ROLE_INSTANTIATION)
+                .assertion(revNode, RDF.TYPE, GEN.REVOKED_ROLE_INSTANTIATION)
+                .assertion(revNode, GEN.FOR_SPACE, SPACE_IRI_1)
+                .assertion(revNode, GEN.HAS_ROLE, role)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        assertTrue(out.stream().noneMatch(st -> ROLE_REVOCATION.equals(st.getObject())),
+                "an incomplete revocation node emits no RoleRevocation row");
+    }
+
+    @Test
+    void extract_detachedRole_emitsRoleDetachmentRow() throws Exception {
+        IRI role = vf.createIRI("https://example.org/roles/reviewer");
+        Nanopub np = creator()
+                .type(GEN.DETACHED_ROLE)
+                .assertion(SPACE_IRI_1, GEN.DETACHED_ROLE, role)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forRoleDetachment(ARTIFACT_CODE, Utils.createHash(role.stringValue()));
+        assertContains(out, subject, RDF.TYPE, ROLE_DETACHMENT);
+        assertContains(out, subject, FOR_SPACE, SPACE_IRI_1);
+        assertContains(out, subject, REVOKED_ROLE, role);
+        assertContains(out, subject, VIA_NANOPUB, NP_URI);
+        assertContains(out, subject, DCTERMS.CREATED, vf.createLiteral(new Date(1_700_000_000_000L)));
+    }
+
+    @Test
+    void triggerTypes_includeRevocationVocab() {
+        assertTrue(SpacesExtractor.TRIGGER_TYPES.contains(GEN.REVOKED_ROLE_INSTANTIATION),
+                "RevokedRoleInstantiation is space-relevant");
+        assertTrue(SpacesExtractor.TRIGGER_TYPES.contains(GEN.DETACHED_ROLE),
+                "detachedRole is space-relevant");
+    }
+
     // ---------------- helpers ----------------
 
     private SpacesExtractor.Context defaultContext() {


### PR DESCRIPTION
Implements **#129** — key-level role **revocation** and **re-assignment**, server side, reusing the authorization-scoped latest-wins model proven for preset assignments (#302). `npx:invalidates` stays for nanopub-level undo; these negatives are key-level.

## What

Two new, previously-unused vocabulary terms:
- `gen:RevokedRoleInstantiation` — `(space, agent, role)` instantiation revocation (admin uses `gen:hasRole gen:AdminRole`).
- `gen:detachedRole` — `(space, role)` attachment revocation; cascades to anchored instantiations.

State of each key = sign of the **latest authorized assertion** by `dct:created` (active-by-default). Negatives never materialize as state rows — each is consumed as an inline suppression `FILTER NOT EXISTS` in its INSERT tier plus a displacement `DELETE` in `applyInvalidations`.

- **`nonAdminTierUpdate`** — per-tier suppression + per-tier displacement DELETE (**structural**: a revoked maintainer/member is a sub-granting authority).
- **`adminTierUpdate`** — keyed on `gen:AdminRole`; **root admins exempt** via derive-on-demand `hasRootAdmin` filter (overrides self-leave); structural DELETE.
- **attachment + preset-attachment tiers** — `gen:detachedRole` suppression + displacement (non-sticky; covers direct and preset-derived attachments).

**Authorization matrix** (one compile-time arm builder shared by the inline filter and the per-tier DELETE): a revoker must hold a tier strictly higher than the target, or be the assignee (self-leave); admins revoke admin peers. Authority derives from the *target tier*, not the positive arm's `publisherConstraint` (the multi-arm hazard). Missing `dct:created` sorts as epoch; no `npx:invalidates` un-revoke (re-assignment only).

## Compatibility & consumers

- **No state-shape change** for the no-negative case → fully back-compat, **no re-ingest** (effective on the next periodic rebuild; mixed fleet fails open).
- **Consumer queries need no change**: `get-space-members` `?validated` flips to `false` for a revoked member; `get-space-roles` drops a detached role — verified by read-path canary tests.

## Decisions (per issue author)

admin → `gen:hasRole gen:AdminRole` · root admins can't self-leave · missing timestamp = epoch · no invalidates-based un-revoke · non-sticky detach re-attach. Known limitation accepted as intended: revocation authority is current-cycle, so a revoked grant may reappear if the revoker later loses authority (shared with #302) — see `doc/design-role-revocation.md` §8.

## Tests

`AuthorityResolverRevocationTest` (SPARQL string-contract), `AuthorityResolverRevocationBehaviorTest` (in-memory runtime: latest-wins, authority matrix, self-leave, displacement, detachment, admin root exemption, + read-path canaries), `SpacesExtractorTest` additions. **318 tests green.**

## Follow-ups

- Nanodash publishing templates + UI: **knowledgepixels/nanodash#513** (must stamp `dct:created`; detachment typing convention).
- Deploy needs only a redeploy (no re-sync); full fleet `/api` read-path canary per `doc/canary-checklist-spaceref-1.15.md` at deploy time.

Design: `doc/design-role-revocation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
