### PR TITLE
fix(triplestore): defer repo-cache eviction shutdown and pin hot repos

### DIFF
--- a/src/main/java/com/knowledgepixels/query/TripleStore.java
+++ b/src/main/java/com/knowledgepixels/query/TripleStore.java
@@ -8,6 +8,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import com.google.common.hash.Hashing;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,6 +57,44 @@ public class TripleStore {
      * {@link RepositoryConnectionWrapper} that intercepts {@code close()} exactly once.
      */
     private final ConcurrentHashMap<String, AtomicInteger> openConnections = new ConcurrentHashMap<>();
+
+    /**
+     * Handles evicted from {@link #repositories} but not yet shut down. Eviction is
+     * deferred and idle-only: calling {@link HTTPRepository#shutDown()} closes the
+     * session manager and kills any live (possibly streaming) server-side transaction
+     * with the {@code MMapIndexInput - Already closed} error, which can wedge the
+     * underlying LMDB store on the server for <em>every</em> client. Instead of shutting
+     * a handle down the instant its app-side connection count hits zero — a count that
+     * can momentarily read zero between operations, or undercount a result set still
+     * being streamed — we park it here and only shut it down from
+     * {@link #reapPendingShutdowns()} once it has stayed idle for {@link #SHUTDOWN_GRACE_MS}.
+     * Guarded by the {@code this} monitor, like {@link #repositories}.
+     */
+    private final Map<String, Repository> pendingShutdown = new LinkedHashMap<>();
+    private final Map<String, Long> pendingShutdownSince = new HashMap<>();
+
+    /** Idle grace period before a parked handle is actually shut down. */
+    private static final long SHUTDOWN_GRACE_MS = 60_000;
+
+    /**
+     * Repos that are never evicted. The core named repos plus the view-critical type
+     * repos: ResourceView and ViewDisplay are queried and federated into constantly by
+     * the spaces/view UI, so they churn through the {@code cap 100} LRU fastest and were
+     * the handles most exposed to the shutdown-during-use race. Pinning a handful of
+     * them is cheap (a few always-warm LMDB envs) and removes the thrash on exactly the
+     * repos that wedge.
+     */
+    private static final Set<String> PINNED_REPO_NAMES = buildPinnedRepoNames();
+
+    private static Set<String> buildPinnedRepoNames() {
+        Set<String> names = new HashSet<>(Arrays.asList("admin", "empty", "meta", "full", "spaces", "last30d"));
+        for (String typeIri : new String[] {
+                "https://w3id.org/kpxl/gen/terms/ResourceView",
+                "https://w3id.org/kpxl/gen/terms/ViewDisplay" }) {
+            names.add("type_" + Hashing.sha256().hashString(typeIri, StandardCharsets.UTF_8).toString());
+        }
+        return Collections.unmodifiableSet(names);
+    }
 
     private String endpointBase = null;
     private String endpointType = null;
@@ -140,12 +180,23 @@ public class TripleStore {
     @GeneratedFlagForDependentElements
     Repository getRepository(String name) {
         synchronized (this) {
+            // Reap parked handles that have now been idle long enough, even when we're
+            // not over cap, so a burst that parked some repos doesn't leave them warm
+            // forever if load then drops. Cheap: early-returns when nothing is parked.
+            reapPendingShutdowns();
             if (repositories.size() > 100) {
                 evictIdleRepos();
             }
             if (repositories.containsKey(name)) {
                 // Move to the end of the list:
                 Repository repo = repositories.remove(name);
+                repositories.put(name, repo);
+            } else if (pendingShutdown.containsKey(name)) {
+                // Needed again before its grace period elapsed: resurrect the parked
+                // handle instead of shutting it down and re-creating, avoiding both the
+                // re-init round-trip and any shutdown/use race.
+                Repository repo = pendingShutdown.remove(name);
+                pendingShutdownSince.remove(name);
                 repositories.put(name, repo);
             } else {
                 Repository repository = null;
@@ -200,35 +251,91 @@ public class TripleStore {
 
     /**
      * Evicts the eldest cache entries until either the size is back within the
-     * 100-entry cap or every remaining entry has at least one open connection.
+     * 100-entry cap or every remaining entry is pinned or has an open connection.
      * The cap is load-bearing — each cached entry keeps an LMDB environment alive
      * on the RDF4J server (in-memory cache, mmap pages, native memory), so
-     * exceeding it by much risks server-side OOM. Actively-used repos are skipped
-     * rather than shut down, because {@link org.eclipse.rdf4j.repository.http.HTTPRepository#shutDown()}
-     * closes the session manager and kills any live transaction on that repo with
-     * a connection-close error (the {@code MMapIndexInput – Already closed}
-     * failure mode observed on query-3 in the April test). The cache self-converges
-     * as active repos become idle.
+     * exceeding it by much risks server-side OOM.
+     *
+     * <p>Eviction is <em>non-destructive</em>: it only unlinks the handle from the
+     * live cache into {@link #pendingShutdown}; it does <strong>not</strong> call
+     * {@link org.eclipse.rdf4j.repository.http.HTTPRepository#shutDown()} here.
+     * Shutting a handle down closes the session manager and kills any live transaction
+     * on that repo with a connection-close error (the {@code MMapIndexInput – Already
+     * closed} failure mode observed on query-3 in the April test), which can wedge the
+     * server-side LMDB store for every client. The actual shutdown happens later in
+     * {@link #reapPendingShutdowns()}, only after a repo has stayed provably idle for
+     * {@link #SHUTDOWN_GRACE_MS}. Pinned and actively-used repos are skipped entirely.
+     * The cap is still enforced immediately, because unlinked handles leave
+     * {@link #repositories} right away.
      */
+    /**
+     * Current time in millis. A seam so tests can drive the eviction grace period
+     * deterministically instead of sleeping.
+     */
+    long nowMillis() {
+        return System.currentTimeMillis();
+    }
+
     @GeneratedFlagForDependentElements
-    private void evictIdleRepos() {
+    void evictIdleRepos() {
+        reapPendingShutdowns();
         List<String> skipped = new ArrayList<>();
+        long now = nowMillis();
         Iterator<Entry<String, Repository>> iter = repositories.entrySet().iterator();
         while (iter.hasNext() && repositories.size() > 100) {
             Entry<String, Repository> e = iter.next();
-            AtomicInteger active = openConnections.get(e.getKey());
+            String name = e.getKey();
+            if (PINNED_REPO_NAMES.contains(name)) {
+                skipped.add(name);
+                continue;
+            }
+            AtomicInteger active = openConnections.get(name);
             if (active != null && active.get() > 0) {
-                skipped.add(e.getKey());
+                skipped.add(name);
                 continue;
             }
             iter.remove();
-            logger.info("Shutting down repo: {}", e.getKey());
-            e.getValue().shutDown();
-            logger.info("Shutdown complete");
+            // Park for deferred shutdown rather than shutting down in this hot path.
+            pendingShutdown.put(name, e.getValue());
+            pendingShutdownSince.put(name, now);
         }
         if (!skipped.isEmpty()) {
-            logger.warn("Skipped eviction for {} active repo(s); cache size is now {} (cap 100). Active names: {}",
+            logger.warn("Skipped eviction for {} active/pinned repo(s); cache size is now {} (cap 100). Active names: {}",
                     skipped.size(), repositories.size(), skipped);
+        }
+    }
+
+    /**
+     * Shuts down handles parked in {@link #pendingShutdown} that have stayed idle
+     * ({@code openConnections == 0}) for at least {@link #SHUTDOWN_GRACE_MS}. The grace
+     * period keeps eviction from killing a server-side transaction whose app-side
+     * connection count merely dipped to zero between operations, or that is still
+     * streaming a result set. A handle re-requested before it is reaped is resurrected
+     * in {@link #getRepository(String)} and never shut down. Must be called under the
+     * {@code this} monitor.
+     */
+    void reapPendingShutdowns() {
+        if (pendingShutdown.isEmpty()) {
+            return;
+        }
+        long now = nowMillis();
+        Iterator<Entry<String, Repository>> iter = pendingShutdown.entrySet().iterator();
+        while (iter.hasNext()) {
+            Entry<String, Repository> e = iter.next();
+            String name = e.getKey();
+            AtomicInteger active = openConnections.get(name);
+            Long since = pendingShutdownSince.get(name);
+            if ((active == null || active.get() == 0) && since != null && now - since >= SHUTDOWN_GRACE_MS) {
+                iter.remove();
+                pendingShutdownSince.remove(name);
+                logger.info("Shutting down idle repo (deferred): {}", name);
+                try {
+                    e.getValue().shutDown();
+                } catch (Exception ex) {
+                    logger.warn("Deferred shutdown failed for repo '{}': {}", name, ex.getMessage());
+                }
+                logger.info("Shutdown complete");
+            }
         }
     }
 

--- a/src/test/java/com/knowledgepixels/query/TripleStoreTest.java
+++ b/src/test/java/com/knowledgepixels/query/TripleStoreTest.java
@@ -10,14 +10,29 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.support.ReflectionSupport;
 
+import com.google.common.hash.Hashing;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 class TripleStoreTest {
@@ -157,5 +172,169 @@ class TripleStoreTest {
         verify(httpClientMock, times(1)).execute(any(HttpUriRequest.class));
         assertEquals(0, repoNamesCacheLock.getReadLockCount());
         assertEquals(0, repoNamesCacheLock.getWriteHoldCount());
+    }
+
+    // --- repo-cache eviction: deferred idle-only shutdown + pinned hot repos ---
+
+    private static final long GRACE_MS = 60_000;
+
+    private void setField(TripleStore mock, String name, Object value) {
+        final Field f = ReflectionSupport.findFields(
+                TripleStore.class,
+                fl -> fl.getName().equals(name),
+                HierarchyTraversalMode.TOP_DOWN
+        ).getFirst();
+        f.setAccessible(true);
+        try {
+            f.set(mock, value);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * A {@link TripleStore} mock running the real cache methods, with the four cache
+     * maps injected (mocks don't run field initialisers) and {@code nowMillis()} driven
+     * by the supplied clock so the grace period is deterministic.
+     */
+    private TripleStore cacheMock(AtomicLong clock,
+                                  Map<String, Repository> repositories,
+                                  ConcurrentHashMap<String, AtomicInteger> openConnections,
+                                  Map<String, Repository> pendingShutdown,
+                                  Map<String, Long> pendingShutdownSince) {
+        TripleStore mock = mock(TripleStore.class, CALLS_REAL_METHODS);
+        setField(mock, "repositories", repositories);
+        setField(mock, "openConnections", openConnections);
+        setField(mock, "pendingShutdown", pendingShutdown);
+        setField(mock, "pendingShutdownSince", pendingShutdownSince);
+        doAnswer(inv -> clock.get()).when(mock).nowMillis();
+        return mock;
+    }
+
+    /** Inserts {@code n} idle mock repos named {@code type_0..type_{n-1}} in order. */
+    private List<Repository> fillIdle(Map<String, Repository> repositories, int n) {
+        List<Repository> repos = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            Repository r = mock(Repository.class);
+            repos.add(r);
+            repositories.put("type_" + i, r);
+        }
+        return repos;
+    }
+
+    @Test
+    void evictionParksEldestWithoutShutdownThenReapsAfterGrace() {
+        AtomicLong clock = new AtomicLong(1_000);
+        Map<String, Repository> repositories = new LinkedHashMap<>();
+        Map<String, Repository> pending = new LinkedHashMap<>();
+        Map<String, Long> since = new HashMap<>();
+        TripleStore store = cacheMock(clock, repositories, new ConcurrentHashMap<>(), pending, since);
+        List<Repository> repos = fillIdle(repositories, 101);
+
+        store.evictIdleRepos();
+
+        // Cap enforced immediately, eldest parked but NOT shut down.
+        assertEquals(100, repositories.size());
+        assertFalse(repositories.containsKey("type_0"));
+        assertTrue(pending.containsKey("type_0"));
+        verify(repos.get(0), never()).shutDown();
+
+        // Still within the grace window: not reaped.
+        clock.set(1_000 + GRACE_MS - 1);
+        store.reapPendingShutdowns();
+        verify(repos.get(0), never()).shutDown();
+        assertTrue(pending.containsKey("type_0"));
+
+        // Grace elapsed: now shut down exactly once and unparked.
+        clock.set(1_000 + GRACE_MS);
+        store.reapPendingShutdowns();
+        verify(repos.get(0), times(1)).shutDown();
+        assertFalse(pending.containsKey("type_0"));
+    }
+
+    @Test
+    void activeRepoIsNeverParked() {
+        AtomicLong clock = new AtomicLong(1_000);
+        Map<String, Repository> repositories = new LinkedHashMap<>();
+        ConcurrentHashMap<String, AtomicInteger> open = new ConcurrentHashMap<>();
+        Map<String, Repository> pending = new LinkedHashMap<>();
+        TripleStore store = cacheMock(clock, repositories, open, pending, new HashMap<>());
+        List<Repository> repos = fillIdle(repositories, 101);
+        // Eldest has a live connection.
+        open.put("type_0", new AtomicInteger(1));
+
+        store.evictIdleRepos();
+
+        // type_0 is skipped; the next idle one (type_1) is parked instead.
+        assertTrue(repositories.containsKey("type_0"));
+        assertFalse(pending.containsKey("type_0"));
+        assertTrue(pending.containsKey("type_1"));
+        verify(repos.get(0), never()).shutDown();
+    }
+
+    @Test
+    void pinnedViewRepoIsNeverParked() {
+        AtomicLong clock = new AtomicLong(1_000);
+        Map<String, Repository> repositories = new LinkedHashMap<>();
+        Map<String, Repository> pending = new LinkedHashMap<>();
+        TripleStore store = cacheMock(clock, repositories, new ConcurrentHashMap<>(), pending, new HashMap<>());
+
+        // The ResourceView type repo (the one that wedged) is pinned and sits eldest.
+        String resourceView = "type_" + Hashing.sha256()
+                .hashString("https://w3id.org/kpxl/gen/terms/ResourceView", StandardCharsets.UTF_8);
+        Repository rvRepo = mock(Repository.class);
+        repositories.put(resourceView, rvRepo);
+        fillIdle(repositories, 100); // 101 total
+
+        store.evictIdleRepos();
+
+        assertTrue(repositories.containsKey(resourceView));
+        assertFalse(pending.containsKey(resourceView));
+        verify(rvRepo, never()).shutDown();
+        // Exactly one non-pinned idle repo was parked to get back under cap.
+        assertEquals(1, pending.size());
+    }
+
+    @Test
+    void reapDoesNotShutDownAHandleThatBecameActiveAgain() {
+        AtomicLong clock = new AtomicLong(1_000);
+        Map<String, Repository> pending = new LinkedHashMap<>();
+        Map<String, Long> since = new HashMap<>();
+        ConcurrentHashMap<String, AtomicInteger> open = new ConcurrentHashMap<>();
+        TripleStore store = cacheMock(clock, new LinkedHashMap<>(), open, pending, since);
+
+        Repository parked = mock(Repository.class);
+        pending.put("type_x", parked);
+        since.put("type_x", 1_000L);
+        // A connection was opened against it after parking.
+        open.put("type_x", new AtomicInteger(1));
+
+        clock.set(1_000 + GRACE_MS);
+        store.reapPendingShutdowns();
+
+        verify(parked, never()).shutDown();
+        assertTrue(pending.containsKey("type_x"));
+    }
+
+    @Test
+    void getRepositoryResurrectsParkedHandleWithoutShutdown() {
+        AtomicLong clock = new AtomicLong(1_000);
+        Map<String, Repository> repositories = new LinkedHashMap<>();
+        Map<String, Repository> pending = new LinkedHashMap<>();
+        Map<String, Long> since = new HashMap<>();
+        TripleStore store = cacheMock(clock, repositories, new ConcurrentHashMap<>(), pending, since);
+
+        Repository parked = mock(Repository.class);
+        pending.put("type_x", parked);
+        since.put("type_x", 1_000L);
+
+        // Requested again before the grace period elapses.
+        clock.set(1_000 + GRACE_MS / 2);
+        Repository got = store.getRepository("type_x");
+
+        assertSame(parked, got);
+        assertTrue(repositories.containsKey("type_x"));
+        assertFalse(pending.containsKey("type_x"));
+        verify(parked, never()).shutDown();
     }
 }


### PR DESCRIPTION
## Problem

The repo-cache (cap 100) in `TripleStore` evicted handles by calling `HTTPRepository.shutDown()` **synchronously in the `getRepository()` hot path**. `shutDown()` closes the session manager and kills any live (possibly streaming) server-side transaction with the `MMapIndexInput – Already closed` error (the failure mode the existing code comments already flag from the "April test"). That can wedge the underlying LMDB store **for every client**, surfacing as a deterministic, repo-specific `503` on the **ResourceView** type repo.

ResourceView is queried and federated into most heavily by the spaces/view UI, so it churns through the LRU fastest and was the handle most exposed to the shutdown-during-use race. The previous "skip repos with open connections" guard was insufficient — the app-side connection counter can momentarily read `0` between operations.

This was reproduced from a **fresh DB** (ruling out on-disk corruption / stale locks), and the same repo broke every time, while the identical data serves fine on the other live instances.

## Fix

Make eviction **non-destructive and idle-only**:

- `evictIdleRepos()` now only **unlinks** the eldest handles into a `pendingShutdown` parking map (the cap is still enforced immediately, since they leave the live cache at once). It no longer shuts anything down in the hot path.
- `reapPendingShutdowns()` performs the actual `shutDown()`, but **only after a handle has stayed idle** (`openConnections == 0`) for a 60s grace period.
- A handle re-requested before it is reaped is **resurrected** in `getRepository()` and never shut down.
- **Pin** the core named repos (`admin`, `empty`, `meta`, `full`, `spaces`, `last30d`) plus the view-critical type repos (`ResourceView`, `ViewDisplay`) so eviction never targets the repos that wedge.

The cap stays at 100; memory bound is preserved (live cache ≤ 100 + a handful of pinned + transiently-parked handles).

## Tests

Added a `nowMillis()` seam so the grace period is deterministic without sleeping, plus 5 unit tests:

- park-without-shutdown, then reap exactly once after grace
- active repo never parked
- pinned ResourceView repo never parked
- no shutdown of a handle that became active again after parking
- `getRepository()` resurrects a parked handle without shutting it down

`mvn test -Dtest=TripleStoreTest` → 11 passing.

## Notes / follow-ups (not in this PR)

- Verifying `HTTPRepository.shutDown()` doesn't tear down the shared `httpclient`, and auditing the connection counter for streaming-result leaks — investigations, not code changes. The grace period makes counter accuracy far less load-bearing.
- The separate **`meta` repo lagging `full` by 4,763** nanopubs (deferred-meta-commit drop, mostly FIP-Declaration) observed during the same fresh sync is a distinct issue and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6AcRywUVHdPvgfJHvtLdi