### PR TITLE
feat(loader): periodic shard-consistency sweep to detect and repair missing shard writes

### DIFF
--- a/src/main/java/com/knowledgepixels/query/FeatureFlags.java
+++ b/src/main/java/com/knowledgepixels/query/FeatureFlags.java
@@ -107,6 +107,21 @@ public final class FeatureFlags {
                 Utils.getEnvString("NANOPUB_QUERY_ENABLE_LAST30D_REPO", "true"));
     }
 
+    /**
+     * When {@code false}, the periodic shard-consistency sweep
+     * ({@link ShardReconciler#tick()}) is disabled: no reconciliation checkpoint
+     * is established and missing shards are never detected or re-loaded.
+     *
+     * <p>Controlled by the {@code NANOPUB_QUERY_ENABLE_RECONCILIATION} environment
+     * variable. Default: {@code true}.
+     *
+     * @return {@code true} if the shard-consistency sweep is enabled
+     */
+    public static boolean reconciliationEnabled() {
+        return "true".equalsIgnoreCase(
+                Utils.getEnvString("NANOPUB_QUERY_ENABLE_RECONCILIATION", "true"));
+    }
+
     private FeatureFlags() {
     }
 

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -68,6 +68,10 @@ public class MainVerticle extends AbstractVerticle {
             logger.warn("Writes to the 'last30d' repo disabled via NANOPUB_QUERY_ENABLE_LAST30D_REPO=false — "
                     + "the /repo/last30d endpoint will be empty; rewrite queries against /repo/full with a date filter.");
         }
