### PR TITLE
fix(rdf4j): exit on OOM and shut down gracefully, so a wedged store can recover

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,28 @@ services:
       # starving every /api call with "Timeout waiting for connection from
       # pool" (incident 2026-07-28). Keep the sum of concurrent outer queries
       # and federated self-calls below Tomcat's worker pool (200).
-      - JAVA_OPTS=-Dorg.eclipse.rdf4j.client.http.connectionTimeout=10000 -Dorg.eclipse.rdf4j.client.http.connectionRequestTimeout=10000 -Dorg.eclipse.rdf4j.client.http.socketTimeout=10000 -Dorg.eclipse.rdf4j.client.http.maxConnPerRoute=100 -Dorg.eclipse.rdf4j.client.http.maxConnTotal=120
+      #
+      # ExitOnOutOfMemoryError: without it, a heap OOM is survivable in the worst
+      # possible way. On kpxl 2026-08-05 the OOM killed the "http-nio-8080-Acceptor"
+      # thread (04:17:08) and then the Poller (04:17:30) while the JVM stayed alive
+      # spinning in GC. With no acceptor, the socket stays bound but nothing ever
+      # accepts: the backlog fills, the kernel drops SYNs, and every client sees a
+      # 10 s connect timeout. The process never exits, so `restart: unless-stopped`
+      # never fires, and with RDF4J_HEALTHCHECK_RESTART=off nothing else intervenes
+      # — the instance sat wedged for 11 hours while still reporting READY.
+      # Exiting on the first OOM turns that permanent outage into a ~2 min restart.
+      # It also composes with the healthcheck decision rather than fighting it: the
+      # JVM only dies when it is already unrecoverable, so this does not reintroduce
+      # the mid-write kill risk of issue #142 that turning restarts off avoided.
+      #
+      # MaxRAMPercentage: the container has no mem_limit, so the JVM default of 25%
+      # of *host* RAM applied. Pinning it makes the ceiling explicit and independent
+      # of the host the stack lands on.
+      #
+      # HeapDumpOnOutOfMemoryError: /var/info is host-mounted (./data/info), so the
+      # dump survives the exit above and can be opened after the fact. Sized in GB —
+      # check free space there before enabling on a small host.
+      - JAVA_OPTS=-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/info/ -XX:MaxRAMPercentage=${RDF4J_MAX_RAM_PERCENTAGE:-50} -Dorg.eclipse.rdf4j.client.http.connectionTimeout=10000 -Dorg.eclipse.rdf4j.client.http.connectionRequestTimeout=10000 -Dorg.eclipse.rdf4j.client.http.socketTimeout=10000 -Dorg.eclipse.rdf4j.client.http.maxConnPerRoute=100 -Dorg.eclipse.rdf4j.client.http.maxConnTotal=120
       # Used by the healthcheck's federation probe below; defaults to the same
       # in-cluster URL the SERVICE rewrite uses, so the probe tests the real
       # federation route. Set explicitly empty to disable the probe.
@@ -71,6 +92,12 @@ services:
     ports:
       - "8081:8080"
     entrypoint: /var/entrypoint/init.sh
+    # Docker's default grace period is 10 s, but a clean Tomcat shutdown here has to
+    # close thousands of LMDB repos and measured ~100 s on kpxl (2026-07-31: kill at
+    # 13:55:14, port closed 13:56:54). At 10 s every stop became a SIGKILL, which is
+    # the hard-kill-mid-write condition implicated in issue #142. Forwarding SIGTERM
+    # from init.sh is pointless without giving the shutdown room to finish.
+    stop_grace_period: 120s
     healthcheck:
         # If the direct-query curl succeeds, mark the instance as "has been
         # ready". Only force a restart (via pkill) when a probe fails AND we've

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,15 @@ services:
       # HeapDumpOnOutOfMemoryError: /var/info is host-mounted (./data/info), so the
       # dump survives the exit above and can be opened after the fact. Sized in GB —
       # check free space there before enabling on a small host.
