### PR TITLE
fix(status): open a fresh admin-repo connection per transaction

### DIFF
--- a/src/main/java/com/knowledgepixels/query/StatusController.java
+++ b/src/main/java/com/knowledgepixels/query/StatusController.java
@@ -3,6 +3,7 @@ package com.knowledgepixels.query;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.nanopub.vocabulary.NPA;
@@ -54,11 +55,55 @@ public class StatusController {
     static final IRI HAS_REGISTRY_SETUP_ID =
             SimpleValueFactory.getInstance().createIRI(NPA.NAMESPACE, "hasRegistrySetupId");
 
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
     private boolean initialized = false;
     private volatile State state = null;
     private volatile long lastCommittedCounter = -1;
     private volatile Long registrySetupId = null;
-    private RepositoryConnection adminRepoConn;
+
+    /**
+     * Opens a fresh admin-repo connection for a single transaction.
+     *
+     * <p>This class used to hold one connection for the lifetime of the process,
+     * assigned once in {@link #initialize()} and never re-acquired. An RDF4J restart
+     * — which the {@code rdf4j} healthcheck performs by design when its probes fail —
+     * orphaned that connection permanently: every subsequent admin-repo write threw,
+     * so {@code setLoadingUpdates} failed before {@code loadBatch} could run and the
+     * instance ingested nothing until the query container itself was restarted.
+     * RDF4J recovering on its own was not enough. Acquiring per transaction means a
+     * restart costs one failed tick instead of wedging the loader (incident
+     * 2026-07-31, query.knowledgepixels.com).
+     *
+     * <p>Cheap enough to do per call: {@code getConnection()} on an
+     * {@code HTTPRepository} is local and does no HTTP, as
+     * {@link TripleStore#getRepoConnection(String)} notes. Every other admin-repo
+     * caller in the codebase already works this way.
+     *
+     * @return a new connection the caller must close
+     */
+    private static RepositoryConnection openAdminConnection() {
+        return TripleStore.get().getAdminRepoConnection();
+    }
+
+    /**
+     * Rolls back an active transaction, suppressing any failure to do so.
+     *
+     * <p>The transaction may no longer exist server-side (already committed, timed
+     * out, or lost to a restart), and that secondary failure must not mask the
+     * original one.
+     *
+     * @param conn the connection whose transaction should be rolled back
+     */
+    private static void rollbackQuietly(RepositoryConnection conn) {
+        try {
+            if (conn.isActive()) {
+                conn.rollback();
+            }
+        } catch (Exception rollbackException) {
+            // Deliberately ignored; the caller rethrows the original cause.
+        }
+    }
 
     /**
      * Represents the current status of the service, including the load counter.
@@ -119,45 +164,41 @@ public class StatusController {
                 throw new IllegalStateException("Already initialized");
             }
             state = State.LAUNCHING;
-            adminRepoConn = TripleStore.get().getAdminRepoConnection();
-            // Serializable, as the service state needs to be strictly consistent
-            adminRepoConn.begin(IsolationLevels.SERIALIZABLE);
-            // Fetch the state from the DB
-            try (var statements = adminRepoConn.getStatements(NPA.THIS_REPO, NPA.HAS_STATUS, null, NPA.GRAPH)) {
-                if (!statements.hasNext()) {
-                    adminRepoConn.add(NPA.THIS_REPO, NPA.HAS_STATUS, stateAsLiteral(state), NPA.GRAPH);
-                } else {
-                    var stateStatement = statements.next();
-                    state = State.valueOf(stateStatement.getObject().stringValue());
-                }
-            }
-            // Fetch the load counter from the DB
-            try (var statements = adminRepoConn.getStatements(NPA.THIS_REPO, NPA.HAS_REGISTRY_LOAD_COUNTER, null, NPA.GRAPH)) {
-                if (!statements.hasNext()) {
-                    adminRepoConn.add(NPA.THIS_REPO, NPA.HAS_REGISTRY_LOAD_COUNTER, adminRepoConn.getValueFactory().createLiteral(-1L), NPA.GRAPH);
-                } else {
-                    var counterStatement = statements.next();
-                    var stringVal = counterStatement.getObject().stringValue();
-                    lastCommittedCounter = Long.parseLong(stringVal);
-                }
-            }
-            // Fetch the registry setup ID from the DB
-            try (var statements = adminRepoConn.getStatements(NPA.THIS_REPO, HAS_REGISTRY_SETUP_ID, null, NPA.GRAPH)) {
-                if (statements.hasNext()) {
-                    var setupIdStatement = statements.next();
-                    registrySetupId = Long.parseLong(setupIdStatement.getObject().stringValue());
-                }
-                adminRepoConn.commit();
-            } catch (Exception e) {
-                if (adminRepoConn.isActive()) {
-                    try {
-                        adminRepoConn.rollback();
-                    } catch (Exception rollbackException) {
-                        // Transaction may not be registered on server (e.g., already committed, timed out, or connection reset)
-                        // Log the rollback failure but don't mask the original exception
+            try (RepositoryConnection conn = openAdminConnection()) {
+                try {
+                    // Serializable, as the service state needs to be strictly consistent
+                    conn.begin(IsolationLevels.SERIALIZABLE);
+                    // Fetch the state from the DB
+                    try (var statements = conn.getStatements(NPA.THIS_REPO, NPA.HAS_STATUS, null, NPA.GRAPH)) {
+                        if (!statements.hasNext()) {
+                            conn.add(NPA.THIS_REPO, NPA.HAS_STATUS, stateAsLiteral(state), NPA.GRAPH);
+                        } else {
+                            var stateStatement = statements.next();
+                            state = State.valueOf(stateStatement.getObject().stringValue());
+                        }
                     }
+                    // Fetch the load counter from the DB
+                    try (var statements = conn.getStatements(NPA.THIS_REPO, NPA.HAS_REGISTRY_LOAD_COUNTER, null, NPA.GRAPH)) {
+                        if (!statements.hasNext()) {
+                            conn.add(NPA.THIS_REPO, NPA.HAS_REGISTRY_LOAD_COUNTER, vf.createLiteral(-1L), NPA.GRAPH);
+                        } else {
+                            var counterStatement = statements.next();
+                            var stringVal = counterStatement.getObject().stringValue();
+                            lastCommittedCounter = Long.parseLong(stringVal);
+                        }
+                    }
+                    // Fetch the registry setup ID from the DB
+                    try (var statements = conn.getStatements(NPA.THIS_REPO, HAS_REGISTRY_SETUP_ID, null, NPA.GRAPH)) {
+                        if (statements.hasNext()) {
+                            var setupIdStatement = statements.next();
+                            registrySetupId = Long.parseLong(setupIdStatement.getObject().stringValue());
+                        }
+                    }
+                    conn.commit();
+                } catch (Exception e) {
+                    rollbackQuietly(conn);
+                    throw new RuntimeException(e);
                 }
-                throw new RuntimeException(e);
             }
             initialized = true;
             return getState();
@@ -271,21 +312,17 @@ public class StatusController {
      */
     public void setRegistrySetupId(long setupId) {
         synchronized (this) {
-            try {
-                adminRepoConn.begin(IsolationLevels.SERIALIZABLE);
-                adminRepoConn.remove(NPA.THIS_REPO, HAS_REGISTRY_SETUP_ID, null, NPA.GRAPH);
-                adminRepoConn.add(NPA.THIS_REPO, HAS_REGISTRY_SETUP_ID, adminRepoConn.getValueFactory().createLiteral(setupId), NPA.GRAPH);
-                adminRepoConn.commit();
-                registrySetupId = setupId;
-            } catch (Exception e) {
-                if (adminRepoConn.isActive()) {
-                    try {
-                        adminRepoConn.rollback();
-                    } catch (Exception rollbackException) {
-                        // Log the rollback failure but don't mask the original exception
-                    }
+            try (RepositoryConnection conn = openAdminConnection()) {
+                try {
+                    conn.begin(IsolationLevels.SERIALIZABLE);
+                    conn.remove(NPA.THIS_REPO, HAS_REGISTRY_SETUP_ID, null, NPA.GRAPH);
+                    conn.add(NPA.THIS_REPO, HAS_REGISTRY_SETUP_ID, vf.createLiteral(setupId), NPA.GRAPH);
+                    conn.commit();
+                    registrySetupId = setupId;
+                } catch (Exception e) {
+                    rollbackQuietly(conn);
+                    throw new RuntimeException(e);
                 }
-                throw new RuntimeException(e);
             }
         }
     }
@@ -313,32 +350,27 @@ public class StatusController {
      */
     void updateState(State newState, long loadCounter) {
         synchronized (this) {
-            try {
-                // Serializable, as the service state needs to be strictly consistent
-                adminRepoConn.begin(IsolationLevels.SERIALIZABLE);
-                adminRepoConn.remove(NPA.THIS_REPO, NPA.HAS_STATUS, null, NPA.GRAPH);
-                adminRepoConn.add(NPA.THIS_REPO, NPA.HAS_STATUS, stateAsLiteral(newState), NPA.GRAPH);
-                adminRepoConn.remove(NPA.THIS_REPO, NPA.HAS_REGISTRY_LOAD_COUNTER, null, NPA.GRAPH);
-                adminRepoConn.add(NPA.THIS_REPO, NPA.HAS_REGISTRY_LOAD_COUNTER, adminRepoConn.getValueFactory().createLiteral(loadCounter), NPA.GRAPH);
-                adminRepoConn.commit();
-                state = newState;
-                lastCommittedCounter = loadCounter;
-            } catch (Exception e) {
-                if (adminRepoConn.isActive()) {
-                    try {
-                        adminRepoConn.rollback();
-                    } catch (Exception rollbackException) {
-                        // Transaction may not be registered on server (e.g., already committed, timed out, or connection reset)
-                        // Log the rollback failure but don't mask the original exception
-                    }
+            try (RepositoryConnection conn = openAdminConnection()) {
+                try {
+                    // Serializable, as the service state needs to be strictly consistent
+                    conn.begin(IsolationLevels.SERIALIZABLE);
+                    conn.remove(NPA.THIS_REPO, NPA.HAS_STATUS, null, NPA.GRAPH);
+                    conn.add(NPA.THIS_REPO, NPA.HAS_STATUS, stateAsLiteral(newState), NPA.GRAPH);
+                    conn.remove(NPA.THIS_REPO, NPA.HAS_REGISTRY_LOAD_COUNTER, null, NPA.GRAPH);
+                    conn.add(NPA.THIS_REPO, NPA.HAS_REGISTRY_LOAD_COUNTER, vf.createLiteral(loadCounter), NPA.GRAPH);
+                    conn.commit();
+                    state = newState;
+                    lastCommittedCounter = loadCounter;
+                } catch (Exception e) {
+                    rollbackQuietly(conn);
+                    throw new RuntimeException(e);
                 }
-                throw new RuntimeException(e);
             }
         }
     }
 
     private Literal stateAsLiteral(State s) {
-        return adminRepoConn.getValueFactory().createLiteral(s.toString());
+        return vf.createLiteral(s.toString());
     }
 
     /**
@@ -351,7 +383,6 @@ public class StatusController {
             state = null;
             lastCommittedCounter = -1;
             registrySetupId = null;
-            adminRepoConn = null;
         }
     }
 

--- a/src/test/java/com/knowledgepixels/query/StatusControllerTest.java
+++ b/src/test/java/com/knowledgepixels/query/StatusControllerTest.java
@@ -330,6 +330,66 @@ class StatusControllerTest {
     }
 
     @Test
+    void recoversOnceANewConnectionWorks() {
+        // The controller used to hold one admin-repo connection for the lifetime of the
+        // process. An RDF4J restart orphaned it permanently: every later write threw, so
+        // setLoadingUpdates failed before loadBatch could run and the instance ingested
+        // nothing until the query container was restarted. A fresh connection per
+        // transaction must let the very next tick succeed.
+        try (MockedStatic<TripleStore> mockedTripleStoreStatic = mockStatic(TripleStore.class)) {
+            StatusController controller = StatusController.get();
+            TripleStore tripleStore = mock(TripleStore.class);
+            mockedTripleStoreStatic.when(TripleStore::get).thenReturn(tripleStore);
+
+            RepositoryConnection good = mock(RepositoryConnection.class);
+            when(good.getStatements(any(), any(), any(), any())).thenReturn(mock(RepositoryResult.class));
+
+            RepositoryConnection orphaned = mock(RepositoryConnection.class);
+            when(orphaned.getStatements(any(), any(), any(), any())).thenReturn(mock(RepositoryResult.class));
+            doThrow(new RuntimeException("connection orphaned by RDF4J restart")).when(orphaned).commit();
+
+            when(tripleStore.getAdminRepoConnection()).thenReturn(good);
+            controller.initialize();
+            controller.updateState(StatusController.State.READY, 100);
+
+            // RDF4J restarts: the connection handed out now is dead.
+            when(tripleStore.getAdminRepoConnection()).thenReturn(orphaned);
+            assertThrows(RuntimeException.class,
+                    () -> controller.updateState(StatusController.State.LOADING_UPDATES, 200));
+            assertEquals(StatusController.LoadingStatus.of(StatusController.State.READY, 100),
+                    controller.getState());
+
+            // RDF4J is back; the next transaction gets a healthy connection and must work.
+            when(tripleStore.getAdminRepoConnection()).thenReturn(good);
+            controller.updateState(StatusController.State.LOADING_UPDATES, 200);
+            assertEquals(StatusController.LoadingStatus.of(StatusController.State.LOADING_UPDATES, 200),
+                    controller.getState());
+        }
+    }
+
+    @Test
+    void everyTransactionClosesItsConnection() {
+        // Connections are counted by TripleStore; leaking one per state transition would
+        // exhaust the pool over a long run.
+        try (MockedStatic<TripleStore> mockedTripleStoreStatic = mockStatic(TripleStore.class)) {
+            StatusController controller = StatusController.get();
+            TripleStore tripleStore = mock(TripleStore.class);
+            mockedTripleStoreStatic.when(TripleStore::get).thenReturn(tripleStore);
+
+            RepositoryConnection conn = mock(RepositoryConnection.class);
+            when(conn.getStatements(any(), any(), any(), any())).thenReturn(mock(RepositoryResult.class));
+            when(tripleStore.getAdminRepoConnection()).thenReturn(conn);
+
+            controller.initialize();
+            controller.updateState(StatusController.State.READY, 10);
+            controller.setRegistrySetupId(999L);
+
+            // initialize + updateState + setRegistrySetupId
+            verify(conn, times(3)).close();
+        }
+    }
+
+    @Test
     void registrySetupIdPersistence() {
         try (MockedStatic<TripleStore> mockedTripleStoreStatic = mockStatic(TripleStore.class)) {
             StatusController controller = StatusController.get();


### PR DESCRIPTION
Root-cause fix for the `query.knowledgepixels.com` ingestion stall on 2026-07-31. Follow-up to #146, which made the same code path fail safely but did not stop it failing.

## Root cause

`StatusController` held a single `RepositoryConnection` for the lifetime of the process — assigned once in `initialize()` and never re-acquired. The `rdf4j` healthcheck restarts Tomcat (`pkill java`) by design when its probes fail, which orphans that connection permanently. Every subsequent admin-repo write then threw, so `setLoadingUpdates` failed *before* `loadBatch` could run and the instance ingested nothing at all. RDF4J recovering on its own did not help; only restarting the query container did.

## Evidence

- Last successful load 09:58:31Z; `data/info/restart` records a Tomcat kill at **10:00:15Z**; ingestion never resumed and the gap grew for hours.
- The stuck nanopub was absent from **every** shard (`full`, `text`, `meta`, `spaces`, `last30d`, both type repos, the pubkey repo) — no partial write, so the failure preceded any shard commit.
- Ruled out upstream: the registry served the exact stuck batch in 0.13 s, and all 7 nanopubs decoded cleanly through `NanopubStream`. Every required shard repo existed and answered fast.
- `LOADING_UPDATES` bursts lasted ~2 s. A genuine shard-write failure cannot be that quick — `loadNanopubToRepo` retries 8× with 1/2/4/8/16/32/60 s backoff, so ~2 min elapses before it throws.
- The instance served queries in ~0.1 s and reported `READY` throughout, because reads take a connection per request. `StatusController` was the only place holding one open.

## The change

Take a connection per transaction, matching every other admin-repo caller (`Utils.createHash`, `getInvalidatingStatements`, `loadNanopubToRepo`). An RDF4J restart now costs one failed tick instead of wedging the loader indefinitely. `getConnection()` on an `HTTPRepository` is local and does no HTTP — as `TripleStore.getRepoConnection` already notes — so per-call acquisition is cheap.

Also drops the last uses of the held connection's `ValueFactory` for a static `SimpleValueFactory`, and factors three duplicated rollback-and-swallow blocks into `rollbackQuietly`.

## Testing

Two new tests:

- `recoversOnceANewConnectionWorks` — a transaction fails against an orphaned connection, in-memory state is unchanged, and the **next** transaction against a healthy connection succeeds. This is the actual regression.
- `everyTransactionClosesItsConnection` — connections are counted by `TripleStore`, so leaking one per state transition would exhaust the pool.

Both verified to genuinely catch the old design: simulating a cached connection makes them fail (along with #146's `updateStateKeepsInMemoryStateWhenCommitFails`). Full suite green, 336 tests.

## Deploy note

Those Tomcat restarts are routine — 10 between 29 and 31 July — so this recurs. Whether a given restart wedges the loader probably depends on a transaction being active at kill time, which is why it has been intermittent. Worth deploying to all three instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)