### PR TITLE
feat(reconciler): retro pass for verified-then-lost shards + healthcheck restart softening

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,12 +81,32 @@ services:
         # healthy. Probe that exact route and restart when it no longer
         # answers. Uses NANOPUB_QUERY_INTERNAL_URL (with trailing slash);
         # skipped when explicitly set to empty.
+        # restart_tomcat gives Tomcat up to 60 s to stop gracefully before the
+        # kill -9: dozens of LMDB repos need to close cleanly, and the previous
+        # 10 s window meant effectively every restart was a hard kill — which
+        # the 2026-07-29 incident (issue #142) showed can discard acknowledged
+        # writes held in a wedged store. The 10-minute backoff prevents restart
+        # storms: a persistently wedged repo used to trigger a kill every probe
+        # interval, multiplying the data-loss windows; now the probe reports
+        # unhealthy without re-killing until the backoff elapses.
         test: |
           restart_tomcat() {
+            if [ -f /var/info/restart ]; then
+              last_s=$$(date -d "$$(tail -1 /var/info/restart)" +%s 2>/dev/null || echo 0)
+              if [ $$(( $$(date +%s) - last_s )) -lt 600 ]; then
+                return
+              fi
+            fi
             date >> /var/info/restart
             pkill -15 java
-            sleep 10
-            pkill -9 java
+            i=0
+            while [ $$i -lt 12 ] && pgrep java > /dev/null; do
+              sleep 5
+              i=$$((i + 1))
+            done
+            if pgrep java > /dev/null; then
+              pkill -9 java
+            fi
           }
           if ! curl -fsS --retry 2 --max-time 10 --retry-delay 2 --retry-max-time 10 --retry-connrefused \
               "http://localhost:8080/rdf4j-server/repositories/full?query=select%2Awhere%7B%3Fs%3Cx%3A%3E%3Fo%7Dlimit1" > /dev/null; then

--- a/src/main/java/com/knowledgepixels/query/MetricsCollector.java
+++ b/src/main/java/com/knowledgepixels/query/MetricsCollector.java
@@ -71,6 +71,10 @@ public final class MetricsCollector {
                         () -> (double) ShardReconciler.repairedShardCount)
                 .description("Missing shard repos detected and re-loaded by the reconciliation sweep since process start")
                 .register(meterRegistry);
