### PR TITLE
feat(headers): expose loader liveness as a response header

### DIFF
--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -696,5 +696,19 @@ public class MainVerticle extends AbstractVerticle {
         if (loadedChecksum != null) {
             response.putHeader("Nanopub-Query-Loaded-Nanopub-Checksum", loadedChecksum);
         }
+        // Loader liveness over HTTP. The same value backs
+        // registry.loader.last_successful_batch_age_seconds, but the metrics port is
+        // bound to loopback, so anything off-host — nanopub-monitor in particular —
+        // cannot read it. Without this, a stalled instance looks identical to a healthy
+        // one from outside: it keeps answering queries and keeps reporting READY, which
+        // is how the 2026-07-31 stall stayed invisible for hours.
+        //
+        // Omitted rather than sent as 0 before the first tick completes, so consumers can
+        // tell "not started yet" from "just ticked".
+        long lastBatchAt = JellyNanopubLoader.lastSuccessfulBatchAtMs;
+        if (lastBatchAt != 0L) {
+            long ageSeconds = Math.max(0L, (System.currentTimeMillis() - lastBatchAt) / 1000L);
+            response.putHeader("Nanopub-Query-Loader-Last-Success-Age-Seconds", String.valueOf(ageSeconds));
+        }
     }
 }

--- a/src/test/java/com/knowledgepixels/query/MainVerticleGlobalHeadersTest.java
+++ b/src/test/java/com/knowledgepixels/query/MainVerticleGlobalHeadersTest.java
@@ -41,6 +41,49 @@ class MainVerticleGlobalHeadersTest {
     }
 
     @Test
+    void setsLoaderAgeHeaderOnceTheLoaderHasTicked() {
+        try (MockedStatic<TripleStore> mockedTripleStore = mockStatic(TripleStore.class)) {
+            initializeStatusController(mockedTripleStore);
+            long saved = JellyNanopubLoader.lastSuccessfulBatchAtMs;
+            try {
+                JellyNanopubLoader.lastSuccessfulBatchAtMs = System.currentTimeMillis() - 7_440_000L;
+
+                HttpServerResponse response = mock(HttpServerResponse.class);
+                when(response.putHeader(anyString(), anyString())).thenReturn(response);
+
+                MainVerticle.applyGlobalHeaders(response);
+
+                // 7440 s — the age the loader had reached when the 2026-07-31 stall was noticed.
+                verify(response).putHeader("Nanopub-Query-Loader-Last-Success-Age-Seconds", "7440");
+            } finally {
+                JellyNanopubLoader.lastSuccessfulBatchAtMs = saved;
+            }
+        }
+    }
+
+    @Test
+    void omitsLoaderAgeHeaderBeforeTheFirstTick() {
+        // Sending 0 here would be indistinguishable from "just ticked", which is the one
+        // reading a consumer must not confuse with a freshly started instance.
+        try (MockedStatic<TripleStore> mockedTripleStore = mockStatic(TripleStore.class)) {
+            initializeStatusController(mockedTripleStore);
+            long saved = JellyNanopubLoader.lastSuccessfulBatchAtMs;
+            try {
+                JellyNanopubLoader.lastSuccessfulBatchAtMs = 0L;
+
+                HttpServerResponse response = mock(HttpServerResponse.class);
+                when(response.putHeader(anyString(), anyString())).thenReturn(response);
+
+                MainVerticle.applyGlobalHeaders(response);
+
+                verify(response, never()).putHeader(eq("Nanopub-Query-Loader-Last-Success-Age-Seconds"), anyString());
+            } finally {
+                JellyNanopubLoader.lastSuccessfulBatchAtMs = saved;
+            }
+        }
+    }
+
+    @Test
     void setsRegistryUrlHeader() {
         try (MockedStatic<TripleStore> mockedTripleStore = mockStatic(TripleStore.class)) {
             initializeStatusController(mockedTripleStore);


### PR DESCRIPTION
Adds `Nanopub-Query-Loader-Last-Success-Age-Seconds` to the global response headers. Companion to knowledgepixels/nanopub-monitor#TBD, which reads it to populate the new **Loader** column.

## Why a header when the metric already exists

The same value backs `registry.loader.last_successful_batch_age_seconds`, but `docker-compose.yml` binds the metrics port to `127.0.0.1`, so anything off-host can't read it. nanopub-monitor needs it, and over HTTP a stalled instance is otherwise indistinguishable from a healthy one — it keeps answering queries and keeps reporting `READY`. That is precisely how the 2026-07-31 stall stayed invisible for hours.

The monitor's sync-lag check can't cover this on its own. Its registry side comes from the instance's last successful poll, so if polling is what broke, both counts freeze together and the lag reads a reassuring `0`.

## Detail worth reviewing

The header is **omitted** before the first tick completes rather than sent as `0`, so consumers can distinguish "not started yet" from "just ticked" — `0` is the healthiest possible reading and would be exactly the wrong thing to emit for a process that has never successfully polled.

## Testing

Two tests: one asserting the age is emitted (using 7440 s, the age the loader had actually reached when the stall was noticed), one asserting the header is absent before the first tick. Full suite green, 340 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)