### PR TITLE
fix(headers): stop blocking the event loop on a cold header cache

### DIFF
--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -688,11 +688,20 @@ public class MainVerticle extends AbstractVerticle {
         if (nanopubCount != null) {
             response.putHeader("Nanopub-Query-Registry-Nanopub-Count", nanopubCount);
         }
-        Long loadedCount = NanopubLoader.getLoadedNanopubCount();
+        // Cached reads only. This method runs on the Vert.x event loop for every
+        // inbound request, and the non-cached accessors fall back to a blocking store
+        // read whenever the cache is cold — which it is after every restart. That
+        // stalled the event loop on 2026-07-31 (BlockedThreadChecker fired five times
+        // right after the 1.24.0 rollout), and with the store unreachable it would
+        // block every request for the full 10 s connect timeout, taking the HTTP layer
+        // down with RDF4J. NanopubLoader.primeHeaderCaches() keeps these warm from the
+        // metrics tick; until it has run, the headers are simply omitted, exactly as
+        // they already are before the first load.
+        Long loadedCount = NanopubLoader.getCachedLoadedNanopubCount();
         if (loadedCount != null) {
             response.putHeader("Nanopub-Query-Loaded-Nanopub-Count", loadedCount.toString());
         }
-        String loadedChecksum = NanopubLoader.getLoadedNanopubChecksum();
+        String loadedChecksum = NanopubLoader.getCachedLoadedNanopubChecksum();
         if (loadedChecksum != null) {
             response.putHeader("Nanopub-Query-Loaded-Nanopub-Checksum", loadedChecksum);
         }

--- a/src/main/java/com/knowledgepixels/query/MetricsCollector.java
+++ b/src/main/java/com/knowledgepixels/query/MetricsCollector.java
@@ -177,6 +177,11 @@ public final class MetricsCollector {
                         .count()
         );
         fullRepositoriesCounter.set(repoNames.size());
+        // Keeps the loaded-count/checksum caches warm for applyGlobalHeaders, which
+        // runs on the event loop and therefore reads them without a store fallback.
+        // This tick is the right host: it already runs unconditionally on its own
+        // executor at a fixed cadence, and computeSyncLag below needs the count anyway.
+        NanopubLoader.primeHeaderCaches();
         syncLagNanopubs.set(computeSyncLag());
 
         // Update status gauge

--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -713,6 +713,9 @@ public class NanopubLoader {
      * hasn't been initialised yet). Reads the persisted {@code npa:hasNanopubCount}
      * triple on first call and caches it in {@link #loadedNanopubCount};
      * subsequent fresh loads update the cache in-place.
+     *
+     * <p><b>Blocks</b> on a cold cache — use {@link #getCachedLoadedNanopubCount()}
+     * from the event loop.
      */
     public static Long getLoadedNanopubCount() {
         Long v = loadedNanopubCount;
@@ -735,12 +738,65 @@ public class NanopubLoader {
     }
 
     /**
+     * The cached loaded-nanopub count, without the store read that
+     * {@link #getLoadedNanopubCount()} falls back to, or {@code null} if nothing has
+     * populated it yet.
+     *
+     * <p>For callers that must not block — specifically
+     * {@link MainVerticle#applyGlobalHeaders}, which runs on the Vert.x event loop
+     * for every inbound request. The lazy fallback does blocking HTTP, and on a cold
+     * cache (i.e. after every restart) that stalled the event loop until the store
+     * answered; Vert.x's BlockedThreadChecker fired repeatedly on 2026-07-31. Worse,
+     * with the store unreachable it would have blocked every request for the full
+     * 10 s connect timeout, turning an RDF4J outage into a total outage of the HTTP
+     * layer — including the status headers used to diagnose it.
+     *
+     * <p>Kept warm off the event loop by {@link #primeHeaderCaches()}.
+     *
+     * @return the cached count, or null if not yet known
+     */
+    public static Long getCachedLoadedNanopubCount() {
+        return loadedNanopubCount;
+    }
+
+    /**
+     * The cached loaded-nanopub checksum, without the store read that
+     * {@link #getLoadedNanopubChecksum()} falls back to, or {@code null} if nothing
+     * has populated it yet. Same event-loop rationale as
+     * {@link #getCachedLoadedNanopubCount()}.
+     *
+     * @return the cached checksum, or null if not yet known
+     */
+    public static String getCachedLoadedNanopubChecksum() {
+        return loadedNanopubChecksum;
+    }
+
+    /**
+     * Populates the caches read by {@link #getCachedLoadedNanopubCount()} and
+     * {@link #getCachedLoadedNanopubChecksum()}, going to the store if they are cold.
+     *
+     * <p>Both values are otherwise only refreshed when a nanopub is actually loaded,
+     * so an instance that starts up already caught up would never populate them and
+     * would serve those headers empty forever. Something off the event loop has to
+     * prime them; {@link MetricsCollector#updateMetrics()} does, on its own executor.
+     *
+     * <p><b>Blocks.</b> Never call from the Vert.x event loop.
+     */
+    public static void primeHeaderCaches() {
+        getLoadedNanopubCount();
+        getLoadedNanopubChecksum();
+    }
+
+    /**
      * Returns the order-independent XOR checksum (Base64-encoded) of trusty URIs
      * of all nanopubs ever loaded into the {@code meta} repo, or {@code null} if
      * the value cannot be determined (e.g. the store hasn't been initialised
      * yet). Reads the persisted {@code npa:hasNanopubChecksum} triple on first
      * call and caches it in {@link #loadedNanopubChecksum}; subsequent fresh
      * loads update the cache in-place alongside {@link #loadedNanopubCount}.
+     *
+     * <p><b>Blocks</b> on a cold cache — use {@link #getCachedLoadedNanopubChecksum()}
+     * from the event loop.
      */
     public static String getLoadedNanopubChecksum() {
         String v = loadedNanopubChecksum;

--- a/src/test/java/com/knowledgepixels/query/MainVerticleGlobalHeadersTest.java
+++ b/src/test/java/com/knowledgepixels/query/MainVerticleGlobalHeadersTest.java
@@ -26,6 +26,63 @@ class MainVerticleGlobalHeadersTest {
     }
 
     @Test
+    void neverReadsTheStoreWhenTheLoadedCountCacheIsCold() {
+        // applyGlobalHeaders runs on the Vert.x event loop for every inbound request.
+        // The non-cached accessors fall back to a blocking store read on a cold cache,
+        // which stalled the loop after the 1.24.0 rollout (BlockedThreadChecker fired
+        // five times). A cold cache must mean "omit the header", never "go and fetch".
+        try (MockedStatic<TripleStore> mockedTripleStore = mockStatic(TripleStore.class)) {
+            initializeStatusController(mockedTripleStore);
+            TripleStore store = TripleStore.get();
+            clearInvocations(store);
+
+            Long savedCount = NanopubLoader.loadedNanopubCount;
+            String savedChecksum = NanopubLoader.loadedNanopubChecksum;
+            try {
+                NanopubLoader.loadedNanopubCount = null;
+                NanopubLoader.loadedNanopubChecksum = null;
+
+                HttpServerResponse response = mock(HttpServerResponse.class);
+                when(response.putHeader(anyString(), anyString())).thenReturn(response);
+
+                MainVerticle.applyGlobalHeaders(response);
+
+                verify(response, never()).putHeader(eq("Nanopub-Query-Loaded-Nanopub-Count"), anyString());
+                verify(response, never()).putHeader(eq("Nanopub-Query-Loaded-Nanopub-Checksum"), anyString());
+                // The load-bearing assertion: no connection was opened to satisfy them.
+                verify(store, never()).getRepoConnection(anyString());
+            } finally {
+                NanopubLoader.loadedNanopubCount = savedCount;
+                NanopubLoader.loadedNanopubChecksum = savedChecksum;
+            }
+        }
+    }
+
+    @Test
+    void servesLoadedCountAndChecksumOnceTheCacheIsWarm() {
+        try (MockedStatic<TripleStore> mockedTripleStore = mockStatic(TripleStore.class)) {
+            initializeStatusController(mockedTripleStore);
+            Long savedCount = NanopubLoader.loadedNanopubCount;
+            String savedChecksum = NanopubLoader.loadedNanopubChecksum;
+            try {
+                NanopubLoader.loadedNanopubCount = 86636L;
+                NanopubLoader.loadedNanopubChecksum = "GrBjnnFQ2ahO";
+
+                HttpServerResponse response = mock(HttpServerResponse.class);
+                when(response.putHeader(anyString(), anyString())).thenReturn(response);
+
+                MainVerticle.applyGlobalHeaders(response);
+
+                verify(response).putHeader("Nanopub-Query-Loaded-Nanopub-Count", "86636");
+                verify(response).putHeader("Nanopub-Query-Loaded-Nanopub-Checksum", "GrBjnnFQ2ahO");
+            } finally {
+                NanopubLoader.loadedNanopubCount = savedCount;
+                NanopubLoader.loadedNanopubChecksum = savedChecksum;
+            }
+        }
+    }
+
+    @Test
     void setsStatusHeader() {
         try (MockedStatic<TripleStore> mockedTripleStore = mockStatic(TripleStore.class)) {
             initializeStatusController(mockedTripleStore);


### PR DESCRIPTION
Found while verifying the 1.24.0 rollout. Pre-existing, not introduced by #149.

## What happened

Five `io.vertx.core.VertxException: Thread blocked` warnings fired right after the rollout, with the stack pointing straight at the header path:

```
NanopubLoader.getLoadedNanopubCount(NanopubLoader.java:722)
MainVerticle.applyGlobalHeaders(MainVerticle.java:691)
MainVerticle.lambda$start$30(MainVerticle.java:471)
```

`applyGlobalHeaders` runs on the Vert.x event loop for **every inbound request**, and both `getLoadedNanopubCount()` and `getLoadedNanopubChecksum()` fall back to a blocking store read when their cache is cold — which it is after every restart.

## Why it's worth fixing even though it self-cleared

It stopped as soon as the cache warmed. But the failure mode compounds badly with the RDF4J outages these instances have been having: with the store unreachable and the cache cold, every request would block the event loop for the full 10 s connect timeout. That turns an RDF4J outage into a total outage of the HTTP layer — including the very status headers the monitor reads to tell you what's wrong, and which this repo has spent several PRs making trustworthy.

## The change

- New non-blocking accessors `getCachedLoadedNanopubCount()` / `getCachedLoadedNanopubChecksum()`, used by `applyGlobalHeaders`.
- `primeHeaderCaches()` called from `MetricsCollector.updateMetrics`, which already runs unconditionally on its own executor at a fixed cadence and already needs the count for the sync-lag gauge.

Priming is not optional: the two values are otherwise only refreshed when a nanopub is actually loaded, so an instance that starts up already caught up would serve those headers empty indefinitely. That would have been a real regression for the monitor.

Until the first prime lands (within a second of startup), the headers are omitted — exactly what they already did before the first load, so no consumer sees a new shape.

## Testing

`neverReadsTheStoreWhenTheLoadedCountCacheIsCold` is the regression test. Beyond asserting the headers are omitted, it asserts `getRepoConnection` is **never** called — the actual property at stake. Verified it fails against the old code with precisely the right diagnostic:

```
tripleStore.getRepoConnection(<any string>);
Never wanted here ... But invoked here:
-> at NanopubLoader.getLoadedNanopubCount(NanopubLoader.java:725) with arguments: [meta]
```

`servesLoadedCountAndChecksumOnceTheCacheIsWarm` covers the other side, so the fix can't silently stop serving the headers. Full suite green, 342 tests.

## Not in scope

The same warnings show a second blocking path — `handleProxyRequest` constructing a `GrlcSpec` on the event loop, which fetches a nanopub and hits the triple store. Fixing that means moving the `/api` proxy onto `executeBlocking`. That's a larger change on a hot path currently serving 400–1300 requests/minute, and doing it in the same PR would make both harder to review and riskier to deploy. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)