### PR TITLE
fix(loader): only report liveness after RDF4J has actually answered

### DIFF
--- a/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
@@ -6,6 +6,8 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.nanopub.NanopubUtils;
 import org.nanopub.jelly.NanopubStream;
 import org.slf4j.Logger;
@@ -54,15 +56,44 @@ public class JellyNanopubLoader {
     static final long BREAKER_PAUSE_MS = 30_000L;
 
     /**
-     * Epoch-millis of the last successful {@code loadUpdates} invocation (whether it
-     * actually loaded a batch or was a "caught up, nothing to do" tick). Read by
-     * {@link MetricsCollector} to expose {@code registry.loader.last_successful_batch_age_seconds}
-     * so an operator can tell at a glance from Grafana whether an instance is still
-     * making progress. Updated on every non-exceptional return from loadUpdates,
-     * including idle returns — an instance that is caught up and correctly polling
-     * still counts as alive.
+     * Epoch-millis of the last {@code loadUpdates} invocation that demonstrably reached
+     * the triple store — either by committing a batch, or, on an idle tick, by passing
+     * {@link #probeStoreReachable()}. Read by {@link MetricsCollector} to expose
+     * {@code registry.loader.last_successful_batch_age_seconds} and served as the
+     * {@code Nanopub-Query-Loader-Last-Success-Age-Seconds} header, so an operator can
+     * tell from outside whether an instance is still able to serve.
+     *
+     * <p><strong>Must only be stamped after RDF4J has actually answered.</strong> Until
+     * 2026-08-05 the idle branch stamped it unconditionally, but an idle tick reads the
+     * counter from in-memory {@link StatusController} state and otherwise talks only to
+     * the registry — it never touched RDF4J. A caught-up instance therefore reported
+     * age 0 and READY throughout an 11-hour total RDF4J outage on kpxl (Tomcat's acceptor
+     * thread had died of {@code OutOfMemoryError}, so every connect timed out), which is
+     * precisely the failure this signal exists to surface. A caught-up instance could
+     * never fail the check, which made the check worthless exactly when it mattered.
+     *
+     * <p>On a healthy idle instance the age now oscillates between 0 and
+     * {@link #STORE_PROBE_INTERVAL_MS}, rather than sitting at 0.
      */
     static volatile long lastSuccessfulBatchAtMs = 0L;
+
+    /**
+     * Minimum interval between idle-path store-reachability probes, and hence the
+     * granularity of {@link #lastSuccessfulBatchAtMs} on a caught-up instance. The idle
+     * path runs every {@link #UPDATES_POLL_INTERVAL} ms; probing on every poll would add
+     * 30 round trips a minute without sharpening the signal, since any alert on this
+     * value is measured in minutes.
+     */
+    static final long STORE_PROBE_INTERVAL_MS = 30_000L;
+
+    /**
+     * Epoch-millis of the last store-reachability probe, whether it was a dedicated
+     * {@link #probeStoreReachable()} call or a batch commit (which proves the same thing
+     * more strongly). Confined to the single-threaded loader executor in
+     * {@link MainVerticle}, so a plain field is enough. Package-private only so tests
+     * can reset it between cases.
+     */
+    static long lastStoreProbeAtMs = 0L;
 
     /**
      * Heartbeat counter for loadUpdates invocations. A summary log line is emitted
@@ -226,9 +257,18 @@ public class JellyNanopubLoader {
                 // that the old flow did on every idle poll. Also reset the breaker
                 // counter — a successful "nothing to do" is still a successful tick
                 // and should clear stale failure state from earlier transient errors.
+                //
+                // Probe the store *before* recording liveness: nothing else on this
+                // path touches RDF4J, so without it "caught up" would keep passing
+                // for liveness while the store was unreachable. A failing probe
+                // throws into the catch below, which increments the breaker and
+                // leaves lastSuccessfulBatchAtMs to go stale — the intended signal.
+                boolean probed = probeStoreReachable();
                 StatusController.get().setReady();
                 consecutiveBatchFailures = 0;
-                lastSuccessfulBatchAtMs = System.currentTimeMillis();
+                if (probed) {
+                    lastSuccessfulBatchAtMs = System.currentTimeMillis();
+                }
                 maybeLogHeartbeat(targetCounter, true);
                 return;
             }
@@ -237,6 +277,9 @@ public class JellyNanopubLoader {
             // Batch completed without an exception — reset the breaker counter.
             consecutiveBatchFailures = 0;
             lastSuccessfulBatchAtMs = System.currentTimeMillis();
+            // A committed batch is a stronger reachability proof than the ASK probe,
+            // so it also defers the next one.
+            lastStoreProbeAtMs = lastSuccessfulBatchAtMs;
             maybeLogHeartbeat(targetCounter, false);
             logger.info("Loaded {} update(s). Counter: {}, target was: {}",
                     lastCommittedCounter - status.loadCounter, lastCommittedCounter, targetCounter);
@@ -255,6 +298,35 @@ public class JellyNanopubLoader {
                 logger.info("Failure Reason: ", e);
             }
         }
+    }
+
+    /**
+     * Verify that the triple store is reachable and answering, so that
+     * {@link #lastSuccessfulBatchAtMs} means "this instance can still serve" rather than
+     * merely "the loader loop is still running".
+     *
+     * <p>Uses {@code ASK {}} against the admin repo: it matches the empty group pattern
+     * without touching any index, so the cost is one HTTP round trip and essentially no
+     * query work — while still exercising the exact client, connection pool and endpoint
+     * that a real query would use.
+     *
+     * <p>Throttled to one probe per {@link #STORE_PROBE_INTERVAL_MS}. Callers must treat
+     * a {@code false} return as "not verified now" and leave the liveness timestamp
+     * alone, so the stamp always refers to a round trip that actually happened.
+     *
+     * @return true if a probe ran and succeeded; false if one ran too recently to repeat
+     * @throws RuntimeException (from RDF4J) if the store did not answer
+     */
+    private static boolean probeStoreReachable() {
+        long now = System.currentTimeMillis();
+        if (now - lastStoreProbeAtMs < STORE_PROBE_INTERVAL_MS) {
+            return false;
+        }
+        try (RepositoryConnection conn = TripleStore.get().getAdminRepoConnection()) {
+            conn.prepareBooleanQuery(QueryLanguage.SPARQL, "ASK {}").evaluate();
+        }
+        lastStoreProbeAtMs = now;
+        return true;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -714,6 +714,11 @@ public class MainVerticle extends AbstractVerticle {
         //
         // Omitted rather than sent as 0 before the first tick completes, so consumers can
         // tell "not started yet" from "just ticked".
+        //
+        // The value is only stamped after RDF4J has actually answered (see
+        // JellyNanopubLoader#lastSuccessfulBatchAtMs), so on a caught-up instance it
+        // cycles 0..JellyNanopubLoader.STORE_PROBE_INTERVAL_MS rather than sitting at 0.
+        // Alert thresholds must therefore exceed that interval; minutes, not seconds.
         long lastBatchAt = JellyNanopubLoader.lastSuccessfulBatchAtMs;
         if (lastBatchAt != 0L) {
             long ageSeconds = Math.max(0L, (System.currentTimeMillis() - lastBatchAt) / 1000L);

--- a/src/test/java/com/knowledgepixels/query/JellyNanopubLoaderLivenessTest.java
+++ b/src/test/java/com/knowledgepixels/query/JellyNanopubLoaderLivenessTest.java
@@ -1,0 +1,137 @@
+package com.knowledgepixels.query;
+
+import com.knowledgepixels.query.JellyNanopubLoader.RegistryMetadata;
+import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The loader's liveness signal ({@code Nanopub-Query-Loader-Last-Success-Age-Seconds}
+ * and {@code registry.loader.last_successful_batch_age_seconds}) must only advance once
+ * RDF4J has actually answered.
+ *
+ * <p>Regression cover for the kpxl outage of 2026-08-05: RDF4J was unreachable for
+ * 11 hours while this instance reported READY with age 0, because an idle "caught up"
+ * tick reads its counter from in-memory state and otherwise talks only to the registry.
+ * A caught-up instance could never fail the check that exists to catch exactly this.
+ */
+class JellyNanopubLoaderLivenessTest {
+
+    /**
+     * Idle tick, registry caught up, so nothing but the probe would touch RDF4J.
+     */
+    private static final long COUNTER = 42L;
+
+    private static RegistryMetadata caughtUpMetadata() {
+        return new RegistryMetadata(COUNTER, null, null, null, null, null, null);
+    }
+
+    private static void resetLoaderState() {
+        JellyNanopubLoader.lastSuccessfulBatchAtMs = 0L;
+        JellyNanopubLoader.lastStoreProbeAtMs = 0L;
+        JellyNanopubLoader.consecutiveBatchFailures = 0;
+    }
+
+    private static StatusController mockedStatusController(MockedStatic<StatusController> statics) {
+        StatusController status = mock(StatusController.class);
+        statics.when(StatusController::get).thenReturn(status);
+        when(status.getState())
+                .thenReturn(StatusController.LoadingStatus.of(StatusController.State.READY, COUNTER));
+        return status;
+    }
+
+    @Test
+    void idleTickDoesNotRecordLivenessWhenStoreIsUnreachable() {
+        try (MockedStatic<JellyNanopubLoader> loader = mockStatic(JellyNanopubLoader.class, CALLS_REAL_METHODS);
+             MockedStatic<StatusController> statusStatic = mockStatic(StatusController.class);
+             MockedStatic<TripleStore> storeStatic = mockStatic(TripleStore.class)) {
+
+            mockedStatusController(statusStatic);
+            loader.when(JellyNanopubLoader::fetchRegistryMetadata).thenReturn(caughtUpMetadata());
+
+            TripleStore store = mock(TripleStore.class);
+            storeStatic.when(TripleStore::get).thenReturn(store);
+            when(store.getAdminRepoConnection())
+                    .thenThrow(new RepositoryException("Connect to rdf4j:8080 failed: Connect timed out"));
+
+            resetLoaderState();
+            JellyNanopubLoader.loadUpdates();
+
+            assertEquals(0L, JellyNanopubLoader.lastSuccessfulBatchAtMs,
+                    "an idle tick must not record liveness when RDF4J never answered");
+            assertEquals(1, JellyNanopubLoader.consecutiveBatchFailures,
+                    "an unreachable store must count as a failed tick, not a successful idle one");
+        }
+    }
+
+    @Test
+    void idleTickRecordsLivenessWhenStoreAnswers() {
+        try (MockedStatic<JellyNanopubLoader> loader = mockStatic(JellyNanopubLoader.class, CALLS_REAL_METHODS);
+             MockedStatic<StatusController> statusStatic = mockStatic(StatusController.class);
+             MockedStatic<TripleStore> storeStatic = mockStatic(TripleStore.class)) {
+
+            mockedStatusController(statusStatic);
+            loader.when(JellyNanopubLoader::fetchRegistryMetadata).thenReturn(caughtUpMetadata());
+
+            TripleStore store = mock(TripleStore.class);
+            storeStatic.when(TripleStore::get).thenReturn(store);
+            RepositoryConnection conn = mock(RepositoryConnection.class);
+            BooleanQuery ask = mock(BooleanQuery.class);
+            when(store.getAdminRepoConnection()).thenReturn(conn);
+            when(conn.prepareBooleanQuery(any(QueryLanguage.class), eq("ASK {}"))).thenReturn(ask);
+            when(ask.evaluate()).thenReturn(true);
+
+            resetLoaderState();
+            long before = System.currentTimeMillis();
+            JellyNanopubLoader.loadUpdates();
+
+            assertTrue(JellyNanopubLoader.lastSuccessfulBatchAtMs >= before,
+                    "a verified round trip must record liveness");
+            assertEquals(0, JellyNanopubLoader.consecutiveBatchFailures);
+            verify(conn, atLeastOnce()).close();
+        }
+    }
+
+    @Test
+    void idleProbeIsThrottledAcrossConsecutiveTicks() {
+        try (MockedStatic<JellyNanopubLoader> loader = mockStatic(JellyNanopubLoader.class, CALLS_REAL_METHODS);
+             MockedStatic<StatusController> statusStatic = mockStatic(StatusController.class);
+             MockedStatic<TripleStore> storeStatic = mockStatic(TripleStore.class)) {
+
+            mockedStatusController(statusStatic);
+            loader.when(JellyNanopubLoader::fetchRegistryMetadata).thenReturn(caughtUpMetadata());
+
+            TripleStore store = mock(TripleStore.class);
+            storeStatic.when(TripleStore::get).thenReturn(store);
+            RepositoryConnection conn = mock(RepositoryConnection.class);
+            BooleanQuery ask = mock(BooleanQuery.class);
+            when(store.getAdminRepoConnection()).thenReturn(conn);
+            when(conn.prepareBooleanQuery(any(QueryLanguage.class), eq("ASK {}"))).thenReturn(ask);
+            when(ask.evaluate()).thenReturn(true);
+
+            resetLoaderState();
+            // The idle path runs every UPDATES_POLL_INTERVAL ms; probing on each would be
+            // 30 needless round trips a minute. Only the first of a burst may probe.
+            JellyNanopubLoader.loadUpdates();
+            JellyNanopubLoader.loadUpdates();
+            JellyNanopubLoader.loadUpdates();
+
+            verify(store, times(1)).getAdminRepoConnection();
+        }
+    }
+}


### PR DESCRIPTION
## Why

`Nanopub-Query-Loader-Last-Success-Age-Seconds` and `registry.loader.last_successful_batch_age_seconds` exist so a stalled instance is distinguishable from a healthy one from outside. They could not do that job.

The idle "caught up, nothing to do" branch stamped `lastSuccessfulBatchAtMs` unconditionally — but that branch **never touches RDF4J**. It reads the counter from in-memory `StatusController` state, and its only network call goes to the *registry*. So a caught-up instance could never fail the check.

On kpxl 2026-08-05 this instance reported `READY` with **age 0 for eleven hours** while RDF4J was completely unreachable (Tomcat's acceptor thread had died of `OutOfMemoryError`, so every connect timed out) and every `/repo` and `/api` request returned 5xx. The signal added specifically to catch this — its own comment cites the 2026-07-31 stall — reported perfect health throughout.

## What

Probe the store on the idle path before recording liveness: `ASK {}` against the admin repo. It matches the empty group pattern without touching an index, so it costs one HTTP round trip and essentially no query work, while still exercising the real client, connection pool and endpoint a query would use. A failing probe throws into the existing catch, which trips the circuit breaker and leaves the timestamp to go stale — the intended signal.

Throttled to one probe per 30 s: the idle path runs every 2 s, and probing on each would be 30 needless round trips a minute for no extra signal, since any alert on this value is measured in minutes. A committed batch is a stronger reachability proof and defers the next probe.

## Behaviour change for consumers

On a healthy idle instance the reported age now cycles **0..30 s** instead of sitting at 0. **Alert thresholds must exceed 30 s** — noted in comments at both the header and the field. Nothing currently scrapes these metrics (the outstanding half of #148), so there is no live alert to adjust.

## Scope

Deliberately does *not* change what `READY` means. Gating the status itself would affect every consumer of the fleet-wide race and nanopub-monitor; the liveness header is the signal designed for this, and making it honest is the contained fix. Whether `READY` should also imply serveability is worth deciding separately.

## Tests

Three cases — unreachable store does not stamp liveness and does count as a failure; a verified round trip does stamp; the probe is throttled across consecutive ticks. **All three confirmed to fail without the fix** (verified by reverting the guard). Full suite: 345 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)