-      - JAVA_OPTS=-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/info/ -XX:MaxRAMPercentage=${RDF4J_MAX_RAM_PERCENTAGE:-50} -Dorg.eclipse.rdf4j.client.http.connectionTimeout=10000 -Dorg.eclipse.rdf4j.client.http.connectionRequestTimeout=10000 -Dorg.eclipse.rdf4j.client.http.socketTimeout=10000 -Dorg.eclipse.rdf4j.client.http.maxConnPerRoute=100 -Dorg.eclipse.rdf4j.client.http.maxConnTotal=120
+      #
+      # PrintConcurrentLocks: makes a SIGQUIT (`kill -3`) thread dump include the
+      # "Locked ownable synchronizers" block, i.e. which thread *owns* each
+      # java.util.concurrent lock. Without it a plain kill -3 shows waiters but not
+      # holders. On 2026-08-05 a dump showed 171 threads parked on one
+      # SailSourceBranch ReentrantLock with no way to tell who held it, and the
+      # image ships a JRE (no jcmd/jstack), so there was no second way to ask.
+      # Zero runtime cost until a dump is requested.
+      - JAVA_OPTS=-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/info/ -XX:MaxRAMPercentage=${RDF4J_MAX_RAM_PERCENTAGE:-50} -XX:+PrintConcurrentLocks -Dorg.eclipse.rdf4j.client.http.connectionTimeout=10000 -Dorg.eclipse.rdf4j.client.http.connectionRequestTimeout=10000 -Dorg.eclipse.rdf4j.client.http.socketTimeout=10000 -Dorg.eclipse.rdf4j.client.http.maxConnPerRoute=100 -Dorg.eclipse.rdf4j.client.http.maxConnTotal=120
       # Used by the healthcheck's federation probe below; defaults to the same
       # in-cluster URL the SERVICE rewrite uses, so the probe tests the real
       # federation route. Set explicitly empty to disable the probe.

--- a/entrypoint/init.sh
+++ b/entrypoint/init.sh
@@ -29,4 +29,49 @@ fi
 rm -f /var/info/ready
 
 # Drop privileges back to the image's default tomcat user for the JVM itself.
-runuser -u tomcat -- catalina.sh run
+#
+# Run it in the background and wait, with SIGTERM/SIGINT forwarded to the JVM.
+# Without this, `docker stop` / `docker compose restart` / a container exit hands
+# SIGTERM to *this* script (PID 1); bash sitting in a foreground child does not
+# pass it on, the JVM never runs its shutdown hook, and 10 s later Docker sends
+# SIGKILL. Every Docker-initiated restart was therefore a hard kill — and a hard
+# kill of a store mid-write is the condition implicated in the acknowledged-write
+# loss of issue #142. kpxl restarted this container 97 times in the four days to
+# 2026-08-05, so this was the normal case, not an edge case.
+#
+# Deliberately still not `exec`: the JVM must stay a child rather than become PID 1,
+# both because signals to PID 1 are ignored unless explicitly handled and because
+# the healthcheck's restart_tomcat reaches it with pkill (see docker-compose.yml).
+#
+# The JVM is signalled directly rather than via $! (which is runuser's PID, not
+# the JVM's). Verified 2026-08-05: `kill -TERM` on the runuser PID does NOT reach
+# the JVM, so forwarding via $! would silently do nothing. `pkill java` is the
+# mechanism the healthcheck's restart_tomcat already relies on in this image.
+#
+# The wait is bounded rather than a bare `wait`: if pkill is ever missing or
+# matches nothing, blocking here would swallow the signal and sit until Docker's
+# SIGKILL — guaranteeing the hard kill this handler exists to prevent. Bounded at
+# just under the stop_grace_period set in docker-compose.yml.
+term_handler() {
+    if command -v pkill > /dev/null 2>&1; then
+        pkill -TERM java 2>/dev/null
+    else
+        kill -TERM "$child_pid" 2>/dev/null
+    fi
+    i=0
+    while [ "$i" -lt 110 ] && kill -0 "$child_pid" 2>/dev/null; do
+        sleep 1
+        i=$((i + 1))
+    done
+    exit 143
+}
+trap term_handler TERM INT
+
+runuser -u tomcat -- catalina.sh run &
+child_pid=$!
+# A trapped signal interrupts `wait`, but term_handler exits from inside the trap,
+# so control only reaches the next line when the JVM exited on its own — e.g. via
+# -XX:+ExitOnOutOfMemoryError. Propagating that status exits the container, which
+# is what lets `restart: unless-stopped` recover it.
+wait "$child_pid"
+exit $?


