### PR TITLE
Resolve role-predicate direction from pubinfo pins (#136 Part B)

### DIFF
--- a/doc/design-role-direction-pinning.md
+++ b/doc/design-role-direction-pinning.md
@@ -212,9 +212,10 @@ quo, not a regression, so Part A is unaffected).
 - **Inline `gen:Space` path:** honored iff fixed-predicate or pinned (B.3 above).
 - **Predicate scope in Part A:** `gen:hasMaintainer` only; `gen:hasHelper` reserved as the
   Part B pilot and migrated manually.
-- **Multi-space batching:** supported — one nanopub may assign one predicate across several
-  spaces, each a separate assignment; key the RI subject on `(predicate, space)` and group
-  by `(space, predicate, direction)`.
+- **Multi-space batching:** supported on the **pinned** path — one nanopub may assign one
+  predicate across several spaces, each a separate assignment; RI subject keyed on
+  `(predicate, space)`, grouped by `(space, predicate)`. The backcompat classified branch
+  keeps its legacy one-per-nanopub shape (no multi-space data there).
 - **Vocabulary publication:** Nanodash may emit the new `gen:` classes before they are
   formally defined; publishing them in the kpxl vocab is a follow-up.
 
@@ -233,16 +234,21 @@ quo, not a regression, so Part A is unaffected).
   to correct existing `hasMaintainer` data. **Partially** closes #136 (`hasHelper` deferred
   to Part B). Independent of Part B.
 - **Part B** —
-  1. Extractor: shared `resolveDirection(predicate, pins)` with precedence
-     `BackcompatRolePredicates` → pubinfo pin → **drop**; wire into both
-     `extractRoleInstantiation` and `emitInlineRoleInstantiations`, and rework the
-     classified branch to group by `(space, predicate, direction)` with per-`(predicate,
-     space)` subject keying (multi-space support).
+  1. **DONE (extractor side, this repo):** `gen:InverseRoleProperty` / `gen:RegularRoleProperty`
+     added to `GEN`; `directionPins(np)` reads the pubinfo pins; shared
+     `resolveDirection(predicate, pins)` with precedence `BackcompatRolePredicates` → pin →
+     **drop**; wired into both `extractRoleInstantiation` (its former neutral branch is
+     replaced by pin-resolution grouped by `(space, predicate)` with per-`(predicate, space)`
+     subject keying — multi-space support) and `emitInlineRoleInstantiations`. **Scope note:**
+     the backcompat *classified* branch was intentionally left unchanged (legacy
+     one-assignment-per-nanopub), so multi-space batching applies to **pinned** predicates
+     (the forward path), not the drainable backcompat ones — which have no multi-space data.
   2. Nanodash emits the pin using `gen:InverseRoleProperty` / `gen:RegularRoleProperty`
      (may precede formal vocab definition — cross-repo dependency, not blocked on the vocab).
   3. Migrate existing `hasHelper` instances (republish with pins); then full re-ingest.
-  4. Follow-up: remove the now-vestigial neutral branch + `nonAdminTierUpdate` arms 3–4;
-     publish the `gen:` vocab term definitions.
+  4. Follow-up: remove the now-vestigial neutral branch + `nonAdminTierUpdate` arms 3–4
+     (safe only *after* re-ingest, since old neutral rows in `spacesGraph` still rely on
+     arms 3–4 until then); publish the `gen:` vocab term definitions.
 
 ## Related
 

