### PR TITLE
fix(rdf4j): stop the healthcheck from killing Tomcat by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,9 @@ services:
       # in-cluster URL the SERVICE rewrite uses, so the probe tests the real
       # federation route. Set explicitly empty to disable the probe.
       - NANOPUB_QUERY_INTERNAL_URL=${NANOPUB_QUERY_INTERNAL_URL-http://query:9393/}
+      # Whether a failing healthcheck probe may kill Tomcat. Off by default —
+      # see the reasoning above the healthcheck test block.
+      - RDF4J_HEALTHCHECK_RESTART=${RDF4J_HEALTHCHECK_RESTART:-off}
     volumes:
       - ./data/rdf4j/data:/var/rdf4j
       - ./data/rdf4j/logs:/usr/local/tomcat/logs
@@ -89,8 +92,35 @@ services:
         # storms: a persistently wedged repo used to trigger a kill every probe
         # interval, multiplying the data-loss windows; now the probe reports
         # unhealthy without re-killing until the backoff elapses.
+        #
+        # Auto-restart is OFF by default since 2026-07-31. Both probes still run
+        # and still record failures, so a wedge is visible (container goes
+        # unhealthy, timestamps land in /var/info/), but nothing kills Tomcat.
+        #
+        # Why: on 2026-07-31 the healthcheck killed Tomcat 10 times, 7 of them
+        # between 12:00 and 13:55 — and it was not curing anything. Each cycle
+        # cost ~110 s of downtime (13:55:14 kill -> 13:57:04 back up) and the
+        # store re-wedged within 11-20 minutes, so the restart only reset a
+        # clock. Meanwhile every kill is a roll of the issue #142 dice:
+        # acknowledged, read-back-verified writes reverting. Trading a visible
+        # degradation for silent data loss is the wrong way round.
+        #
+        # Attribution, so the next reader does not repeat our mistake: 8 of the
+        # 10 kills came from the FIRST (direct-query) probe, only 2 from the
+        # federation probe. /var/info/restart is the kill log;
+        # /var/info/federation-restart is written *before* restart_tomcat, which
+        # often returns early on the backoff — the two files are not comparable
+        # counts. Disabling the federation probe alone would have prevented 2.
+        #
+        # Re-enable with RDF4J_HEALTHCHECK_RESTART=on once the underlying LMDB
+        # ValueStore$ReadTxn leak is resolved upstream (still present in 5.3.2,
+        # after #5807; see rdf4j-issue-draft.md).
         test: |
           restart_tomcat() {
+            if [ "$$RDF4J_HEALTHCHECK_RESTART" != "on" ]; then
+              date >> /var/info/restart-suppressed
+              return
+            fi
             if [ -f /var/info/restart ]; then
               last_s=$$(date -d "$$(tail -1 /var/info/restart)" +%s 2>/dev/null || echo 0)
               if [ $$(( $$(date +%s) - last_s )) -lt 600 ]; then


### PR DESCRIPTION
Sets `RDF4J_HEALTHCHECK_RESTART=off` as the default. Both probes still run and still record failures — the container goes unhealthy and timestamps land in `/var/info/` — but nothing kills Tomcat. Paired with knowledgepixels/nanopub-infrastructure (same change in the deployed config).

## Why

On 2026-07-31 the healthcheck killed Tomcat **10 times**, 7 of them between 12:00 and 13:55, and it was not curing anything. Each cycle cost ~110 s of downtime (13:55:14 kill → 13:57:04 back up, most of it the slow LMDB shutdown) and the store re-wedged within 11–20 minutes. The restart only reset a clock.

Meanwhile every kill is a roll of the #142 dice — acknowledged, read-back-verified writes reverting. 851ceb6 already identified this kill path as that incident's loss amplifier and softened it (10 s → 60 s grace, 10-minute backoff); this goes the rest of the way. Trading a visible degradation for silent data loss is the wrong way round.

## A correction worth recording

This investigation started from "disable the federation probe", on my reading that it caused today's restarts. **That was wrong**, and the PR keeps the correction in a comment so nobody repeats it:

- `/var/info/restart` is the **kill** log.
- `/var/info/federation-restart` is written **before** `restart_tomcat`, which often returns early on the backoff.

They are not comparable counts. Attributing today's 10 kills properly: **8 came from the direct-query probe, only 2 from the federation probe** (three further federation failures were suppressed by the backoff). Disabling the federation probe alone would have prevented 2 of 10 — which is why the fix targets the response rather than either probe.

## What is preserved

Detection. Both probes run unchanged, failures are still timestamped, and the container reports unhealthy so `docker ps` shows it. What is removed is only the kill. Suppressed restarts are logged to `/var/info/restart-suppressed` so the rate stays measurable.

## Root cause, unchanged by this

Upstream: LMDB `ValueStore$ReadTxn` transactions leak onto Tomcat worker threads under aborted-query load, still present in 5.3.2 after #5807. See `rdf4j-issue-draft.md`. Re-enable with `RDF4J_HEALTHCHECK_RESTART=on` once that is resolved.

## Risk

A genuinely dead RDF4J will no longer self-recover — it will sit unhealthy until someone acts. That is the deliberate trade: a wedge degrades `/api` visibly, whereas a lost commit is silent. It does raise the priority of the outstanding alerting work (nothing scrapes the metrics yet, and nanopub-monitor#49 is unmerged), because detection is now entirely on the operator.

Validated with `docker compose config`; the gate renders correctly with the default `off`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)