+        Gauge.builder("registry.reconciler.shards_relost_total",
+                        () -> (double) ShardReconciler.relostShardCount)
+                .description("Shards that a previous sweep verified present and that later vanished (backend revoked readable state, issue #142)")
+                .register(meterRegistry);
 
         // Status label metrics
         for (final var status : StatusController.State.values()) {

--- a/src/main/java/com/knowledgepixels/query/ShardReconciler.java
+++ b/src/main/java/com/knowledgepixels/query/ShardReconciler.java
@@ -101,6 +101,19 @@ public class ShardReconciler {
     static final int MAX_NPS_PER_TICK = 1000;
 
     /**
+     * How far below the checkpoint the retro pass re-verifies. The forward sweep
+     * proves shard membership once and moves on — but the 2026-07-29 incident
+     * (issue #142) showed the backend can revoke a write <em>after</em> it was
+     * acknowledged and readable: a shard verified present at sweep time vanished
+     * when the store's wedged state was discarded by a later restart. The retro
+     * pass therefore re-verifies every nanopub whose driver-repo load timestamp
+     * is within this window, even though their load numbers are at or below the
+     * checkpoint. Losses older than this window can still be caught by manually
+     * lowering the checkpoint ({@code scripts/set-reconciliation-checkpoint.sh}).
+     */
+    static final long RETRO_WINDOW_MS = 24L * 60 * 60 * 1000;
+
+    /**
      * Cumulative count of nanopubs whose shard fan-out was verified (clean or
      * repaired) since process start. Read by {@link MetricsCollector}.
      */
@@ -113,13 +126,25 @@ public class ShardReconciler {
      */
     static volatile long repairedShardCount = 0;
 
+    /**
+     * Cumulative count of shard losses detected by the retro pass: shards that a
+     * previous sweep verified present and that have since vanished. Read by
+     * {@link MetricsCollector}. This is the direct "backend revoked durable
+     * state" incident counter (issue #142) — even sharper evidence than
+     * {@link #repairedShardCount}, which also counts never-landed writes.
+     */
+    static volatile long relostShardCount = 0;
+
     private ShardReconciler() {
     }
 
     /**
-     * Runs one bounded reconciliation pass. Never throws: any failure is logged
-     * and retried on the next tick (the checkpoint only advances past verified
-     * nanopubs). No-op unless the reconciliation feature is enabled and the
+     * Runs one bounded reconciliation pass: the forward sweep (nanopubs above
+     * the checkpoint) followed by the retro pass (re-verification of the
+     * trailing {@link #RETRO_WINDOW_MS} at or below the checkpoint). Never
+     * throws: any failure is logged and retried on the next tick (the
+     * checkpoint only advances past verified nanopubs; the retro pass is
+     * stateless). No-op unless the reconciliation feature is enabled and the
      * service is READY.
      */
     public static void tick() {
@@ -133,6 +158,11 @@ public class ShardReconciler {
             runTick();
         } catch (Exception ex) {
             logger.warn("Shard reconciliation tick failed; will retry on next tick: {}", ex.getMessage(), ex);
+        }
+        try {
+            runRetroTick();
+        } catch (Exception ex) {
+            logger.warn("Shard retro-verification tick failed; will retry on next tick: {}", ex.getMessage(), ex);
         }
     }
 
@@ -228,6 +258,105 @@ public class ShardReconciler {
         } else {
             logger.debug("Shard reconciliation verified {} nanopub(s) up to load number {} of repo '{}'", checked, newCheckpoint, driverRepo);
         }
+    }
+
+    /**
+     * Retro pass: re-verifies nanopubs the forward sweep already passed —
+     * everything with a driver-repo load timestamp inside {@link #RETRO_WINDOW_MS}
+     * and a load number at or below the checkpoint. A shard found missing here
+     * was present when the forward sweep verified it, i.e. the backend revoked
+     * previously readable state (issue #142) — counted separately in
+     * {@link #relostShardCount} and logged loudly with the nanopub IRI so the
+     * incident window is pinned for server-side log capture. Unlike the forward
+     * sweep, a failed repair does not halt anything: the pass is stateless and
+     * re-derives its window from time on every tick, so it retries automatically
+     * until the loss ages out of the window.
+     */
+    private static void runRetroTick() {
+        String driverRepo = FeatureFlags.fullRepoEnabled() ? "full" : "meta";
+        Long checkpoint = readCheckpoint(driverRepo);
+        if (checkpoint == null) {
+            return;
+        }
+        List<WindowEntry> window = fetchRetroWindow(driverRepo, checkpoint);
+        if (window.isEmpty()) {
+            return;
+        }
+        Map<IRI, NanopubShardInfo> shardInfos = fetchShardInfos(driverRepo, window);
+
+        Map<String, List<IRI>> npsByShard = new LinkedHashMap<>();
+        for (WindowEntry e : window) {
+            NanopubShardInfo info = shardInfos.get(e.npId());
+            if (info == null) {
+                continue;
+            }
+            for (String repo : expectedShardRepos(e.npId(), info.pubkeyHash(), info.types(), driverRepo)) {
+                npsByShard.computeIfAbsent(repo, k -> new ArrayList<>()).add(e.npId());
+            }
+        }
+        Map<String, Set<IRI>> presentByShard = new HashMap<>();
+        for (Map.Entry<String, List<IRI>> e : npsByShard.entrySet()) {
+            presentByShard.put(e.getKey(), fetchPresentNanopubs(e.getKey(), e.getValue()));
+        }
+
+        long relost = 0;
+        long repaired = 0;
+        for (WindowEntry e : window) {
+            NanopubShardInfo info = shardInfos.get(e.npId());
+            if (info == null) {
+                continue;
+            }
+            List<String> missing = new ArrayList<>();
+            for (String repo : expectedShardRepos(e.npId(), info.pubkeyHash(), info.types(), driverRepo)) {
+                if (!presentByShard.getOrDefault(repo, Set.of()).contains(e.npId())) {
+                    missing.add(repo);
+                }
+            }
+            if (missing.isEmpty()) {
+                continue;
+            }
+            logger.warn("Previously verified nanopub <{}> (load number {}) has LOST shard(s) {} — the backend revoked readable state (issue #142); capture the RDF4J server logs around now before restarting", e.npId(), e.loadNumber(), missing);
+            relost += missing.size();
+            if (repairNanopub(driverRepo, e.npId(), missing)) {
+                repaired += missing.size();
+            }
+        }
+        relostShardCount += relost;
+        repairedShardCount += repaired;
+        if (relost > 0) {
+            logger.warn("Shard retro-verification found {} lost shard(s) across the last {} h window; {} re-repaired", relost, RETRO_WINDOW_MS / 3_600_000, repaired);
+        } else {
+            logger.debug("Shard retro-verification: {} nanopub(s) in the trailing window still consistent", window.size());
+        }
+    }
+
+    /**
+     * Fetches the retro window: nanopubs at or below the checkpoint whose driver
+     * load timestamp falls inside {@link #RETRO_WINDOW_MS}. Ordered by
+     * descending load number so that, when the window exceeds
+     * {@link #MAX_NPS_PER_TICK} (e.g. during a resync), the newest — most
+     * loss-prone — nanopubs are always covered.
+     */
+    private static List<WindowEntry> fetchRetroWindow(String driverRepo, long checkpoint) {
+        List<WindowEntry> window = new ArrayList<>();
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(driverRepo)) {
+            TupleQuery q = conn.prepareTupleQuery(QueryLanguage.SPARQL,
+                    "SELECT ?np ?ln ?ts WHERE { graph <" + NPA.GRAPH + "> { "
+                    + "?np <" + NPA.HAS_LOAD_NUMBER + "> ?ln ; <" + NPA.HAS_LOAD_TIMESTAMP + "> ?ts . "
+                    + "FILTER (?ln <= " + checkpoint + ") FILTER (?ts >= ?cutoff) "
+                    + "} } ORDER BY DESC(?ln) LIMIT " + MAX_NPS_PER_TICK);
+            q.setBinding("cutoff", vf.createLiteral(new Date(System.currentTimeMillis() - RETRO_WINDOW_MS)));
+            try (TupleQueryResult r = q.evaluate()) {
+                while (r.hasNext()) {
+                    BindingSet b = r.next();
+                    if (b.getValue("np") instanceof IRI npId && b.getValue("ts") instanceof Literal tsLit) {
+                        window.add(new WindowEntry(npId, Long.parseLong(b.getValue("ln").stringValue()),
+                                tsLit.calendarValue().toGregorianCalendar().getTimeInMillis()));
+                    }
+                }
+            }
+        }
+        return window;
     }
 
     /**


### PR DESCRIPTION
Counter-measures from the 2026-07-29 incident (#142): the backend revoked a shard write that was acknowledged **and readable** — the sweep verified `RAdtjqGM…` present in `type_ec6722…` on all three instances, and it vanished afterwards (bracketed by healthcheck restarts at 12:07:06 and 12:11:56). With a monotonic checkpoint, that loss class escaped the sweep permanently.

## Commit 1 — retro pass in the reconciler

Each tick now runs a second, stateless pass re-verifying every nanopub whose driver-repo load timestamp is in the trailing 24 h and whose load number is at or below the checkpoint (newest-first, capped at 1,000 so resync bursts keep the most loss-prone tail covered). A shard missing there is by definition *verified-then-lost*:

- WARN log naming the nanopub + an explicit prompt to capture the RDF4J server logs before restarting (they live in `docker logs rdf4j`, not the mounted Tomcat files, and die with container recreation — the reason today's forensics came up empty).
- New gauge `registry.reconciler.shards_relost_total` — the sharpest #142 signal available, since unlike `shards_repaired_total` it cannot include never-landed writes.
- Immediate re-repair; failed repairs halt nothing (the window is time-derived and retries every tick until the loss ages out). Older losses remain healable via `scripts/set-reconciliation-checkpoint.sh`.

Today's scenario would have been re-detected and re-healed within one 5-minute tick of the loss instead of escaping.

## Commit 2 — healthcheck restart softening (compose)

The healthcheck restarted Tomcat ~21× on 2026-07-29 (background rate: 2–5/day), and `pkill -15; sleep 10; pkill -9` gave dozens of LMDB repos ten seconds to close — effectively a hard kill every time, i.e. the loss amplifier. Now: up to 60 s graceful stop before any `kill -9`, plus a 10-minute restart backoff so a persistently wedged repo reports unhealthy instead of triggering a kill on every probe interval. Backoff timestamp parsing matches the existing `/var/info/restart` format; logic validated by simulation (restart allowed / suppressed / re-allowed cases).

Mirrored in nanopub-infrastructure for the deployed compose file.

## Verification

Full suite green (333 tests); compose config validates; rendered healthcheck script syntax-checked and behavior-simulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)