### PR DESCRIPTION
## Why

query.knowledgepixels.com served nothing for **11 hours** on 2026-08-05 (04:26 UTC and earlier: every `/repo/*` 504, every `/api/*` 502) while still advertising `Nanopub-Query-Status: READY`. Root cause, from `docker compose logs rdf4j`:

```
04:17:08  OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "http-nio-8080-Acceptor"
04:17:30  OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "http-nio-8080-Poller"
```

The first `Connect timed out` in the query app's log is 04:17:30 — an exact match. With the acceptor thread dead the socket stays bound but nothing ever accepts, so the backlog fills, the kernel drops SYNs, and every client waits out a 10 s connect timeout.

**The JVM never exited** — it sat at ~99 % CPU in a GC death spiral (1 h50 m CPU in ~75 min wall). So `restart: unless-stopped` never fired, and since healthcheck auto-restart has been off since 2026-07-31 (#151) nothing else intervened. Of all the ways this container fails — `RestartCount=97` in four days — the only unrecoverable one is where the JVM refuses to die.

## What

1. **`-XX:+ExitOnOutOfMemoryError`** — turns the permanent wedge into a ~2 min Docker restart. This *composes* with the decision in #151 rather than reverting it: the JVM only dies once already unrecoverable, so it does not reintroduce the mid-write hard-kill risk of #142.
2. **`-XX:MaxRAMPercentage`** — no `mem_limit` is set, so the JVM default of 25 % of *host* RAM applied and varied silently with the host. **`-XX:+HeapDumpOnOutOfMemoryError`** to `/var/info` (host-mounted) so the next OOM is diagnosable; we still do not know what consumed the heap.
3. **SIGTERM forwarding in `init.sh`** — `runuser … catalina.sh run` was a plain foreground child of bash at PID 1, and non-interactive bash does not forward SIGTERM. Every Docker-initiated restart (97 of them) was therefore a hard kill of the store, possibly mid-write — the #142 condition.
4. **`stop_grace_period: 120s`** — a clean shutdown closes thousands of LMDB repos and measured ~100 s, against Docker's 10 s default. Forwarding SIGTERM is pointless without room to finish.

## Verification

Signal handling is subtle, so it was tested in containers rather than reasoned about:

- `docker stop` → SIGTERM now reaches the JVM; container exits **143, not 137**.
- JVM exiting on its own (as the OOM policy makes it) → status propagates, container exits, restart policy recovers it (`RestartCount` incremented).
- Two findings that changed the implementation: `kill -TERM` on the **runuser** PID does *not* reach the child, so forwarding via `$!` would have silently done nothing; and a bare `wait` in the handler **hangs until SIGKILL** if `pkill` is missing — observed in a procps-less test image — which is why the wait is bounded.

JVM flags verified to parse on JDK 25.0.3, the exact version in the image. Both compose files pass `docker compose config`.

## Note

Includes the previously-uncommitted `fix(rdf4j): clear the ready marker at container start` (7f27c52), which had no PR and touches the same file. Pairs with knowledgepixels/nanopub-infrastructure#29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)