### PR TITLE
fix(rdf4j): clear the ready marker at container start

### DIFF
--- a/entrypoint/init.sh
+++ b/entrypoint/init.sh
@@ -11,5 +11,22 @@ if ! command -v curl >/dev/null 2>&1; then
     apt-get update && apt-get install -y --no-install-recommends curl
 fi
 
+# Clear the "has been ready" marker for this container instance. The healthcheck
+# only restarts Tomcat when /var/info/ready exists, so that a probe failing while
+# the WARs are still deploying doesn't kill a perfectly healthy start-up. But
+# /var/info is a host-mounted volume, so the marker outlived the container it was
+# created for: after any `docker compose up -d rdf4j` it was already present, and
+# the guard protected only a genuinely first-ever start.
+#
+# Observed on kpxl 2026-07-31: the container was recreated at 14:40:50, the first
+# probe failed at 14:40:55 while Tomcat was still deploying, and the marker from
+# the previous instance made the healthcheck call restart_tomcat — a kill during
+# a WAR deploy, which is exactly the condition implicated in the acknowledged-
+# write loss of issue #142. Only RDF4J_HEALTHCHECK_RESTART=off stopped it.
+#
+# Removing it here makes the marker mean what its use claims: "*this* container
+# instance has been seen healthy". The first successful probe recreates it.
+rm -f /var/info/ready
+
 # Drop privileges back to the image's default tomcat user for the JVM itself.
 runuser -u tomcat -- catalina.sh run


### PR DESCRIPTION
Paired with knowledgepixels/nanopub-infrastructure#25 (identical change to the deployed `entrypoint/init.sh`).

## The bug

The healthcheck only kills Tomcat when `/var/info/ready` exists — the stated intent being "don't kill Tomcat mid-deploy during `start_period`". But `/var/info` is a host-mounted volume, so **the marker survives container recreation**. The guard therefore protected only a genuinely first-ever start; every `docker compose up -d rdf4j` since has been unprotected.

## How it surfaced

On kpxl today, applying the `RDF4J_HEALTHCHECK_RESTART=off` change recreated the container at **14:40:50**. The first probe failed at **14:40:55**, while Tomcat was still deploying the WARs — and the marker left by the previous instance made the healthcheck call `restart_tomcat`. A kill during a WAR deploy is exactly the condition #142 implicates in acknowledged, read-back-verified writes reverting.

It only became a line in `/var/info/restart-suppressed` instead of a `pkill` because #151 had landed minutes earlier. The gate's first act in production was to prevent a kill that should never have been possible.

## The fix

`rm -f /var/info/ready` before launching Tomcat. The first successful probe recreates it, so the marker comes to mean what its use already claims: *this* container instance has been seen healthy.

## Why it matters even with restarts off

This is a **prerequisite for ever setting `RDF4J_HEALTHCHECK_RESTART=on` again**. Without it, the first recreation after re-enabling would kill Tomcat mid-deploy, and we would likely read that as fresh evidence of instability rather than as our own healthcheck.

## Verification

`bash -n` on both copies, and the guard's four cases simulated directly:

| situation | before | after |
|---|---|---|
| recreation, probe fails during deploy | **KILL** | no-kill |
| after a successful probe, genuine wedge | KILL | KILL |
| truly first-ever start (empty volume) | no-kill | no-kill |

`rm -f` on an absent marker exits 0, so a first-ever start is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)