### PR TITLE
feat(metrics): add loader sync-lag gauge and ship alerting rules

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,90 @@
+# Monitoring nanopub-query
+
+`prometheus-alerts.yml` holds alerting rules for the loader. They exist because
+of a specific gap, worth understanding before tuning them.
+
+## Why these rules
+
+On 2026-07-31 `query.knowledgepixels.com` stopped ingesting at 09:58:31Z and
+stayed stuck for over two hours. Throughout, it served SPARQL in ~0.1 s and
+reported `Nanopub-Query-Status: READY`. The public monitor rated it OK apart
+from a checksum marked "outlier".
+
+Two things made it invisible:
+
+- **The monitor compares instances against each other.** It flags a checksum
+  that disagrees with the consensus, which only works while at least one
+  instance is healthy. A fleet-wide stall — a bad deploy, a shared upstream
+  fault, one bug firing everywhere — produces unanimous agreement and reads as
+  all-clear.
+- **The metrics that would have caught it were already correct, and nothing was
+  watching them.** `registry_loader_breaker_active` would have flipped within
+  seconds and `registry_loader_last_successful_batch_age_seconds` would have
+  climbed from the first failure. Both were exposed the whole time.
+
+So the fix is mostly configuration, not instrumentation. The one metric added
+afterwards is `registry_loader_sync_lag_nanopubs`, which reports the outcome
+(how far behind the registry this instance is) rather than the loader's internal
+state, and is absolute rather than relative — it fires even when every instance
+is equally broken.
+
+## Scrape setup
+
+`docker-compose.yml` binds the metrics port to loopback only:
+
+```yaml
+ports:
+  - "127.0.0.1:9394:9394"
+```
+
+Prometheus therefore has to run on the same host (or share its network
+namespace). Do not publish 9394 publicly to work around this — the endpoint is
+unauthenticated.
+
+```yaml
+scrape_configs:
+  - job_name: nanopub-query
+    static_configs:
+      - targets: ['127.0.0.1:9394']
+```
+
+The `job_name` matters: `NanopubQueryMetricsUnreachable` matches on
+`up{job="nanopub-query"}`.
+
+Load the rules with `rule_files: [ /path/to/prometheus-alerts.yml ]` and verify
+with `promtool check rules monitoring/prometheus-alerts.yml`.
+
+## Reading the signals together
+
+`last_successful_batch_age_seconds` and `sync_lag_nanopubs` look redundant and
+are not. The lag is computed against the registry count forwarded by the most
+recent successful poll. If the poll itself is what broke, both the loaded count
+and the forwarded registry count freeze together and the lag reads a reassuring
+`0` forever. The staleness gauge is what catches that case. Conversely, if the
+loader ticks happily but falls behind for some reason that never throws, the
+staleness gauge stays low and only the lag moves.
+
+`sync_lag_nanopubs` reports `-1` when either count is unavailable — before the
+first registry poll, or if the forwarded value is unparseable. That is
+deliberately distinct from `0`, which asserts the instance is genuinely in sync.
+Real lags are clamped at zero, so `-1` can only ever mean "unknown". Any rule
+written over this metric should use `> 0` rather than `!= 0`.
+
+## When an alert fires
+
+Start with the loader's own error, which carries the stack trace:
+
+```bash
+docker compose logs query --since <time> 2>&1 | grep -A30 "Failed to load updates"
+```
+
+Then check whether RDF4J was restarted underneath it — the healthcheck kills
+Tomcat by design when its probes fail, and records each one:
+
+```bash
+tail -20 data/info/restart data/info/federation-restart
+```
+
+The absence of `Retrying load of <...> to repo` lines alongside a
+`Could not update the nanopub counter in DB` means the failure is in the
+admin-repo write, before `loadBatch` ever runs.

