### PR TITLE
fix(status): persist state before adopting it in memory

### DIFF
--- a/src/main/java/com/knowledgepixels/query/StatusController.java
+++ b/src/main/java/com/knowledgepixels/query/StatusController.java
@@ -290,11 +290,29 @@ public class StatusController {
         }
     }
 
+    /**
+     * Persist a state transition, then adopt it in memory.
+     *
+     * <p>The in-memory fields are assigned only after the admin-repo commit succeeds,
+     * mirroring {@link #setRegistrySetupId(long)}. The earlier order (assign first,
+     * commit second) left the two permanently divergent whenever the commit threw,
+     * because nothing rolled the fields back: the loader would then read a
+     * {@code lastCommittedCounter} ahead of the persisted one, conclude from
+     * {@code lastCommittedCounter >= targetCounter} that it was caught up, and skip
+     * those nanopubs forever while still reporting READY.
+     *
+     * <p>Readers may observe the previous state for the few ms of the commit — the
+     * same window {@link #getRegistrySetupId()} already documents, and no caller
+     * depends on stronger consistency. If a commit lands server-side but the response
+     * is lost, the fields stay behind the DB instead of ahead of it; the next
+     * transition re-writes the same triples (the remove/add pair is idempotent), so
+     * that direction costs at most some re-processing rather than silent data loss.
+     *
+     * @param newState    the state to transition to
+     * @param loadCounter the load counter to persist alongside it
+     */
     void updateState(State newState, long loadCounter) {
         synchronized (this) {
-            // Update in-memory state first so getState() (called from the event loop) never blocks
-            state = newState;
-            lastCommittedCounter = loadCounter;
             try {
                 // Serializable, as the service state needs to be strictly consistent
                 adminRepoConn.begin(IsolationLevels.SERIALIZABLE);
@@ -303,6 +321,8 @@ public class StatusController {
                 adminRepoConn.remove(NPA.THIS_REPO, NPA.HAS_REGISTRY_LOAD_COUNTER, null, NPA.GRAPH);
                 adminRepoConn.add(NPA.THIS_REPO, NPA.HAS_REGISTRY_LOAD_COUNTER, adminRepoConn.getValueFactory().createLiteral(loadCounter), NPA.GRAPH);
                 adminRepoConn.commit();
+                state = newState;
+                lastCommittedCounter = loadCounter;
             } catch (Exception e) {
                 if (adminRepoConn.isActive()) {
                     try {

--- a/src/test/java/com/knowledgepixels/query/StatusControllerTest.java
+++ b/src/test/java/com/knowledgepixels/query/StatusControllerTest.java
@@ -303,6 +303,33 @@ class StatusControllerTest {
     }
 
     @Test
+    void updateStateKeepsInMemoryStateWhenCommitFails() {
+        // A failed admin-repo commit must leave the in-memory state untouched. When it
+        // advanced anyway, the loader read a lastCommittedCounter ahead of the persisted
+        // one, took the "caught up, nothing to do" branch on every subsequent poll, and
+        // skipped those nanopubs permanently while still reporting READY.
+        try (MockedStatic<TripleStore> mockedTripleStoreStatic = mockStatic(TripleStore.class)) {
+            StatusController controller = StatusController.get();
+            mockedTripleStoreStatic.when(TripleStore::get).thenReturn(mock(TripleStore.class));
+            when(TripleStore.get().getAdminRepoConnection()).thenReturn(mock(RepositoryConnection.class));
+            when(TripleStore.get().getAdminRepoConnection().getValueFactory()).thenReturn(SimpleValueFactory.getInstance());
+            when(TripleStore.get().getAdminRepoConnection().getStatements(any(), any(), any(), any())).thenReturn(mock(RepositoryResult.class));
+
+            controller.initialize();
+            controller.updateState(StatusController.State.READY, 100);
+
+            RepositoryConnection conn = TripleStore.get().getAdminRepoConnection();
+            doThrow(new RuntimeException("admin-repo commit failed")).when(conn).commit();
+
+            assertThrows(RuntimeException.class,
+                    () -> controller.updateState(StatusController.State.LOADING_UPDATES, 200));
+
+            assertEquals(StatusController.LoadingStatus.of(StatusController.State.READY, 100),
+                    controller.getState());
+        }
+    }
+
+    @Test
     void registrySetupIdPersistence() {
         try (MockedStatic<TripleStore> mockedTripleStoreStatic = mockStatic(TripleStore.class)) {
             StatusController controller = StatusController.get();


### PR DESCRIPTION
## What

`StatusController.updateState` assigned the in-memory `state` and `lastCommittedCounter` fields *before* committing them to the admin repo, and nothing rolled them back if the commit threw. The two could then diverge permanently, with in-memory ahead of the persisted value.

This PR assigns the fields only after `commit()` returns.

## Why it matters

The in-memory-ahead direction is the dangerous one. The updates loader reads `lastCommittedCounter` back through `getState()` at the top of every tick, so an inflated value makes `lastCommittedCounter >= targetCounter` true and the loader takes the "caught up, nothing to do" branch — skipping those nanopubs for good rather than retrying them.

That branch also resets `consecutiveBatchFailures` and stamps `lastSuccessfulBatchAtMs`, so a stalled instance keeps reporting `Nanopub-Query-Status: READY` with a healthy `last_successful_batch_age_seconds`. The failure is silent at both the status and metrics layers.

## Approach

Commit first, then assign — the order `setRegistrySetupId` in the same class already uses.

The comment justifying the old order claimed it kept `getState()` from blocking on the Vert.x event loop. That rationale doesn't hold: `getState()` reads two volatile fields and never takes the lock, so it cannot block regardless of ordering. The `getRegistrySetupId` javadoc already documents the real tradeoff (a reader may observe the previous value for the few ms of the commit). Replaced the misleading comment with javadoc recording the actual failure mode.

This trades the failure direction rather than eliminating it. If a commit lands server-side but the response is lost, the fields now sit *behind* the DB instead of ahead. The next transition rewrites the same triples and the remove/add pair is idempotent, so that direction costs at most some re-processing rather than silent data loss.

## Testing

Added `updateStateKeepsInMemoryStateWhenCommitFails`: drives a successful transition to `READY`/100, stubs `commit()` to throw, attempts `LOADING_UPDATES`/200, asserts the observable state is still `READY`/100.

Verified it is a real regression test rather than one that merely passes — temporarily restoring the old ordering makes it fail with an assertion error at that line. Full suite green (334 tests).

## Scope

This is a **latent** hazard, found while investigating the `query.knowledgepixels.com` ingestion stall on 2026-07-31. It is **not** the cause of that stall — ruled out, because the registry's target counter kept climbing past any stale in-memory value and would have re-triggered a batch load. That instance is still frozen at 86,598 nanopubs and needs its container logs read separately.

Worth noting that this bug requires an admin-repo commit failure to trigger, which means it is most likely to bite during exactly the kind of RDF4J trouble that instance appears to be having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)