--- a/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
+++ b/src/main/java/com/knowledgepixels/query/SpacesExtractor.java
@@ -333,6 +333,7 @@ public final class SpacesExtractor {
      */
     private static void emitInlineRoleInstantiations(Nanopub np, Context ctx, IRI spaceIri,
                                                      List<Statement> out) {
+        Map<IRI, BackcompatRolePredicates.Direction> pins = directionPins(np);
         Map<IRI, BackcompatRolePredicates.Direction> directionByPred = new LinkedHashMap<>();
         Map<IRI, Set<IRI>> agentsByPred = new LinkedHashMap<>();
         for (Statement st : np.getAssertion()) {
@@ -340,7 +341,9 @@ public final class SpacesExtractor {
             if (GEN.HAS_ADMIN.equals(predicate)) {
                 continue; // already emitted above
             }
-            BackcompatRolePredicates.Direction direction = BackcompatRolePredicates.DIRECTIONS.get(predicate);
+            // Direction from the backcompat list or, for a user-defined predicate, a pubinfo
+            // pin (issue #136 Part B); unresolved predicates are dropped.
+            BackcompatRolePredicates.Direction direction = resolveDirection(predicate, pins);
             if (direction == null) {
                 continue;
             }
@@ -594,22 +597,37 @@ public final class SpacesExtractor {
         }
 
         // No predicate with a known direction. For a nanopub explicitly typed
-        // gen:RoleInstantiation, the assertion still binds an agent to a space via a
-        // custom role predicate declared in a gen:SpaceMemberRole nanopub (e.g.
-        // gen:hasMaintainer). We can't classify its direction here — that lives in the
-        // role declaration, a different nanopub the extractor can't see — so emit a
-        // neutral binding carrying the raw (subject, predicate, object). The materializer
-        // resolves direction + tier by joining the predicate against the role declaration
-        // attached to the space (see AuthorityResolver#nonAdminTierUpdate). Gated on the
-        // explicit type so we don't mint inert entries for incidental IRI-valued triples
-        // in nanopubs that only matched via a backcompat predicate.
+        // gen:RoleInstantiation, the assertion binds an agent to a space via a user-defined
+        // role predicate whose direction is pinned in pubinfo (<pred> a
+        // gen:InverseRoleProperty / gen:RegularRoleProperty; issue #136 Part B). We resolve
+        // the direction from that pin and emit the normalized shape directly, so
+        // get-space-members (which reads the raw spacesGraph) surfaces the member without a
+        // materializer round-trip. A predicate with neither a known direction nor a pin is
+        // DROPPED — no neutral binding is emitted (strict). Gated on the explicit type so we
+        // don't mint entries for incidental IRI-valued triples in backcompat-only nanopubs.
+        //
+        // One nanopub may bind a predicate across several spaces, each its own assignment:
+        // group by (space, predicate) with multi-valued forAgent and mint one subject per
+        // (predicate, space). (The classified branch above keeps its legacy one-per-nanopub
+        // shape for the drainable backcompat predicates.)
         if (!explicitRoleInstantiation) {
             return;
         }
+        Map<IRI, BackcompatRolePredicates.Direction> pins = directionPins(np);
+        if (pins.isEmpty()) {
+            return;
+        }
+        // Keyed by [predicate, spaceSide] (List equality is value-based).
+        Map<List<IRI>, BackcompatRolePredicates.Direction> directionByKey = new LinkedHashMap<>();
+        Map<List<IRI>, Set<IRI>> agentsByKey = new LinkedHashMap<>();
         for (Statement st : np.getAssertion()) {
             IRI predicate = st.getPredicate();
             if (predicate.equals(RDF.TYPE) || directionFor(predicate) != null) {
                 continue;
+            }
+            BackcompatRolePredicates.Direction direction = pins.get(predicate);
+            if (direction == null) {
+                continue; // unpinned custom predicate → dropped
             }
             if (!(st.getSubject() instanceof IRI subjIri)) {
                 continue;
@@ -617,14 +635,36 @@ public final class SpacesExtractor {
             if (!(st.getObject() instanceof IRI objIri)) {
                 continue;
             }
-            // Discriminate the subject by predicate so multiple custom-predicate triples
-            // in one nanopub don't collide on the artifact-code-derived subject.
-            IRI subject = SpacesVocab.forRoleInstantiation(
-                    ctx.artifactCode(), Utils.createHash(predicate.stringValue()));
+            IRI spaceSide;
+            IRI agentSide;
+            if (direction == BackcompatRolePredicates.Direction.REGULAR) {
+                agentSide = subjIri;
+                spaceSide = objIri;
+            } else {
+                spaceSide = subjIri;
+                agentSide = objIri;
+            }
+            List<IRI> key = List.of(predicate, spaceSide);
+            directionByKey.put(key, direction);
+            agentsByKey.computeIfAbsent(key, k -> new LinkedHashSet<>()).add(agentSide);
+        }
+        for (Map.Entry<List<IRI>, Set<IRI>> entry : agentsByKey.entrySet()) {
+            IRI predicate = entry.getKey().get(0);
+            IRI spaceSide = entry.getKey().get(1);
+            BackcompatRolePredicates.Direction direction = directionByKey.get(entry.getKey());
+            // Discriminate by (predicate, space) so several predicates AND several spaces
+            // in one nanopub each get a distinct entry.
+            IRI subject = SpacesVocab.forRoleInstantiation(ctx.artifactCode(),
+                    Utils.createHash(predicate.stringValue() + "\n" + spaceSide.stringValue()));
             out.add(vf.createStatement(subject, RDF.TYPE, GEN.ROLE_INSTANTIATION, GRAPH));
-            out.add(vf.createStatement(subject, SpacesVocab.ROLE_PREDICATE, predicate, GRAPH));
-            out.add(vf.createStatement(subject, SpacesVocab.BINDING_SUBJECT, subjIri, GRAPH));
-            out.add(vf.createStatement(subject, SpacesVocab.BINDING_OBJECT, objIri, GRAPH));
+            out.add(vf.createStatement(subject, SpacesVocab.FOR_SPACE, spaceSide, GRAPH));
+            IRI directionPredicate = (direction == BackcompatRolePredicates.Direction.REGULAR)
+                    ? SpacesVocab.REGULAR_PROPERTY
+                    : SpacesVocab.INVERSE_PROPERTY;
+            out.add(vf.createStatement(subject, directionPredicate, predicate, GRAPH));
+            for (IRI agent : entry.getValue()) {
+                out.add(vf.createStatement(subject, SpacesVocab.FOR_AGENT, agent, GRAPH));
+            }
             out.add(vf.createStatement(subject, SpacesVocab.VIA_NANOPUB, np.getUri(), GRAPH));
             addProvenance(subject, ctx, out);
         }
@@ -635,6 +675,38 @@ public final class SpacesExtractor {
             return BackcompatRolePredicates.Direction.INVERSE;
         }
         return BackcompatRolePredicates.DIRECTIONS.get(predicate);
+    }
+
+    /**
+     * Direction pins declared in the nanopub's pubinfo: {@code <pred> a
+     * gen:InverseRoleProperty} or {@code <pred> a gen:RegularRoleProperty}. Lets the
+     * extractor resolve a user-defined role predicate's direction from the assigning
+     * nanopub alone (issue #136 Part B; see {@code doc/design-role-direction-pinning.md}).
+     */
+    private static Map<IRI, BackcompatRolePredicates.Direction> directionPins(Nanopub np) {
+        Map<IRI, BackcompatRolePredicates.Direction> pins = new LinkedHashMap<>();
+        for (Statement st : np.getPubinfo()) {
+            if (!RDF.TYPE.equals(st.getPredicate()) || !(st.getSubject() instanceof IRI predicate)) {
+                continue;
+            }
+            if (GEN.INVERSE_ROLE_PROPERTY.equals(st.getObject())) {
+                pins.put(predicate, BackcompatRolePredicates.Direction.INVERSE);
+            } else if (GEN.REGULAR_ROLE_PROPERTY.equals(st.getObject())) {
+                pins.put(predicate, BackcompatRolePredicates.Direction.REGULAR);
+            }
+        }
+        return pins;
+    }
+
+    /**
+     * Resolves a role predicate's direction: a statically-known predicate
+     * ({@link #directionFor}) wins; otherwise a pubinfo {@code pins} entry; otherwise
+     * {@code null} (the predicate is dropped).
+     */
+    private static BackcompatRolePredicates.Direction resolveDirection(IRI predicate,
+            Map<IRI, BackcompatRolePredicates.Direction> pins) {
+        BackcompatRolePredicates.Direction known = directionFor(predicate);
+        return (known != null) ? known : pins.get(predicate);
     }
 
     // ---------------- gen:isSubSpaceOf (standalone path) ----------------

--- a/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
+++ b/src/main/java/com/knowledgepixels/query/vocabulary/GEN.java
@@ -62,6 +62,22 @@ public class GEN {
     public static final IRI HAS_INVERSE_PROPERTY = VocabUtils.createIRI(NAMESPACE, "hasInverseProperty");
 
     /**
+     * Pubinfo pin (issue #136 Part B) marking a role predicate as <em>inverse</em>-direction:
+     * the role-assigning triple is {@code <space> <predicate> <agent>}. Lets the extractor
+     * resolve a user-defined predicate's direction from the assigning nanopub alone, without the
+     * separate role declaration. Mirrors {@link #HAS_INVERSE_PROPERTY} on the role declaration.
+     * See {@code doc/design-role-direction-pinning.md}.
+     */
+    public static final IRI INVERSE_ROLE_PROPERTY = VocabUtils.createIRI(NAMESPACE, "InverseRoleProperty");
+
+    /**
+     * Pubinfo pin (issue #136 Part B) marking a role predicate as <em>regular</em>-direction:
+     * the role-assigning triple is {@code <agent> <predicate> <space>}. Mirrors
+     * {@link #HAS_REGULAR_PROPERTY} on the role declaration.
+     */
+    public static final IRI REGULAR_ROLE_PROPERTY = VocabUtils.createIRI(NAMESPACE, "RegularRoleProperty");
+
+    /**
      * Nanopub type (new) for role-instantiation nanopubs — those that grant a role to
      * an agent in a space. Extraction entries are also tagged with this class.
      */

--- a/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
+++ b/src/test/java/com/knowledgepixels/query/SpacesExtractorTest.java
@@ -360,17 +360,14 @@ class SpacesExtractorTest {
         assertDoesNotContain(out, subject, INVERSE_PROPERTY, plansToAttend);
     }
 
-    // ---------------- gen:RoleInstantiation with a custom (unclassified) predicate ----------------
+    // ---------------- gen:RoleInstantiation with a custom (pinned / unpinned) predicate ----------------
 
     @Test
-    void extract_customPredicateExplicitlyTyped_emitsNeutralBinding() throws Exception {
-        // gen:hasHelper is a user-defined role predicate (declared via a
-        // gen:SpaceMemberRole nanopub's gen:hasInverseProperty); it is deliberately kept
-        // out of BackcompatRolePredicates as the pinning pilot (issue #136), so the
-        // extractor can't classify its direction. For a nanopub explicitly typed
-        // gen:RoleInstantiation we emit a neutral binding carrying the raw
-        // (subject, predicate, object); the materializer resolves direction + tier from
-        // the role declaration.
+    void extract_customPredicateExplicitlyTyped_noPin_isDropped() throws Exception {
+        // gen:hasHelper is a user-defined role predicate deliberately kept out of
+        // BackcompatRolePredicates as the pinning pilot (issue #136 Part B). Without a
+        // pubinfo direction pin the extractor cannot classify it and DROPS it (strict — no
+        // neutral binding is emitted).
         IRI hasHelper = vf.createIRI("https://w3id.org/kpxl/gen/terms/hasHelper");
         Nanopub np = creator()
                 .type(GEN.ROLE_INSTANTIATION)
@@ -378,27 +375,15 @@ class SpacesExtractorTest {
                 .finalizeNanopub();
 
         List<Statement> out = SpacesExtractor.extract(np, defaultContext());
-        IRI subject = forRoleInstantiation(ARTIFACT_CODE, Utils.createHash(hasHelper.stringValue()));
 
-        assertContains(out, subject, RDF.TYPE, GEN.ROLE_INSTANTIATION);
-        assertContains(out, subject, ROLE_PREDICATE, hasHelper);
-        assertContains(out, subject, BINDING_SUBJECT, SPACE_IRI_1);
-        assertContains(out, subject, BINDING_OBJECT, MEMBER_AGENT);
-        assertContains(out, subject, VIA_NANOPUB, NP_URI);
-        // No direction was committed: neither the classified split nor regular/inverse.
-        assertDoesNotContain(out, subject, FOR_SPACE, SPACE_IRI_1);
-        assertDoesNotContain(out, subject, FOR_AGENT, MEMBER_AGENT);
-        assertDoesNotContain(out, subject, INVERSE_PROPERTY, hasHelper);
-        assertDoesNotContain(out, subject, REGULAR_PROPERTY, hasHelper);
+        assertTrue(out.isEmpty(), "Unpinned custom-predicate instantiation must be dropped");
     }
 
     @Test
     void extract_customPredicateNotExplicitlyTyped_emitsNothing() throws Exception {
         // Without an explicit gen:RoleInstantiation type, a single-triple
         // <space> hasHelper <agent> only auto-types as hasHelper, which is not a
-        // trigger type — so the nanopub isn't space-relevant and nothing is emitted. (The
-        // neutral path is gated on the explicit type to avoid minting inert entries for
-        // incidental IRI-valued triples in nanopubs matched only via a backcompat predicate.)
+        // trigger type — so the nanopub isn't space-relevant and nothing is emitted.
         IRI hasHelper = vf.createIRI("https://w3id.org/kpxl/gen/terms/hasHelper");
         Nanopub np = creator()
                 .assertion(SPACE_IRI_1, hasHelper, MEMBER_AGENT)
@@ -407,6 +392,102 @@ class SpacesExtractorTest {
         List<Statement> out = SpacesExtractor.extract(np, defaultContext());
 
         assertTrue(out.isEmpty(), "Untyped custom-predicate binding must not be space-relevant");
+    }
+
+    @Test
+    void extract_pinnedInversePredicate_emitsResolvedRoleInstantiation_issue136() throws Exception {
+        // A pubinfo pin <pred> a gen:InverseRoleProperty lets the extractor resolve direction
+        // from the assigning nanopub alone: <space> hasHelper <agent> is space-centric.
+        IRI hasHelper = vf.createIRI("https://w3id.org/kpxl/gen/terms/hasHelper");
+        Nanopub np = creator()
+                .type(GEN.ROLE_INSTANTIATION)
+                .assertion(SPACE_IRI_1, hasHelper, MEMBER_AGENT)
+                .pubinfo(hasHelper, RDF.TYPE, GEN.INVERSE_ROLE_PROPERTY)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forRoleInstantiation(ARTIFACT_CODE,
+                Utils.createHash(hasHelper.stringValue() + "\n" + SPACE_IRI_1.stringValue()));
+
+        assertContains(out, subject, RDF.TYPE, GEN.ROLE_INSTANTIATION);
+        assertContains(out, subject, FOR_SPACE, SPACE_IRI_1);
+        assertContains(out, subject, INVERSE_PROPERTY, hasHelper);
+        assertContains(out, subject, FOR_AGENT, MEMBER_AGENT);
+        // Resolved directly — not left as a neutral binding.
+        assertDoesNotContain(out, subject, ROLE_PREDICATE, hasHelper);
+        assertDoesNotContain(out, subject, REGULAR_PROPERTY, hasHelper);
+    }
+
+    @Test
+    void extract_pinnedRegularPredicate_swapsSpaceAndAgent() throws Exception {
+        // <pred> a gen:RegularRoleProperty → agent-centric source <agent> hasHelper <space>.
+        IRI hasHelper = vf.createIRI("https://w3id.org/kpxl/gen/terms/hasHelper");
+        Nanopub np = creator()
+                .type(GEN.ROLE_INSTANTIATION)
+                .assertion(MEMBER_AGENT, hasHelper, SPACE_IRI_1)
+                .pubinfo(hasHelper, RDF.TYPE, GEN.REGULAR_ROLE_PROPERTY)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forRoleInstantiation(ARTIFACT_CODE,
+                Utils.createHash(hasHelper.stringValue() + "\n" + SPACE_IRI_1.stringValue()));
+
+        assertContains(out, subject, FOR_SPACE, SPACE_IRI_1);   // object side
+        assertContains(out, subject, REGULAR_PROPERTY, hasHelper);
+        assertContains(out, subject, FOR_AGENT, MEMBER_AGENT);  // subject side
+        assertDoesNotContain(out, subject, INVERSE_PROPERTY, hasHelper);
+    }
+
+    @Test
+    void extract_pinnedPredicate_multiSpace_emitsSeparateAssignments() throws Exception {
+        // One nanopub may assign the same predicate across several spaces; each becomes its
+        // own (predicate, space)-keyed RoleInstantiation (multi-space batching).
+        IRI hasHelper = vf.createIRI("https://w3id.org/kpxl/gen/terms/hasHelper");
+        IRI spaceTwo = vf.createIRI("https://example.org/spaces/beta");
+        Nanopub np = creator()
+                .type(GEN.ROLE_INSTANTIATION)
+                .assertion(SPACE_IRI_1, hasHelper, MEMBER_AGENT)
+                .assertion(spaceTwo, hasHelper, ADMIN_AGENT_1)
+                .pubinfo(hasHelper, RDF.TYPE, GEN.INVERSE_ROLE_PROPERTY)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject1 = forRoleInstantiation(ARTIFACT_CODE,
+                Utils.createHash(hasHelper.stringValue() + "\n" + SPACE_IRI_1.stringValue()));
+        IRI subject2 = forRoleInstantiation(ARTIFACT_CODE,
+                Utils.createHash(hasHelper.stringValue() + "\n" + spaceTwo.stringValue()));
+
+        assertNotEquals(subject1, subject2);
+        assertContains(out, subject1, FOR_SPACE, SPACE_IRI_1);
+        assertContains(out, subject1, FOR_AGENT, MEMBER_AGENT);
+        assertContains(out, subject1, INVERSE_PROPERTY, hasHelper);
+        assertContains(out, subject2, FOR_SPACE, spaceTwo);
+        assertContains(out, subject2, FOR_AGENT, ADMIN_AGENT_1);
+        assertContains(out, subject2, INVERSE_PROPERTY, hasHelper);
+    }
+
+    @Test
+    void extract_spaceWithInlinePinnedPredicate_emitsResolvedRoleInstantiation() throws Exception {
+        // A gen:Space nanopub may declare a pinned user-defined role inline; the inline path
+        // honors the pubinfo pin too (issue #136 Part B). Inline entries key on the predicate
+        // hash (single space).
+        IRI hasHelper = vf.createIRI("https://w3id.org/kpxl/gen/terms/hasHelper");
+        Nanopub np = creator()
+                .type(GEN.SPACE)
+                .assertion(SPACE_IRI_1, RDF.TYPE, GEN.SPACE)
+                .assertion(SPACE_IRI_1, GEN.HAS_ROOT_DEFINITION, NP_URI)
+                .assertion(SPACE_IRI_1, GEN.HAS_ADMIN, ADMIN_AGENT_1)
+                .assertion(SPACE_IRI_1, hasHelper, MEMBER_AGENT)
+                .pubinfo(hasHelper, RDF.TYPE, GEN.INVERSE_ROLE_PROPERTY)
+                .finalizeNanopub();
+
+        List<Statement> out = SpacesExtractor.extract(np, defaultContext());
+        IRI subject = forRoleInstantiation(ARTIFACT_CODE, Utils.createHash(hasHelper.stringValue()));
+
+        assertContains(out, subject, RDF.TYPE, GEN.ROLE_INSTANTIATION);
+        assertContains(out, subject, FOR_SPACE, SPACE_IRI_1);
+        assertContains(out, subject, INVERSE_PROPERTY, hasHelper);
+        assertContains(out, subject, FOR_AGENT, MEMBER_AGENT);
     }
 
     @Test
@@ -1136,6 +1217,11 @@ class SpacesExtractorTest {
 
         NanopubBuilder assertion(IRI s, IRI p, org.eclipse.rdf4j.model.Value o) throws Exception {
             nc.addAssertionStatement(s, p, o);
+            return this;
+        }
+
+        NanopubBuilder pubinfo(IRI s, IRI p, org.eclipse.rdf4j.model.Value o) throws Exception {
+            nc.addPubinfoStatement(s, p, o);
             return this;
         }
 


### PR DESCRIPTION
## Summary

Part B of the role-direction-pinning design (`doc/design-role-direction-pinning.md`), addressing #136.

A role-assigning nanopub can now **pin its predicate's direction in pubinfo**:

```turtle
# pubinfo
gen:hasHelper a gen:InverseRoleProperty .   # or gen:RegularRoleProperty
```

The extractor resolves a user-defined predicate from the nanopub alone and emits the normalized `npa:forSpace` / `npa:forAgent` / `npa:inverseProperty` shape directly into `npa:spacesGraph` — so `get-space-members` (which reads the **raw** `spacesGraph`, flagging validation via the state graph) surfaces the member without a materializer round-trip. This is the mechanism that lets `gen:hasHelper` — deliberately left out of `BackcompatRolePredicates` (Part A, #e3ffd81) as the pilot — be surfaced.

## Changes

- **`GEN`** — add `InverseRoleProperty` / `RegularRoleProperty`.
- **`SpacesExtractor`**
  - `directionPins(np)` reads the pubinfo pins.
  - shared `resolveDirection(pred, pins)` with precedence **`BackcompatRolePredicates` → pin → drop**, wired into both `extractRoleInstantiation` and `emitInlineRoleInstantiations`.
  - `extractRoleInstantiation`'s former neutral branch is **replaced** by pin-resolution: grouped by `(space, predicate)` with multi-valued `forAgent`, one subject per `(predicate, space)` (**multi-space batching**). Unpinned custom predicates are **dropped** (strict) — no neutral binding.
  - the stable backcompat *classified* branch is left unchanged (legacy one-per-nanopub); multi-space applies to the pinned/forward path.
- **Tests** — strict-drop assertions for the unpinned case + 4 new pin tests (inverse, regular/swap, multi-space, inline-pinned).

Full suite: **328 passing**.

## Deliberately kept (removed in a later follow-up)

The materializer's `nonAdminTierUpdate` arms 3–4 and the `spacesGraph` neutral-binding vocab stay: existing neutral rows still rely on them until a full re-ingest. Removal is the post-re-ingest cleanup.

## Not in this PR (needed to fully close #136 for `hasHelper`)

1. Nanodash emits the pin (may precede formal kpxl-vocab publication).
2. Migrate existing `hasHelper` instances (republish with pins).
3. Full re-ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)