--- a/monitoring/prometheus-alerts.yml
+++ b/monitoring/prometheus-alerts.yml
@@ -1,0 +1,97 @@
+# Alerting rules for nanopub-query.
+#
+# See monitoring/README.md for scrape setup and a walk-through of why these
+# thresholds are what they are. Metric names are pinned by
+# MetricsCollectorTest.exportsTheMetricNamesTheAlertRulesReferenceOn — a rename
+# in MetricsCollector would otherwise stop these firing silently.
+
+groups:
+  - name: nanopub-query-loader
+    interval: 30s
+    rules:
+
+      # The primary signal. loadUpdates stamps its timestamp on every
+      # non-exceptional return, including idle "caught up, nothing to do" ticks,
+      # so on a healthy instance this stays near the 2 s poll interval no matter
+      # how quiet the registry is. It only climbs when ticks are throwing.
+      - alert: NanopubQueryLoaderStalled
+        expr: registry_loader_last_successful_batch_age_seconds > 300
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.instance }} loader has not completed a tick in {{ $value | humanizeDuration }}"
+          description: >
+            Every loadUpdates tick is throwing. The instance keeps serving queries
+            and still reports Nanopub-Query-Status: READY, so nothing else will
+            surface this. Check `docker compose logs query | grep -A30 "Failed to
+            load updates"` for the cause, and `data/info/restart` for a recent
+            RDF4J restart.
+
+      # Redundant with the above by design: the breaker trips within seconds of
+      # the third consecutive failure, so it is the faster of the two, while the
+      # staleness gauge still catches failure modes that never reach the batch.
+      - alert: NanopubQueryLoaderBreakerTripped
+        expr: registry_loader_breaker_active == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.instance }} loader circuit breaker has been tripped for 5m"
+          description: >
+            Three or more consecutive loadUpdates batches failed. Transient
+            breaker trips during RDF4J pressure are expected and clear on their
+            own; sustained means stuck.
+
+      # Absolute rather than relative: unlike the monitor's cross-instance
+      # checksum comparison, this still fires when every instance stalls at once.
+      # Reads -1 while either count is unknown, which never satisfies `> 0`.
+      #
+      # Deliberately slack at 15m. The registry side is only as fresh as the last
+      # successful poll, so a healthy instance can show a small lag between the
+      # poll and the batch landing.
+      - alert: NanopubQueryBehindRegistry
+        expr: registry_loader_sync_lag_nanopubs > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.instance }} is {{ $value }} nanopubs behind its registry"
+          description: >
+            Sustained lag against its own registry. Note this cannot detect a
+            failure of the registry poll itself — both counts freeze together and
+            the lag reads 0 — which is why NanopubQueryLoaderStalled exists
+            alongside it. Neither covers the other's blind spot.
+
+      # Per MetricsCollector: any non-zero repaired value means the backend
+      # acknowledged a shard write that was not durable.
+      - alert: NanopubQueryShardRepaired
+        expr: registry_reconciler_shards_repaired_total > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.instance }} reconciler repaired {{ $value }} missing shard(s)"
+          description: >
+            A shard write was acknowledged but not durable (issue #139). The
+            sweep re-loaded it; investigate the backend if this recurs.
+
+      - alert: NanopubQueryShardRelost
+        expr: registry_reconciler_shards_relost_total > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.instance }} lost {{ $value }} shard(s) that were previously verified present"
+          description: >
+            The backend revoked readable state it had already served (issue
+            #142). Usually follows a hard RDF4J kill; check data/info/restart.
+
+      - alert: NanopubQueryMetricsUnreachable
+        expr: up{job="nanopub-query"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.instance }} metrics endpoint is unreachable"
+          description: >
+            Without this, every other rule in this group goes quiet rather than
+            firing — absence of alerts is not evidence of health.

--- a/src/main/java/com/knowledgepixels/query/MetricsCollector.java
+++ b/src/main/java/com/knowledgepixels/query/MetricsCollector.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Class to collect metrics for performance analysis.
@@ -17,6 +18,25 @@ public final class MetricsCollector {
     private final AtomicInteger typeRepositoriesCounter = new AtomicInteger(0);
     private final AtomicInteger pubkeyRepositoriesCounter = new AtomicInteger(0);
     private final AtomicInteger fullRepositoriesCounter = new AtomicInteger(0);
+
+    /**
+     * Value behind {@code registry.loader.sync_lag_nanopubs}. Refreshed on the
+     * {@code updateMetrics} tick rather than inside the gauge lambda: the gauge is
+     * evaluated on the scrape path, which runs on a Vert.x event loop, and
+     * {@link NanopubLoader#getLoadedNanopubCount()} can fall through to a SPARQL
+     * query on a cold cache. The repo-name counters above are populated the same
+     * way and for the same reason.
+     */
+    private final AtomicLong syncLagNanopubs = new AtomicLong(UNKNOWN_LAG);
+
+    /**
+     * Sentinel for {@code registry.loader.sync_lag_nanopubs} when either side of the
+     * subtraction is unavailable — before the first registry poll, or if the
+     * forwarded count is unparseable. Distinct from {@code 0}, which asserts the
+     * instance is genuinely in sync. Real lags are clamped at zero so this value
+     * can never arise from arithmetic.
+     */
+    private static final long UNKNOWN_LAG = -1L;
 
     private final Map<StatusController.State, AtomicInteger> statusStates = new ConcurrentHashMap<>();
 
@@ -57,6 +77,19 @@ public final class MetricsCollector {
                             return (System.currentTimeMillis() - t) / 1000.0;
                         })
                 .description("Seconds since the last non-exceptional loadUpdates return (idle or loading)")