+        if (!FeatureFlags.reconciliationEnabled()) {
+            logger.warn("Shard reconciliation disabled via NANOPUB_QUERY_ENABLE_RECONCILIATION=false — "
+                    + "nanopubs silently missing from individual shard repos (issue #139) will not be detected or repaired.");
+        }
         HttpClient httpClient = vertx.createHttpClient(
                 new HttpClientOptions()
                         .setConnectTimeout(Utils.getEnvInt("NANOPUB_QUERY_VERTX_CONNECT_TIMEOUT", 1000))
@@ -560,6 +564,22 @@ public class MainVerticle extends AbstractVerticle {
                     JellyNanopubLoader.UPDATES_POLL_INTERVAL,
                     JellyNanopubLoader.UPDATES_POLL_INTERVAL,
                     TimeUnit.MILLISECONDS
+            );
+
+            // Periodic shard-consistency sweep (issue #139): verifies that recently
+            // loaded nanopubs actually landed in every shard repo their metadata
+            // implies, and re-loads any that are missing. Own single-threaded
+            // executor; scheduleWithFixedDelay serialises ticks. The tick itself
+            // no-ops unless the reconciliation flag is on and the state is READY.
+            Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(
+                    () -> {
+                        try {
+                            ShardReconciler.tick();
+                        } catch (Exception ex) {
+                            logger.warn("Shard reconciliation tick failed", ex);
+                        }
+                    },
+                    15, 15, TimeUnit.MINUTES
             );
 
             // Periodic authority-resolver tick: detects trust-state flips and

--- a/src/main/java/com/knowledgepixels/query/MetricsCollector.java
+++ b/src/main/java/com/knowledgepixels/query/MetricsCollector.java
@@ -59,6 +59,19 @@ public final class MetricsCollector {
                 .description("Seconds since the last non-exceptional loadUpdates return (idle or loading)")
                 .register(meterRegistry);
 
+        // Shard-reconciliation observability (issue #139). Both read volatile
+        // counters kept by ShardReconciler — no SPARQL on the scrape path. Any
+        // non-zero repaired value means the backend acknowledged a shard write
+        // that was not durable, and deserves an alert.
+        Gauge.builder("registry.reconciler.nanopubs_checked_total",
+                        () -> (double) ShardReconciler.checkedNanopubCount)
+                .description("Nanopubs whose shard fan-out was verified by the reconciliation sweep since process start")
+                .register(meterRegistry);
+        Gauge.builder("registry.reconciler.shards_repaired_total",
+                        () -> (double) ShardReconciler.repairedShardCount)
+                .description("Missing shard repos detected and re-loaded by the reconciliation sweep since process start")
+                .register(meterRegistry);
+
         // Status label metrics
         for (final var status : StatusController.State.values()) {
             AtomicInteger stateGauge = new AtomicInteger(0);

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -587,7 +587,11 @@ public class NanopubLoader {
                 conn.begin(IsolationLevels.SERIALIZABLE);
                 var repoStatus = fetchRepoStatus(conn, npId);
                 if (repoStatus.isLoaded) {
-                    logger.debug("Skipping already-loaded nanopub <{}> in repo '{}'", npId, repoName);
+                    // INFO, not DEBUG: this skip decides that a shard write is unnecessary
+                    // based on a single store read. When the backend misbehaves (issue #139:
+                    // a shard "successfully" written yet not durable), this line is the only
+                    // trace distinguishing a false skip from a lost commit.
+                    logger.info("Skipping already-loaded nanopub <{}> in repo '{}'", npId, repoName);
                 } else {
                     String newChecksum = NanopubUtils.updateXorChecksum(npId, repoStatus.checksum);
                     conn.remove(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, null, NPA.GRAPH);
@@ -663,7 +667,8 @@ public class NanopubLoader {
                 conn.begin(IsolationLevels.SERIALIZABLE);
                 // Idempotency: skip if this nanopub is already stamped in this repo.
                 if (Utils.getObjectForPattern(conn, NPA.GRAPH, npId, NPA.HAS_LOAD_NUMBER) != null) {
-                    logger.debug("Skipping already-loaded nanopub <{}> in spaces repo", npId);
+                    // INFO for the same reason as the loadNanopubToRepo skip (issue #139).
+                    logger.info("Skipping already-loaded nanopub <{}> in spaces repo", npId);
                     conn.commit();
                     success = true;
                     continue;

--- a/src/main/java/com/knowledgepixels/query/ShardReconciler.java
+++ b/src/main/java/com/knowledgepixels/query/ShardReconciler.java
@@ -1,0 +1,451 @@
+package com.knowledgepixels.query;
+
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryResult;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubImpl;
+import org.nanopub.vocabulary.NPA;
+import org.nanopub.vocabulary.NPX;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * Periodic consistency sweep over the per-nanopub repo fan-out (issue #139).
+ *
+ * <p>{@link NanopubLoader#executeLoading} treats a per-shard commit acknowledgement
+ * as truth: once every shard task has reported success, the {@code meta} write is
+ * committed and the load counter moves on. Issue #139 (and the earlier meta-behind-full
+ * incident) showed that the backend can acknowledge a shard write that never becomes
+ * durable — leaving a nanopub silently missing from one shard forever, while
+ * {@code full}/{@code meta} look complete. This class is the safety net: instead of
+ * trusting acks, it periodically compares durable end-state across repos and re-loads
+ * what is missing.
+ *
+ * <p>Each {@link #tick()} processes a bounded window of recently loaded nanopubs:
+ * <ol>
+ *   <li>Enumerate nanopubs from the <em>driver</em> repo ({@code full}, or {@code meta}
+ *       when the full repo is disabled) with a load number above the persisted
+ *       checkpoint and a load timestamp older than {@link #GRACE_MS} (so in-flight
+ *       loads are never flagged).</li>
+ *   <li>Derive each nanopub's expected shard repos from its admin metadata
+ *       ({@code npa:hasValidSignatureForPublicKeyHash}, {@code npx:hasNanopubType})
+ *       using the same type filters as the loader.</li>
+ *   <li>Check {@code npa:hasLoadNumber} membership per shard in batched queries.</li>
+ *   <li>For any nanopub with a missing shard: reconstruct the nanopub from the driver
+ *       repo's four content graphs and re-run {@link NanopubLoader#load(Nanopub, long)},
+ *       which is idempotent per repo and fills exactly the missing shards (including
+ *       recomputed text filter literals and spaces extractions).</li>
+ *   <li>Advance the checkpoint only past nanopubs that verified clean or were
+ *       repaired; on a repair failure the tick stops so the next tick retries.</li>
+ * </ol>
+ *
+ * <p>The checkpoint is initialised to the driver repo's current maximum load number on
+ * the first tick (or when the driver repo changes), so only nanopubs loaded from then
+ * on are swept. Historical gaps can be swept by manually lowering the
+ * {@code npa:hasReconciliationCheckpoint} value in the admin repo.
+ *
+ * <p>Known limitations: nanopubs missing from the driver repo itself are not
+ * detectable here (the registry resync path remains the authority for that), and the
+ * {@code last30d} repo is not checked (its content expires anyway). The {@code spaces}
+ * shard is only expected via the {@link SpacesExtractor#isSpaceRelevant} trigger-type
+ * proxy; a trigger-typed nanopub whose extraction turns out empty is logged and
+ * treated as consistent after re-verification.
+ */
+public class ShardReconciler {
+
+    private static final Logger logger = LoggerFactory.getLogger(ShardReconciler.class);
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    static final IRI HAS_RECONCILIATION_CHECKPOINT = vf.createIRI(NPA.NAMESPACE + "hasReconciliationCheckpoint");
+    // @ADMIN-TRIPLE-TABLE@ REPO, npa:hasReconciliationCheckpoint, LOAD_NUMBER, npa:graph, admin, driver-repo load number up to which shard consistency has been verified
+    static final IRI HAS_RECONCILIATION_DRIVER = vf.createIRI(NPA.NAMESPACE + "hasReconciliationDriver");
+    // @ADMIN-TRIPLE-TABLE@ REPO, npa:hasReconciliationDriver, REPO_NAME, npa:graph, admin, repo the reconciliation checkpoint refers to
+
+    /**
+     * Nanopubs whose driver-repo load timestamp is younger than this are skipped:
+     * their fan-out may still be in flight (the meta task is deferred behind the
+     * other shards, and per-shard retry chains can run for minutes), and flagging
+     * them would race the loader with spurious repairs.
+     */
+    static final long GRACE_MS = 30L * 60 * 1000;
+
+    /**
+     * Upper bound on nanopubs examined per tick, so a large backlog (e.g. after
+     * downtime) drains incrementally instead of producing one huge query.
+     */
+    static final int MAX_NPS_PER_TICK = 1000;
+
+    /**
+     * Cumulative count of nanopubs whose shard fan-out was verified (clean or
+     * repaired) since process start. Read by {@link MetricsCollector}.
+     */
+    static volatile long checkedNanopubCount = 0;
+
+    /**
+     * Cumulative count of shard repos found missing and successfully re-loaded
+     * since process start. Read by {@link MetricsCollector}. Any non-zero value
+     * is evidence of the backend acknowledging a non-durable write.
+     */
+    static volatile long repairedShardCount = 0;
+
+    private ShardReconciler() {
+    }
+
+    /**
+     * Runs one bounded reconciliation pass. Never throws: any failure is logged
+     * and retried on the next tick (the checkpoint only advances past verified
+     * nanopubs). No-op unless the reconciliation feature is enabled and the
+     * service is READY.
+     */
+    public static void tick() {
+        if (!FeatureFlags.reconciliationEnabled()) {
+            return;
+        }
+        if (StatusController.get().getState().state != StatusController.State.READY) {
+            return;
+        }
+        try {
+            runTick();
+        } catch (Exception ex) {
+            logger.warn("Shard reconciliation tick failed; will retry on next tick: {}", ex.getMessage(), ex);
+        }
+    }
+
+    private static void runTick() {
+        String driverRepo = FeatureFlags.fullRepoEnabled() ? "full" : "meta";
+
+        Long checkpoint = readCheckpoint(driverRepo);
+        if (checkpoint == null) {
+            // First run (or driver repo changed): establish the baseline at the
+            // driver's current max load number. Only nanopubs loaded after this
+            // point are swept.
+            long max = fetchMaxLoadNumber(driverRepo);
+            persistCheckpoint(driverRepo, max);
+            logger.info("Shard reconciliation checkpoint initialized at load number {} of repo '{}'", max, driverRepo);
+            return;
+        }
+
+        List<WindowEntry> window = fetchWindow(driverRepo, checkpoint);
+        if (window.isEmpty()) {
+            return;
+        }
+        Map<IRI, NanopubShardInfo> shardInfos = fetchShardInfos(driverRepo, window);
+
+        // Batched membership lookup: one query per distinct shard repo, covering
+        // all window nanopubs that expect it.
+        Map<String, List<IRI>> npsByShard = new LinkedHashMap<>();
+        for (WindowEntry e : window) {
+            NanopubShardInfo info = shardInfos.get(e.npId());
+            if (info == null) {
+                continue;
+            }
+            for (String repo : expectedShardRepos(e.npId(), info.pubkeyHash(), info.types(), driverRepo)) {
+                npsByShard.computeIfAbsent(repo, k -> new ArrayList<>()).add(e.npId());
+            }
+        }
+        Map<String, Set<IRI>> presentByShard = new HashMap<>();
+        for (Map.Entry<String, List<IRI>> e : npsByShard.entrySet()) {
+            presentByShard.put(e.getKey(), fetchPresentNanopubs(e.getKey(), e.getValue()));
+        }
+
+        long newCheckpoint = checkpoint;
+        long checked = 0;
+        long repaired = 0;
+        try {
+            for (WindowEntry e : window) {
+                NanopubShardInfo info = shardInfos.get(e.npId());
+                if (info == null) {
+                    // No pubkey-hash admin triple in the driver repo; nothing we can
+                    // derive shards from. Loud, but don't stall the sweep on it.
+                    logger.warn("Skipping shard reconciliation for <{}>: no npa:hasValidSignatureForPublicKeyHash found in repo '{}'", e.npId(), driverRepo);
+                    newCheckpoint = e.loadNumber();
+                    continue;
+                }
+                List<String> missing = new ArrayList<>();
+                for (String repo : expectedShardRepos(e.npId(), info.pubkeyHash(), info.types(), driverRepo)) {
+                    if (!presentByShard.getOrDefault(repo, Set.of()).contains(e.npId())) {
+                        missing.add(repo);
+                    }
+                }
+                if (!missing.isEmpty()) {
+                    if (!repairNanopub(driverRepo, e.npId(), missing)) {
+                        // Repair failed: stop here so the checkpoint stays before this
+                        // nanopub and the next tick retries.
+                        return;
+                    }
+                    repaired += missing.size();
+                }
+                newCheckpoint = e.loadNumber();
+                checked++;
+            }
+        } finally {
+            checkedNanopubCount += checked;
+            repairedShardCount += repaired;
+            if (newCheckpoint > checkpoint) {
+                persistCheckpoint(driverRepo, newCheckpoint);
+            }
+        }
+        if (repaired > 0) {
+            logger.warn("Shard reconciliation repaired {} missing shard(s) across {} nanopub(s); the backend acknowledged non-durable writes (see issue #139)", repaired, checked);
+        } else {
+            logger.debug("Shard reconciliation verified {} nanopub(s) up to load number {} of repo '{}'", checked, newCheckpoint, driverRepo);
+        }
+    }
+
+    /**
+     * Derives the set of shard repos the loader is expected to have populated for
+     * a nanopub, from its admin metadata: {@code meta}, {@code full}/{@code text}
+     * (feature-flagged), the signer's pubkey repo, one type repo per eligible
+     * computed type (same exclusions as {@link NanopubLoader#executeLoading}:
+     * locally-minted IRIs and non-http(s) IRIs are skipped), and {@code spaces}
+     * for trigger-typed nanopubs. The driver repo itself is excluded — membership
+     * there is what put the nanopub in the window. {@code last30d} is not checked
+     * (expiring content).
+     */
+    static Set<String> expectedShardRepos(IRI npId, String pubkeyHash, Set<IRI> types, String driverRepo) {
+        Set<String> repos = new LinkedHashSet<>();
+        repos.add("meta");
+        if (FeatureFlags.fullRepoEnabled()) {
+            repos.add("full");
+        }
+        if (FeatureFlags.textRepoEnabled()) {
+            repos.add("text");
+        }
+        repos.add("pubkey_" + pubkeyHash);
+        for (IRI typeIri : types) {
+            if (typeIri.stringValue().startsWith(npId.stringValue())) {
+                continue;
+            }
+            if (!typeIri.stringValue().matches("https?://.*")) {
+                continue;
+            }
+            repos.add("type_" + Utils.createHash(typeIri));
+        }
+        if (FeatureFlags.spacesEnabled() && SpacesExtractor.isSpaceRelevant(types)) {
+            repos.add("spaces");
+        }
+        repos.remove(driverRepo);
+        return repos;
+    }
+
+    /**
+     * Re-loads a nanopub with missing shards: reconstructs it from the driver
+     * repo's four content graphs and re-runs the full (idempotent) load, then
+     * re-verifies the shards that were missing. A {@code spaces} shard that is
+     * still missing after a successful re-load means the trigger-type proxy
+     * over-approximated (empty extraction) — logged and treated as consistent.
+     *
+     * @return true if all missing shards are accounted for afterwards
+     */
+    private static boolean repairNanopub(String driverRepo, IRI npId, List<String> missing) {
+        logger.warn("Nanopub <{}> is missing from shard repo(s) {}; re-loading (see issue #139)", npId, missing);
+        Nanopub np;
+        try {
+            np = reconstructNanopub(driverRepo, npId);
+        } catch (Exception ex) {
+            logger.warn("Could not reconstruct nanopub <{}> from repo '{}': {}", npId, driverRepo, ex.getMessage(), ex);
+            return false;
+        }
+        try {
+            NanopubLoader.load(np, -1);
+        } catch (Exception ex) {
+            logger.warn("Re-load of nanopub <{}> failed: {}", npId, ex.getMessage(), ex);
+            return false;
+        }
+        boolean allRepaired = true;
+        for (String repo : missing) {
+            if (fetchPresentNanopubs(repo, List.of(npId)).contains(npId)) {
+                logger.warn("Repaired: nanopub <{}> re-loaded into shard repo '{}'", npId, repo);
+            } else if ("spaces".equals(repo)) {
+                logger.info("Nanopub <{}> still absent from 'spaces' after re-load; its extraction is empty, treating as consistent", npId);
+            } else {
+                logger.warn("Nanopub <{}> still missing from shard repo '{}' after re-load", npId, repo);
+                allRepaired = false;
+            }
+        }
+        return allRepaired;
+    }
+
+    /**
+     * Rebuilds a {@link Nanopub} object from the four content graphs stored in the
+     * given repo, discovered via {@code <npId> npa:hasGraph ?g} in {@code npa:graph}.
+     */
+    static Nanopub reconstructNanopub(String repoName, IRI npId) throws MalformedNanopubException {
+        List<Statement> content = new ArrayList<>();
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(repoName)) {
+            List<IRI> graphs = new ArrayList<>();
+            try (RepositoryResult<Statement> r = conn.getStatements(npId, NPA.HAS_GRAPH, null, NPA.GRAPH)) {
+                while (r.hasNext()) {
+                    Value o = r.next().getObject();
+                    if (o instanceof IRI iri) {
+                        graphs.add(iri);
+                    }
+                }
+            }
+            for (IRI g : graphs) {
+                try (RepositoryResult<Statement> r = conn.getStatements(null, null, null, g)) {
+                    while (r.hasNext()) {
+                        content.add(r.next());
+                    }
+                }
+            }
+        }
+        return new NanopubImpl(content);
+    }
+
+    private record WindowEntry(IRI npId, long loadNumber) {
+    }
+
+    private record NanopubShardInfo(String pubkeyHash, Set<IRI> types) {
+    }
+
+    /**
+     * Fetches the next batch of nanopubs to verify: load number above the
+     * checkpoint, load timestamp older than the grace period, ordered by load
+     * number, capped at {@link #MAX_NPS_PER_TICK}.
+     */
+    private static List<WindowEntry> fetchWindow(String driverRepo, long checkpoint) {
+        List<WindowEntry> window = new ArrayList<>();
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(driverRepo)) {
+            TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL,
+                    "SELECT ?np ?ln WHERE { graph <" + NPA.GRAPH + "> { "
+                    + "?np <" + NPA.HAS_LOAD_NUMBER + "> ?ln ; <" + NPA.HAS_LOAD_TIMESTAMP + "> ?ts . "
+                    + "FILTER (?ln > " + checkpoint + ") FILTER (?ts <= ?cutoff) "
+                    + "} } ORDER BY ?ln LIMIT " + MAX_NPS_PER_TICK);
+            q.setBinding("cutoff", vf.createLiteral(new Date(System.currentTimeMillis() - GRACE_MS)));
+            try (TupleQueryResult r = q.evaluate()) {
+                while (r.hasNext()) {
+                    BindingSet b = r.next();
+                    if (b.getValue("np") instanceof IRI npId) {
+                        window.add(new WindowEntry(npId, Long.parseLong(b.getValue("ln").stringValue())));
+                    }
+                }
+            }
+        }
+        return window;
+    }
+
+    /**
+     * Fetches pubkey hash and computed types for the window's nanopubs from the
+     * driver repo's admin graph in one query.
+     */
+    private static Map<IRI, NanopubShardInfo> fetchShardInfos(String driverRepo, List<WindowEntry> window) {
+        Map<IRI, NanopubShardInfo> result = new HashMap<>();
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(driverRepo)) {
+            TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL,
+                    "SELECT ?np ?ph ?t WHERE { graph <" + NPA.GRAPH + "> { "
+                    + valuesClause(window.stream().map(WindowEntry::npId).toList())
+                    + "?np <" + NPA.HAS_VALID_SIGNATURE_FOR_PUBLIC_KEY_HASH + "> ?ph . "
+                    + "OPTIONAL { ?np <" + NPX.HAS_NANOPUB_TYPE + "> ?t } "
+                    + "} }");
+            try (TupleQueryResult r = q.evaluate()) {
+                while (r.hasNext()) {
+                    BindingSet b = r.next();
+                    if (!(b.getValue("np") instanceof IRI npId)) {
+                        continue;
+                    }
+                    NanopubShardInfo info = result.computeIfAbsent(npId,
+                            k -> new NanopubShardInfo(b.getValue("ph").stringValue(), new LinkedHashSet<>()));
+                    if (b.getValue("t") instanceof IRI typeIri) {
+                        info.types().add(typeIri);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns which of the given nanopubs carry an {@code npa:hasLoadNumber} stamp
+     * in the given repo's admin graph.
+     */
+    private static Set<IRI> fetchPresentNanopubs(String repoName, List<IRI> npIds) {
+        Set<IRI> present = new HashSet<>();
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(repoName)) {
+            TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL,
+                    "SELECT ?np WHERE { graph <" + NPA.GRAPH + "> { "
+                    + valuesClause(npIds)
+                    + "?np <" + NPA.HAS_LOAD_NUMBER + "> ?ln . "
+                    + "} }");
+            try (TupleQueryResult r = q.evaluate()) {
+                while (r.hasNext()) {
+                    BindingSet b = r.next();
+                    if (b.getValue("np") instanceof IRI npId) {
+                        present.add(npId);
+                    }
+                }
+            }
+        }
+        return present;
+    }
+
+    private static String valuesClause(List<IRI> npIds) {
+        StringBuilder sb = new StringBuilder("VALUES ?np { ");
+        for (IRI npId : npIds) {
+            sb.append("<").append(npId.stringValue()).append("> ");
+        }
+        sb.append("} ");
+        return sb.toString();
+    }
+
+    private static long fetchMaxLoadNumber(String repoName) {
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(repoName)) {
+            TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL,
+                    "SELECT (MAX(?ln) AS ?maxLn) WHERE { graph <" + NPA.GRAPH + "> { "
+                    + "?np <" + NPA.HAS_LOAD_NUMBER + "> ?ln . } }");
+            try (TupleQueryResult r = q.evaluate()) {
+                if (r.hasNext()) {
+                    Value v = r.next().getValue("maxLn");
+                    if (v != null) {
+                        return Long.parseLong(v.stringValue());
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Reads the persisted checkpoint from the admin repo, or {@code null} if none
+     * exists yet or it was recorded against a different driver repo.
+     */
+    private static Long readCheckpoint(String driverRepo) {
+        try (RepositoryConnection conn = TripleStore.get().getAdminRepoConnection()) {
+            Value driver = Utils.getObjectForPattern(conn, NPA.GRAPH, NPA.THIS_REPO, HAS_RECONCILIATION_DRIVER);
+            Value cp = Utils.getObjectForPattern(conn, NPA.GRAPH, NPA.THIS_REPO, HAS_RECONCILIATION_CHECKPOINT);
+            if (driver == null || cp == null || !driverRepo.equals(driver.stringValue())) {
+                return null;
+            }
+            return Long.parseLong(cp.stringValue());
+        } catch (NumberFormatException ex) {
+            logger.warn("Malformed npa:hasReconciliationCheckpoint literal in admin repo: {}", ex.getMessage());
+            return null;
+        }
+    }
+
+    private static void persistCheckpoint(String driverRepo, long checkpoint) {
+        try (RepositoryConnection conn = TripleStore.get().getAdminRepoConnection()) {
+            conn.begin(IsolationLevels.SERIALIZABLE);
+            conn.remove(NPA.THIS_REPO, HAS_RECONCILIATION_DRIVER, null, NPA.GRAPH);
+            conn.remove(NPA.THIS_REPO, HAS_RECONCILIATION_CHECKPOINT, null, NPA.GRAPH);
+            conn.add(NPA.THIS_REPO, HAS_RECONCILIATION_DRIVER, vf.createLiteral(driverRepo), NPA.GRAPH);
+            conn.add(NPA.THIS_REPO, HAS_RECONCILIATION_CHECKPOINT, vf.createLiteral(checkpoint), NPA.GRAPH);
+            conn.commit();
+        }
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/query/ShardReconcilerTest.java
+++ b/src/test/java/com/knowledgepixels/query/ShardReconcilerTest.java
@@ -1,0 +1,121 @@
+package com.knowledgepixels.query;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubImpl;
+import org.nanopub.NanopubUtils;
+import org.nanopub.testsuite.NanopubTestSuite;
+import org.nanopub.vocabulary.NPA;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ShardReconcilerTest {
+
+    private static final SimpleValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final IRI npId = vf.createIRI("https://w3id.org/np/RAabcdefghijklmnopqrstuvwxyzABCDEFGHIJK12345");
+    private static final String pubkeyHash = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    private static MockedStatic<Utils> mockHashSideEffects() {
+        // createHash writes unseen hash mappings to the admin repo; pretend all
+        // hashes are known so the derivation stays free of TripleStore access.
+        MockedStatic<Utils> mockedUtils = mockStatic(Utils.class, CALLS_REAL_METHODS);
+        Map<String, Value> hashToObjectMap = mock(Map.class);
+        when(hashToObjectMap.containsKey(anyString())).thenReturn(true);
+        mockedUtils.when(Utils::getHashToObjectMap).thenReturn(hashToObjectMap);
+        return mockedUtils;
+    }
+
+    @Test
+    void expectedShardReposCoversCoreAndTypeRepos() {
+        try (MockedStatic<Utils> ignored = mockHashSideEffects()) {
+            IRI typeA = vf.createIRI("https://w3id.org/kpxl/gen/terms/ResourceView");
+            IRI typeB = vf.createIRI("http://example.org/SomeType");
+            Set<String> repos = ShardReconciler.expectedShardRepos(npId, pubkeyHash, Set.of(typeA, typeB), "full");
+            assertTrue(repos.contains("meta"));
+            assertTrue(repos.contains("text"));
+            assertTrue(repos.contains("pubkey_" + pubkeyHash));
+            assertTrue(repos.contains("type_" + Utils.createHash(typeA)));
+            assertTrue(repos.contains("type_" + Utils.createHash(typeB)));
+            // The driver repo itself is excluded — membership there is the premise.
+            assertFalse(repos.contains("full"));
+            assertFalse(repos.contains("spaces"));
+            assertFalse(repos.contains("last30d"));
+        }
+    }
+
+    @Test
+    void expectedShardReposAppliesLoaderTypeFilters() {
+        try (MockedStatic<Utils> ignored = mockHashSideEffects()) {
+            IRI locallyMinted = vf.createIRI(npId.stringValue() + "/localType");
+            IRI nonHttp = vf.createIRI("urn:some:type");
+            IRI regular = vf.createIRI("https://example.org/RegularType");
+            Set<String> repos = ShardReconciler.expectedShardRepos(npId, pubkeyHash, Set.of(locallyMinted, nonHttp, regular), "full");
+            assertTrue(repos.contains("type_" + Utils.createHash(regular)));
+            assertEquals(1, repos.stream().filter(r -> r.startsWith("type_")).count(),
+                    "locally-minted and non-http(s) type IRIs must not produce type shards");
+        }
+    }
+
+    @Test
+    void expectedShardReposIncludesSpacesForTriggerTypes() {
+        try (MockedStatic<Utils> ignored = mockHashSideEffects()) {
+            IRI triggerType = SpacesExtractor.TRIGGER_TYPES.iterator().next();
+            Set<String> repos = ShardReconciler.expectedShardRepos(npId, pubkeyHash, Set.of(triggerType), "full");
+            assertTrue(repos.contains("spaces"));
+        }
+    }
+
+    @Test
+    void expectedShardReposWithMetaDriverExpectsFull() {
+        try (MockedStatic<Utils> ignored = mockHashSideEffects()) {
+            Set<String> repos = ShardReconciler.expectedShardRepos(npId, pubkeyHash, Set.of(), "meta");
+            assertTrue(repos.contains("full"));
+            assertFalse(repos.contains("meta"));
+        }
+    }
+
+    @Test
+    void reconstructNanopubRoundTrip() throws MalformedNanopubException, IOException {
+        Nanopub original = new NanopubImpl(NanopubTestSuite.getLatest()
+                .getByArtifactCode("RA6T-YLqLnYd5XfnqR9PaGUjCzudvHdYjcG4GvOc7fdpA").getFirst().toFile());
+
+        SailRepository repo = new SailRepository(new MemoryStore());
+        repo.init();
+        try (var conn = repo.getConnection()) {
+            // Store the nanopub the way loadNanopubToRepo does: the four content
+            // graphs plus the npa:hasGraph admin pointers used for discovery.
+            conn.add(NanopubUtils.getStatements(original));
+            for (IRI g : new IRI[]{original.getHeadUri(), original.getAssertionUri(),
+                    original.getProvenanceUri(), original.getPubinfoUri()}) {
+                conn.add(original.getUri(), NPA.HAS_GRAPH, g, NPA.GRAPH);
+            }
+        }
+
+        TripleStore tripleStore = mock(TripleStore.class);
+        when(tripleStore.getRepoConnection("full")).thenAnswer(inv -> repo.getConnection());
+        try (MockedStatic<TripleStore> mockedTripleStore = mockStatic(TripleStore.class)) {
+            mockedTripleStore.when(TripleStore::get).thenReturn(tripleStore);
+            Nanopub reconstructed = ShardReconciler.reconstructNanopub("full", original.getUri());
+            assertEquals(original.getUri(), reconstructed.getUri());
+            assertEquals(original.getAssertionUri(), reconstructed.getAssertionUri());
+            assertEquals(NanopubUtils.getStatements(original).size(),
+                    NanopubUtils.getStatements(reconstructed).size());
+        } finally {
+            repo.shutDown();
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #139.

## Problem

#139 documented a nanopub that ended up in `full`, its pubkey repo, `meta`, and one of its two type repos — but silently missing from the other (`type_ec6722…`/ResourceView), with internally consistent count/checksum in the affected repo. The investigation showed all six shard tasks reported success within ~150 ms on a clean first load attempt, so the backend acknowledged a write that never became durable (or returned a false "already loaded" answer). Nothing re-checks shards afterwards, so the divergence was permanent. The June meta-behind-full incident (4,763 nanopubs) has the same signature.

## Fix: reconciliation instead of trusting acks

New `ShardReconciler`, scheduled every 15 minutes (no-op unless READY and the new `NANOPUB_QUERY_ENABLE_RECONCILIATION` flag is on, default true):

- Enumerates recently loaded nanopubs from a **driver repo** (`full`, or `meta` when the full repo is disabled): load number above a persisted checkpoint, load timestamp older than a 30-minute grace window (so in-flight loads are never flagged), max 1,000 per tick.
- Derives each nanopub's expected shard repos from its stored admin metadata (`npa:hasValidSignatureForPublicKeyHash`, `npx:hasNanopubType` with the loader's exact type filters, `spaces` via the trigger-type proxy; `last30d` excluded) and batch-checks `npa:hasLoadNumber` membership with one `VALUES` query per distinct shard repo.
- Repairs a missing shard by reconstructing the nanopub from the driver's four content graphs and re-running the idempotent `NanopubLoader.load()` — only the missing shards get written, with correctly recomputed text filter literals and spaces extractions.
- The checkpoint (`npa:hasReconciliationCheckpoint` + `npa:hasReconciliationDriver` on `npa:thisRepo` in the admin repo) only advances past verified nanopubs; failed repairs retry next tick. It initializes at the driver's current max load number, so only new loads are swept — lower it manually for a historical backfill (e.g. to heal the #139 nanopub on query.knowledgepixels.com after deploying, or the June meta gap).

Also:
- Gauges `registry.reconciler.nanopubs_checked_total` and `registry.reconciler.shards_repaired_total`; any non-zero repaired value means the backend acknowledged a non-durable write and deserves an alert.
- The "Skipping already-loaded nanopub" logs in `loadNanopubToRepo`/`loadToSpacesRepo` are bumped DEBUG → INFO — that line is the only trace that distinguishes a false skip from a lost commit next time this happens.

## Verification

- 5 new tests (`ShardReconcilerTest`): shard derivation incl. the loader's type filters and driver exclusion, spaces trigger, meta-driver case, and a real reconstruction round-trip through an in-memory store. Full suite: 333 tests green.
- End-to-end on a local instance: re-created the production incident byte-for-byte (removed the #139 nanopub from its ResourceView type repo, set count/checksum to the exact observed production values, lowered the checkpoint). The next tick detected the missing shard, repaired it in ~70 ms, restored the exact correct count/checksum, and re-advanced the checkpoint; metrics read `checked=15`, `repaired=1`.

Known limitation (documented in the class javadoc): nanopubs missing from the driver repo itself are not detectable here — the registry resync path remains the authority for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)