### PR TITLE
refactor: wait for triple store via compose healthcheck, drop startup sleep (#45)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,12 @@ services:
     build: .
     image: nanopub/query:latest
     restart: unless-stopped
+    # Wait for the triple store to be healthy before starting, so the app does
+    # not need to poll/sleep for it at startup (see issue #45). rdf4j defines the
+    # healthcheck below.
+    depends_on:
+      rdf4j:
+        condition: service_healthy
     ports:
       - "9393:9393"
       # :9394 is only accessible from localhost as it is used for the /metrics endpoint
@@ -16,7 +22,6 @@ services:
       - ENDPOINT_BASE=http://rdf4j:8080/rdf4j-server/
       - REGISTRY_FIXED_URL=https://registry.knowledgepixels.com/
       - RDF4J_PROXY_HOST=rdf4j
-    #     - INIT_WAIT_SECONDS=120   # Only used by the local nanopub loader
     #     - NANOPUB_QUERY_URL=https://query.knowledgepixels.com/
     logging:
       options:

--- a/src/main/java/com/knowledgepixels/query/LocalNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/LocalNanopubLoader.java
@@ -31,8 +31,6 @@ public class LocalNanopubLoader {
      */
     public final static File loadNanopubsFile = new File("load/nanopubs.trig.gz");
 
-    private static final int DEFAULT_WAIT_SECONDS = 120;
-
     /**
      * Load nanopubs from local files.
      *
@@ -43,16 +41,9 @@ public class LocalNanopubLoader {
             logger.info("No local nanopub files for loading found. Moving on to loading via Jelly...");
             return false;
         }
-        logger.info("Waiting {} seconds to make sure the triple store is up...", getWaitSeconds());
-        try {
-            for (int w = 0; w < getWaitSeconds(); w++) {
-                logger.info("Waited {} seconds...", w);
-                Thread.sleep(1000);
-            }
-        } catch (InterruptedException ex) {
-            // ignore
-        }
-
+        // The triple store's availability is guaranteed by the Docker Compose service
+        // dependency (query depends_on rdf4j with condition: service_healthy), so no
+        // fixed startup wait is needed here anymore (see issue #45).
         logger.info("Loading the local list of nanopubs...");
         load();
         return true;
@@ -81,10 +72,6 @@ public class LocalNanopubLoader {
                 logger.info("Loading nanopubs failed.", ex);
             }
         }
-    }
-
-    static int getWaitSeconds() {
-        return Utils.getEnvInt("INIT_WAIT_SECONDS", DEFAULT_WAIT_SECONDS);
     }
 
 }

--- a/src/test/java/com/knowledgepixels/query/LocalNanopubLoaderTest.java
+++ b/src/test/java/com/knowledgepixels/query/LocalNanopubLoaderTest.java
@@ -63,7 +63,6 @@ class LocalNanopubLoaderTest {
         loadUrisFile.createNewFile();
 
         try (MockedStatic<LocalNanopubLoader> mockedLoader = mockStatic(LocalNanopubLoader.class, CALLS_REAL_METHODS)) {
-            mockedLoader.when(LocalNanopubLoader::getWaitSeconds).thenReturn(2);
             mockedLoader.when(LocalNanopubLoader::load).thenAnswer(invocation -> null);
             assertTrue(LocalNanopubLoader.init());
         }


### PR DESCRIPTION
Closes #45.

## What & why

`LocalNanopubLoader.init()` blocked for a fixed `INIT_WAIT_SECONDS` (default **120s**) at startup "to make sure the triple store is up" via a `Thread.sleep()` loop. That blind wait is both wasteful (when rdf4j is ready in seconds) and fragile (fails if it takes longer), and it duplicates ordering that Docker Compose expresses directly.

The `rdf4j` service already defines a `healthcheck`, but the `query` service had **no `depends_on`**. This PR wires that up and removes the sleep:

- `docker-compose.yml`: add `depends_on: rdf4j: condition: service_healthy` to `query`; drop the obsolete `INIT_WAIT_SECONDS` env comment.
- `LocalNanopubLoader`: remove the fixed wait loop and the `getWaitSeconds()` / `INIT_WAIT_SECONDS` / `DEFAULT_WAIT_SECONDS` machinery.
- `LocalNanopubLoaderTest`: drop the now-obsolete `getWaitSeconds` stub.

## Scope: only one sleep was a service-availability wait

The issue says "some classes use `Thread.sleep()` to wait for a service… remove all no-longer-needed calls." After auditing all 13 `Thread.sleep()` calls, **only** the `LocalNanopubLoader` startup wait fits that description. The rest are deliberately **kept** because they are runtime resilience/backoff, not startup service-availability waits:

- `NanopubLoader` (×8): exponential backoff (`computeBackoffMillis`) inside bounded `MAX_RETRIES` retry loops after failed triple-store writes.
- `JellyNanopubLoader` circuit-breaker pauses (`BREAKER_PAUSE_MS`) and batch retry delay (`RETRY_DELAY_JELLY`) for a saturated/restarting RDF4J during operation.
- `JellyNanopubLoader` Registry metadata retry (`RETRY_DELAY_METADATA`): a bounded retry against the **external** Registry (`REGISTRY_FIXED_URL`), which is not a Compose service and cannot be covered by `depends_on`.

## ⚠️ Deployment note

The compose file in this repo is a reference/example. The **deployment** compose lives in the private `nanopub-infrastructure` repo (`nanopub-query/docker-compose.yml`), which I couldn't access. That file must get the **same** `depends_on: rdf4j: condition: service_healthy` addition for the fix to take effect in production — otherwise the app starts without the sleep and without the ordering guarantee. Please mirror this change there.

## Testing

- `LocalNanopubLoaderTest`: 5/5 passing.
- Full `compile` + `test-compile`: clean.
- `docker-compose.yml` parses and resolves `query.depends_on = {rdf4j: {condition: service_healthy}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