+                .register(meterRegistry);
+        // How far behind its own registry this instance is. The gauges above all
+        // describe the loader's *internal* health; this one is the outcome an
+        // operator actually cares about, and it is absolute rather than relative —
+        // unlike the monitor's cross-instance checksum comparison, it still fires
+        // when every instance stalls at once (incident 2026-07-31).
+        //
+        // Pair it with last_successful_batch_age_seconds when alerting. The registry
+        // side of the subtraction is the count forwarded by the most recent poll, so
+        // if polling itself is what broke, both counts freeze together and the lag
+        // reads a falsely reassuring 0. Neither signal covers the other's blind spot.
+        Gauge.builder("registry.loader.sync_lag_nanopubs", syncLagNanopubs, AtomicLong::get)
+                .description("Nanopubs this instance is behind its registry; -1 when either count is unknown")
                 .register(meterRegistry);
 
         // Shard-reconciliation observability (issue #139). Both read volatile
@@ -144,11 +177,36 @@ public final class MetricsCollector {
                         .count()
         );
         fullRepositoriesCounter.set(repoNames.size());
+        syncLagNanopubs.set(computeSyncLag());
 
         // Update status gauge
         final var currentStatus = StatusController.get().getState().state;
         for (final var status : StatusController.State.values()) {
             statusStates.get(status).set(status.equals(currentStatus) ? 1 : 0);
+        }
+    }
+
+    /**
+     * Nanopubs this instance is behind its registry, or {@link #UNKNOWN_LAG} if either
+     * count is unavailable.
+     *
+     * <p>Clamped at zero: the loaded count is bumped as each nanopub lands while the
+     * registry count only refreshes once per poll, so the loaded side can legitimately
+     * run ahead for a tick. Reporting that as negative would collide with the
+     * unknown sentinel.
+     *
+     * @return the lag in nanopubs, clamped to zero, or {@link #UNKNOWN_LAG}
+     */
+    static long computeSyncLag() {
+        String registryCount = JellyNanopubLoader.lastNanopubCount;
+        Long loaded = NanopubLoader.getLoadedNanopubCount();
+        if (registryCount == null || loaded == null) {
+            return UNKNOWN_LAG;
+        }
+        try {
+            return Math.max(0L, Long.parseLong(registryCount.trim()) - loaded);
+        } catch (NumberFormatException ex) {
+            return UNKNOWN_LAG;
         }
     }
 }

