### PR TITLE
fix(logging): default to info and silence HTTP wire logging

### DIFF
--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -2,7 +2,13 @@
 # This file configures the logging behavior for slf4j-simple
 
 # Default log level for all loggers (can be: trace, debug, info, warn, error, off)
-org.slf4j.simpleLogger.defaultLogLevel=debug
+# info, not debug: with jcl-over-slf4j bridged, debug turns on Apache
+# HttpClient wire logging, which hex-dumps every byte of every HTTP exchange —
+# during a full registry resync that logs the entire Jelly stream line by line
+# and throttles loading to a crawl (observed 2026-07-29). Debug can still be
+# re-enabled ad hoc via -Dorg.slf4j.simpleLogger.defaultLogLevel=debug
+# (system properties take precedence over this file).
+org.slf4j.simpleLogger.defaultLogLevel=info
 
 # Show date/time in log output
 org.slf4j.simpleLogger.showDateTime=true
@@ -21,3 +27,9 @@ org.slf4j.simpleLogger.showShortLogName=true
 
 # Log level for specific loggers (optional, can override defaultLogLevel)
 # Example: org.slf4j.simpleLogger.log.com.knowledgepixels.query=debug
+
+# HTTP wire/header logging stays off even if the default level is lowered to
+# debug for the application loggers — wire dumps belong to targeted debugging
+# sessions only, never to production log streams.
+org.slf4j.simpleLogger.log.org.apache.http=warn
+org.slf4j.simpleLogger.log.httpclient.wire=warn


### PR DESCRIPTION
The bundled `simplelogger.properties` set `defaultLogLevel=debug`, which — with `jcl-over-slf4j` on the classpath — turns on Apache HttpClient **wire logging**: every byte of every HTTP exchange is hex-dumped through the logger.

Consequences observed:
- During the 2026-07-29 fresh resync on query.nanodash.net, the entire registry Jelly stream was logged line by line, throttling the initial load to a crawl (the reported "huge problems resyncing").
- In normal operation on all instances it taxed every RDF4J interaction and churned the 10m×3 log rotation so fast that incident forensics repeatedly found empty logs.

Changes: default level `info`; `org.apache.http` and `httpclient.wire` pinned to `warn` so wire dumps can't return even if the default is lowered again for application loggers. Ad-hoc debugging stays available via `-Dorg.slf4j.simpleLogger.defaultLogLevel=debug` (system properties take precedence over the bundled file).

The infrastructure repo already carries a `JDK_JAVA_OPTIONS` override (a3c5288) as immediate relief for the running resync; this PR fixes the image default so the override can eventually be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)