--- a/src/test/java/com/knowledgepixels/query/MetricsCollectorTest.java
+++ b/src/test/java/com/knowledgepixels/query/MetricsCollectorTest.java
@@ -2,6 +2,8 @@ package com.knowledgepixels.query;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
@@ -42,6 +44,56 @@ class MetricsCollectorTest {
         // Pre-cycle, all spaces gauges read 0.
         assertEquals(0.0, registry.find("registry.spaces.subjects.admin_ris").gauge().value());
         assertEquals(0.0, registry.find("registry.spaces.processed_up_to_lag").gauge().value());
+    }
+
+    @Test
+    void exportsTheMetricNamesTheAlertRulesReferenceOn() {
+        // monitoring/prometheus-alerts.yml matches on these exact strings. Micrometer
+        // maps dots to underscores on export, so a rename here silently stops the
+        // alerts firing rather than breaking anything loudly — hence pinning them.
+        var registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        new MetricsCollector(registry);
+        String scrape = registry.scrape();
+        for (String metric : new String[]{
+                "registry_loader_breaker_active",
+                "registry_loader_consecutive_batch_failures",
+                "registry_loader_last_successful_batch_age_seconds",
+                "registry_loader_sync_lag_nanopubs",
+                "registry_reconciler_shards_repaired_total",
+                "registry_reconciler_shards_relost_total",
+        }) {
+            assertTrue(scrape.contains(metric), "alert rules reference missing metric: " + metric);
+        }
+    }
+
+    @Test
+    void syncLagIsUnknownUntilBothCountsAreAvailable() {
+        String savedRegistryCount = JellyNanopubLoader.lastNanopubCount;
+        Long savedLoaded = NanopubLoader.loadedNanopubCount;
+        try {
+            // No registry poll yet: must report the sentinel, not a fabricated 0 —
+            // "unknown" and "in sync" have to stay distinguishable to an alert.
+            JellyNanopubLoader.lastNanopubCount = null;
+            NanopubLoader.loadedNanopubCount = 100L;
+            assertEquals(-1L, MetricsCollector.computeSyncLag());
+
+            JellyNanopubLoader.lastNanopubCount = "not a number";
+            assertEquals(-1L, MetricsCollector.computeSyncLag());
+
+            JellyNanopubLoader.lastNanopubCount = "107";
+            assertEquals(7L, MetricsCollector.computeSyncLag());
+
+            JellyNanopubLoader.lastNanopubCount = "100";
+            assertEquals(0L, MetricsCollector.computeSyncLag());
+
+            // Loaded count runs ahead between registry polls; clamped so it can never
+            // be mistaken for the -1 sentinel.
+            JellyNanopubLoader.lastNanopubCount = "98";
+            assertEquals(0L, MetricsCollector.computeSyncLag());
+        } finally {
+            JellyNanopubLoader.lastNanopubCount = savedRegistryCount;
+            NanopubLoader.loadedNanopubCount = savedLoaded;
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes the monitoring gap behind the 2026-07-31 stall (follow-up to #146 and #147, which fixed the bug itself).

## The gap

The instance was stuck for over two hours while serving queries in ~0.1 s and reporting `Nanopub-Query-Status: READY`. The public monitor rated it OK apart from a checksum marked "outlier". Two reasons it stayed invisible:

- **The monitor compares instances against each other.** It flags a checksum that disagrees with the consensus, which only works while at least one instance is healthy. A fleet-wide stall — bad deploy, shared upstream fault, one bug firing everywhere — produces unanimous agreement and reads as all-clear. We were lucky only one instance was hit.
- **The metrics that would have caught it were already correct, and nothing watched them.** `registry_loader_breaker_active` would have flipped within seconds of the first failure; `last_successful_batch_age_seconds` would have climbed from then on. Both were exposed the entire time.

So this is mostly configuration, not instrumentation.

## What's here

**`monitoring/prometheus-alerts.yml`** — rules over the existing gauges. Against this incident's timeline (stall at 10:00:15Z), `NanopubQueryLoaderStalled` and `NanopubQueryLoaderBreakerTripped` would both have fired by ~10:10 instead of going unnoticed until ~12:00.

**`monitoring/README.md`** — scrape setup and a runbook. Worth noting: `docker-compose.yml` binds 9394 to `127.0.0.1`, so Prometheus must run host-local. Don't publish the port to work around that; it's unauthenticated.

**`registry.loader.sync_lag_nanopubs`** — the one genuinely missing metric. The existing gauges all describe the loader's *internal* state; this reports the outcome an operator cares about, and it's absolute rather than relative, so it fires even when every instance is equally broken. Reads `-1` while either count is unknown, kept distinct from `0` ("genuinely in sync") by clamping real lags at zero — so rules should use `> 0`, never `!= 0`.

## Two things worth reviewing carefully

**Why the lag is computed on the `updateMetrics` tick, not in the gauge lambda.** Gauges are evaluated on the scrape path, which runs on a Vert.x event loop, and `getLoadedNanopubCount()` can fall through to a SPARQL query on a cold cache. Blocking there is the `BlockedThreadChecker` hazard the codebase already guards against elsewhere. The repo-name counters are populated the same way for the same reason.

**Why `sync_lag_nanopubs` and `last_successful_batch_age_seconds` are not redundant.** The lag is computed against the registry count forwarded by the most recent *successful* poll. If polling itself is what broke, both counts freeze together and the lag reads a reassuring `0` forever — only the staleness gauge catches that. Conversely a loader that ticks fine but falls behind without throwing moves only the lag. Alert on both.

## Testing

`exportsTheMetricNamesTheAlertRulesReferenceOn` pins the exact exported names the rules match on, by scraping a real `PrometheusMeterRegistry`. Micrometer maps dots to underscores, so a rename in `MetricsCollector` would otherwise stop the alerts firing silently rather than break anything loudly. `syncLagIsUnknownUntilBothCountsAreAvailable` covers the sentinel, the parse failure, and the clamp.

Full suite green, 338 tests. Rules validated structurally; `promtool check rules monitoring/prometheus-alerts.yml` is worth running wherever promtool is available, as I didn't have it here.

## Still open

This does not touch nanopub-monitor itself, which remains blind to correlated failure. The absolute check it needs is already computable from a single HEAD request — every instance serves both `Nanopub-Query-Loaded-Nanopub-Count` and `Nanopub-Query-Registry-Nanopub-Count` — but the loader-liveness half would need a new public header, since the monitor can't reach loopback-bound metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)