### PR TITLE
fix(spaces): stop acting on failed reads, and self-heal a half-built space state

### DIFF
--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -116,6 +116,30 @@ public final class AuthorityResolver {
     public long getLastIncrementalCycleDurationMs() { return lastIncrementalCycleDurationMs; }
     public long getLastProcessedUpToLag() { return lastProcessedUpToLag; }
 
+    /**
+     * Raised when the space-state bookkeeping in the {@code spaces} repo cannot be
+     * <em>read</em>, as opposed to being legitimately absent.
+     *
+     * <p>The distinction is the whole point. Before 2026-08-05 every reader here
+     * collapsed both cases onto the same value — {@code null} pointer, load counter
+     * {@code 0}, {@code processedUpTo} {@code -1} — so a degraded RDF4J looked
+     * identical to a fresh install. On that day RDF4J was answering reads with
+     * {@code Read timed out}; {@link #tick()} saw a {@code null} pointer, logged a
+     * "trust-state flip" that had not happened, and ran a full build whose every
+     * source read also failed. The build inserted nothing, published the resulting
+     * empty graph, and dropped the previous good one — 2730 triples of live space
+     * state, on a query server that then served zero rows to every state query for
+     * hours. A sibling instance that stayed healthy still had all of it.
+     *
+     * <p>Throwing instead lets the caller abort. Doing nothing this tick is always
+     * safe; acting on a failed read is not.
+     */
+    static class SpaceStateUnavailableException extends RuntimeException {
+        SpaceStateUnavailableException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
     // ---------------- Public entry points ----------------
 
     /**
@@ -135,12 +159,30 @@ public final class AuthorityResolver {
             logger.debug("AuthorityResolver.tick: no current trust state yet — skipping");
             return;
         }
+        // Any of the reads below may throw SpaceStateUnavailableException. Let it
+        // propagate: the caller logs "AuthorityResolver tick failed" and we retry on
+        // the next tick with the state untouched.
         IRI currentGraph = getCurrentSpaceStateGraph();
         String currentGraphName = (currentGraph == null) ? null
                 : currentGraph.stringValue().substring(SpacesVocab.NPASS_NAMESPACE.length());
-        if (currentGraphName == null || !currentGraphName.startsWith(trustStateHash + "_")) {
+        if (currentGraphName == null) {
+            logger.info("AuthorityResolver.tick: no current space-state graph; running full build");
+            runFullBuild(trustStateHash);
+            return;
+        }
+        if (!currentGraphName.startsWith(trustStateHash + "_")) {
             logger.info("AuthorityResolver.tick: trust-state flip detected (now {}); running full build",
                     abbrev(trustStateHash));
+            runFullBuild(trustStateHash);
+            return;
+        }
+        // A pointer at a graph that never got its processedUpTo stamp means the build
+        // that published it did not finish. runIncrementalCycle used to log "missing
+        // processedUpTo; skipping" and return — every 2 s, forever, with every
+        // state-backed query answering empty in the meantime. Rebuild instead.
+        if (readProcessedUpTo(currentGraph) < 0) {
+            logger.warn("AuthorityResolver.tick: current space-state graph {} has no processedUpTo "
+                    + "stamp (incomplete or damaged build); running full build", currentGraph);
             runFullBuild(trustStateHash);
             return;
         }
@@ -173,9 +215,20 @@ public final class AuthorityResolver {
      * {@code npa:hasCurrentSpaceState} pointer isn't pointing at. Orphans come
      * from crashes mid-build. Safe to call at any time; idempotent.
      */
-    public void cleanOrphans() {
+    public synchronized void cleanOrphans() {
         if (!FeatureFlags.spacesEnabled()) return;
-        IRI current = getCurrentSpaceStateGraph();
+        IRI current;
+        try {
+            current = getCurrentSpaceStateGraph();
+        } catch (SpaceStateUnavailableException ex) {
+            // Every npass:* graph is "not the current one" when the pointer cannot be
+            // read, so continuing here would drop the live state along with the
+            // orphans. Skipping costs nothing: orphans are inert, and the next start
+            // will clean them up.
+            logger.warn("AuthorityResolver.cleanOrphans: cannot read the current-state pointer, "
+                    + "skipping so orphan cleanup cannot delete the live graph: {}", ex.toString());
+            return;
+        }
         try (RepositoryConnection conn = TripleStore.get().getRepoConnection(SPACES_REPO)) {
             int dropped = 0;
             try (RepositoryResult<org.eclipse.rdf4j.model.Resource> ctxs = conn.getContextIDs()) {
@@ -216,9 +269,20 @@ public final class AuthorityResolver {
         long loadCounter = getCurrentLoadCounter();
         IRI newGraph = SpacesVocab.forSpaceState(trustStateHash, loadCounter);
         IRI oldGraph = getCurrentSpaceStateGraph();
-        if (newGraph.equals(oldGraph)) {
-            logger.debug("AuthorityResolver.runFullBuild: already current at {}", newGraph);
-            return;
+        boolean rebuildInPlace = newGraph.equals(oldGraph);
+        if (rebuildInPlace) {
+            // "Already current" is only true if that graph was actually finished.
+            // Without the processedUpTo check this early return was the second half
+            // of the 2026-08-05 trap: once a damaged graph was published, the pointer
+            // name still matched, so every subsequent full build returned here and
+            // the instance could never repair itself.
+            if (readProcessedUpTo(oldGraph) >= 0) {
+                logger.debug("AuthorityResolver.runFullBuild: already current at {}", newGraph);
+                return;
+            }
+            logger.warn("AuthorityResolver.runFullBuild: {} is the current graph but has no "
+                    + "processedUpTo stamp; rebuilding it in place", newGraph);
+            dropGraph(newGraph);
         }
 
         // 1. Mirror trust-approved rows into the new graph.
@@ -228,25 +292,44 @@ public final class AuthorityResolver {
         //    delta filter FILTER(?ln > ?lastProcessed) includes everything).
         TierInsertedTriples counts = runAllTierLoops(newGraph, -1);
 
+        // 2b. Refuse to publish an empty build over a state we already have.
+        //
+        // On 2026-08-05 every source read inside this method timed out, so mirrored
+        // and all twelve tier counts came back 0. The build then flipped the pointer
+        // to that empty graph and dropped the previous one, which held 2730 triples
+        // of live space state. Steps 4 and 5 are destructive and must not run on a
+        // result that carries no data.
+        //
+        // Only guarded when a previous state exists: a genuinely empty first build on
+        // a fresh instance has nothing to lose and must still be allowed to publish.
+        long insertedTotal = totalInserted(counts);
+        if (mirrored == 0 && insertedTotal == 0 && oldGraph != null) {
+            logger.error("AuthorityResolver.runFullBuild: build produced an empty state graph "
+                    + "(mirrored=0, inserted=0) while {} holds the current state — refusing to "
+                    + "flip the pointer or drop it. Almost always means the source reads failed; "
+                    + "the next tick will retry.", oldGraph);
+            if (!rebuildInPlace) {
+                dropGraph(newGraph);
+            }
+            return;
+        }
+
         // 3. Stamp processedUpTo inside the new graph.
         writeProcessedUpTo(newGraph, loadCounter);
 
         // 4. Flip the current-space-state pointer.
         flipPointer(newGraph);
 
-        // 5. Drop the old graph if one existed.
-        if (oldGraph != null) {
+        // 5. Drop the old graph if a *different* one existed. Dropping it when
+        //    rebuilding in place would delete what we just built.
+        if (oldGraph != null && !rebuildInPlace) {
             dropGraph(oldGraph);
         }
 
         TierSubjectTotals totals = computeTierSubjectTotals(newGraph);
         long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
         lastSubjectTotals = totals;
-        lastInsertedTriplesTotal = (long) counts.admin + counts.alias + counts.presetAttachment
-                + counts.presetAssignmentRef
-                + counts.attachment + counts.maintainer + counts.member + counts.observer
-                + counts.subSpace + counts.subSpacePrefix + counts.maintainedResource
-                + counts.governingSpaceRef;
+        lastInsertedTriplesTotal = insertedTotal;
         lastFullBuildDurationMs = durationMs;
         lastProcessedUpToLag = 0L;
         logger.info("AuthorityResolver: full build complete — graph={} mirrored={} rows loadCounter={} "
@@ -286,8 +369,11 @@ public final class AuthorityResolver {
         long currentLoadCounter = getCurrentLoadCounter();
         long lastProcessed = readProcessedUpTo(graph);
         if (lastProcessed < 0) {
-            logger.warn("AuthorityResolver.runIncrementalCycle: missing processedUpTo on {}; skipping",
-                    graph);
+            // tick() now catches this first and rebuilds, so reaching here means a
+            // direct caller. Still refuse to run a delta against a graph that was
+            // never finished — the deltas would be layered onto missing base rows.
+            logger.warn("AuthorityResolver.runIncrementalCycle: missing processedUpTo on {}; "
+                    + "skipping (a full build is needed to repair this graph)", graph);
             return;
         }
         lastProcessedUpToLag = currentLoadCounter - lastProcessed;
@@ -587,6 +673,18 @@ public final class AuthorityResolver {
      * {@link #computeTierSubjectTotals} for the distinct-subject totals
      * surfaced to operators.
      */
+    /**
+     * Total triples inserted across every tier. Used both for the metrics gauge and
+     * for the empty-build guard in {@link #runFullBuild}, so the two can never
+     * disagree about what "this build produced nothing" means.
+     */
+    static long totalInserted(TierInsertedTriples c) {
+        return (long) c.admin + c.alias + c.presetAttachment + c.presetAssignmentRef
+                + c.attachment + c.maintainer + c.member + c.observer
+                + c.subSpace + c.subSpacePrefix + c.maintainedResource
+                + c.governingSpaceRef;
+    }
+
     static final class TierInsertedTriples {
         int admin;
         int alias;
@@ -3184,8 +3282,7 @@ public final class AuthorityResolver {
                     SpacesVocab.HAS_CURRENT_SPACE_STATE);
             return (v instanceof IRI iri) ? iri : null;
         } catch (Exception ex) {
-            logger.warn("AuthorityResolver: failed to read hasCurrentSpaceState pointer: {}", ex.toString());
-            return null;
+            throw new SpaceStateUnavailableException("failed to read hasCurrentSpaceState pointer", ex);
         }
     }
 
@@ -3197,12 +3294,15 @@ public final class AuthorityResolver {
             try {
                 return Long.parseLong(v.stringValue());
             } catch (NumberFormatException ex) {
-                logger.warn("AuthorityResolver: non-numeric currentLoadCounter: {}", v);
-                return 0;
+                // Was "return 0", which would name the new graph <hash>_0 and make it
+                // differ from the real current graph — so the build proceeded and then
+                // dropped the good one. Corrupt bookkeeping must stop the build.
+                throw new SpaceStateUnavailableException("non-numeric currentLoadCounter: " + v, ex);
             }
+        } catch (SpaceStateUnavailableException ex) {
+            throw ex;
         } catch (Exception ex) {
-            logger.warn("AuthorityResolver: failed to read currentLoadCounter: {}", ex.toString());
-            return 0;
+            throw new SpaceStateUnavailableException("failed to read currentLoadCounter", ex);
         }
     }
 
@@ -3258,8 +3358,10 @@ public final class AuthorityResolver {
                 return Long.parseLong(b.getBinding("n").getValue().stringValue());
             }
         } catch (Exception ex) {
-            logger.warn("AuthorityResolver: failed to read processedUpTo for {}: {}", graph, ex.toString());
-            return -1;
+            // Must not collapse to -1: callers read -1 as "this graph was never
+            // finished" and rebuild from scratch. A timed-out read returning -1 would
+            // make a healthy state look damaged and trigger a destructive rebuild.
+            throw new SpaceStateUnavailableException("failed to read processedUpTo for " + graph, ex);
         }
     }
 

--- a/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
+++ b/src/main/java/com/knowledgepixels/query/AuthorityResolver.java
@@ -292,22 +292,36 @@ public final class AuthorityResolver {
         //    delta filter FILTER(?ln > ?lastProcessed) includes everything).
         TierInsertedTriples counts = runAllTierLoops(newGraph, -1);
 
-        // 2b. Refuse to publish an empty build over a state we already have.
+        // 2b. Refuse to publish an empty build over a state we already have — but only
+        // when the emptiness cannot be true.
         //
-        // On 2026-08-05 every source read inside this method timed out, so mirrored
-        // and all twelve tier counts came back 0. The build then flipped the pointer
-        // to that empty graph and dropped the previous one, which held 2730 triples
-        // of live space state. Steps 4 and 5 are destructive and must not run on a
-        // result that carries no data.
+        // Steps 4 and 5 below are destructive, so a build that read nothing must not
+        // reach them. The trap is that "produced nothing" has two causes: every source
+        // read failed, or the sources really are empty. Refusing in the second case
+        // would pin a stale space state forever, and stale trust data is
+        // over-permissive — revocations would stop propagating. That is the wrong way
+        // to fail for a trust-derived state.
+        //
+        // So the condition is: nothing was produced *while the trust state still has
+        // content to mirror*. That is the shape of a read failure. A genuinely empty
+        // trust state yields an empty build and is published normally.
         //
         // Only guarded when a previous state exists: a genuinely empty first build on
         // a fresh instance has nothing to lose and must still be allowed to publish.
+        //
+        // Note this would NOT have fired on 2026-08-05: that build reported
+        // subspace-prefix=2478, so it was not empty. The wipe there came from the
+        // registry's trust state collapsing (correctly reflected) plus 2478 triples
+        // that were reported inserted and then measured as zero. This guard is for the
+        // total-read-failure case, which the same outage came close to several times.
         long insertedTotal = totalInserted(counts);
-        if (mirrored == 0 && insertedTotal == 0 && oldGraph != null) {
+        if (mirrored == 0 && insertedTotal == 0 && oldGraph != null
+                && trustStateHasContent(trustStateHash)) {
             logger.error("AuthorityResolver.runFullBuild: build produced an empty state graph "
-                    + "(mirrored=0, inserted=0) while {} holds the current state — refusing to "
-                    + "flip the pointer or drop it. Almost always means the source reads failed; "
-                    + "the next tick will retry.", oldGraph);
+                    + "(mirrored=0, inserted=0) while trust state {} still has content and {} "
+                    + "holds the current state — refusing to flip the pointer or drop it. "
+                    + "This is the shape of a total read failure; the next tick will retry.",
+                    abbrev(trustStateHash), oldGraph);
             if (!rebuildInPlace) {
                 dropGraph(newGraph);
             }
@@ -3208,6 +3222,31 @@ public final class AuthorityResolver {
      *
      * @return number of rows mirrored (useful for metrics / logging)
      */
+    /**
+     * Whether the given trust state's graph holds anything at all.
+     *
+     * <p>Used by {@link #runFullBuild} to tell a build that read nothing because the store
+     * would not answer from a build that read nothing because there is nothing to read. Only
+     * the first is a reason to withhold the result; withholding the second would freeze a
+     * stale space state in place, and stale trust data is over-permissive.
+     *
+     * <p>Throws rather than guessing if the trust repo cannot be read — {@link #runFullBuild}
+     * then aborts without publishing or dropping anything, which is the safe direction.
+     *
+     * @param trustStateHash the trust state hash
+     * @return true if the trust state graph contains at least one triple
+     */
+    boolean trustStateHasContent(String trustStateHash) {
+        IRI trustStateIri = NPAT.forHash(trustStateHash);
+        try (RepositoryConnection conn = TripleStore.get().getRepoConnection(TRUST_REPO)) {
+            String query = String.format("ASK { GRAPH <%s> { ?s ?p ?o } }", trustStateIri);
+            return conn.prepareBooleanQuery(QueryLanguage.SPARQL, query).evaluate();
+        } catch (Exception ex) {
+            throw new SpaceStateUnavailableException(
+                    "failed to read trust state graph " + trustStateIri, ex);
+        }
+    }
+
     int mirrorTrustState(String trustStateHash, IRI newGraph) {
         IRI trustStateIri = NPAT.forHash(trustStateHash);
         int count = 0;

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverBuildGuardTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverBuildGuardTest.java
@@ -31,20 +31,27 @@ import static org.mockito.Mockito.when;
 /**
  * Guards on the destructive half of {@link AuthorityResolver#runFullBuild}.
  *
- * <p>Regression cover for the space-state wipe of 2026-08-05. RDF4J was answering
- * reads with {@code Read timed out}. Each reader collapsed that onto its
- * "legitimately absent" value, so:
- * <ol>
- *   <li>{@code getCurrentSpaceStateGraph()} returned {@code null}, and {@code tick()}
- *       logged a trust-state flip that had not happened;</li>
- *   <li>the resulting full build read nothing — {@code mirrored=0}, all twelve tier
- *       counts {@code 0};</li>
- *   <li>it published that empty graph anyway and dropped the previous one, which held
- *       2730 triples of live space state;</li>
- *   <li>{@code processedUpTo} was never stamped, so every later build hit the
- *       "already current" early return and the instance could not repair itself.</li>
- * </ol>
- * Every state-backed query returned zero rows until an operator intervened.
+ * <p>From the space-state incident of 2026-08-05, where RDF4J was answering reads with
+ * {@code Read timed out} and each reader collapsed that onto its "legitimately absent"
+ * value. What that demonstrably caused, and what these tests cover:
+ * <ul>
+ *   <li>{@code getCurrentLoadCounter()} returned {@code 0} from a failed read, so a graph
+ *       was built and dropped under the bogus name {@code …_0} — visible in the log as
+ *       {@code dropped old space-state graph …/c96bfc42…_0} while the counter was 2570;</li>
+ *   <li>{@code getCurrentSpaceStateGraph()} returned {@code null} from a failed read, so
+ *       {@code tick()} logged a trust-state flip that had not happened and rebuilt;</li>
+ *   <li>{@code processedUpTo} was never stamped, so {@code runIncrementalCycle} logged
+ *       "missing processedUpTo; skipping" every 2 s while {@code runFullBuild} returned
+ *       "already current" — 25 minutes of that, ended only by an operator deleting the
+ *       pointer by hand.</li>
+ * </ul>
+ *
+ * <p>Deliberately <em>not</em> claimed here: that this code emptied the space state. The
+ * shape it ended up with (sub-space rows only) was the correct reflection of a trust state
+ * that had collapsed in the <em>registry</em> — see nanopub-registry#60. The empty-build
+ * guard below would not have fired that day either, since that build inserted 2478
+ * sub-space-prefix triples. It is cover for the total-read-failure case, which the same
+ * outage came close to repeatedly.
  */
 class AuthorityResolverBuildGuardTest {
 
@@ -85,6 +92,7 @@ class AuthorityResolverBuildGuardTest {
         doReturn(mirrored).when(ar).mirrorTrustState(anyString(), any(IRI.class));
         doReturn(tierCounts).when(ar).runAllTierLoops(any(IRI.class), anyLong());
         doReturn(new TierSubjectTotals(0L, 0L, 0L)).when(ar).computeTierSubjectTotals(any(IRI.class));
+        doReturn(true).when(ar).trustStateHasContent(anyString());
         doNothing().when(ar).writeProcessedUpTo(any(IRI.class), anyLong());
         doNothing().when(ar).flipPointer(any(IRI.class));
         doNothing().when(ar).dropGraph(any(IRI.class));
@@ -92,9 +100,9 @@ class AuthorityResolverBuildGuardTest {
     }
 
     @Test
-    void emptyBuildIsNotPublishedOverAnExistingState() {
-        // Exactly the 2026-08-05 shape: every source read failed, so the build carries
-        // no rows, while a good graph is still current.
+    void emptyBuildIsNotPublishedWhenTheTrustStateStillHasContent() {
+        // Total read failure: nothing came back, yet the trust state still holds rows to
+        // mirror. The emptiness cannot be true, so it must not be published.
         AuthorityResolver ar = buildSpy(OLD_GRAPH, 0, counts(0));
 
         ar.runFullBuild(HASH);
@@ -103,6 +111,20 @@ class AuthorityResolverBuildGuardTest {
         verify(ar, never()).dropGraph(OLD_GRAPH);
         // The empty graph it just created is cleaned up instead.
         verify(ar).dropGraph(NEW_GRAPH);
+    }
+
+    @Test
+    void emptyBuildIsPublishedWhenTheTrustStateIsGenuinelyEmpty() {
+        // The other half of the guard. If the trust state really is empty, an empty space
+        // state is the correct answer and withholding it would pin stale trust data in
+        // place — over-permissive, and revocations would stop propagating.
+        AuthorityResolver ar = buildSpy(OLD_GRAPH, 0, counts(0));
+        doReturn(false).when(ar).trustStateHasContent(anyString());
+
+        ar.runFullBuild(HASH);
+
+        verify(ar).flipPointer(NEW_GRAPH);
+        verify(ar).dropGraph(OLD_GRAPH);
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverBuildGuardTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverBuildGuardTest.java
@@ -1,0 +1,230 @@
+package com.knowledgepixels.query;
+
+import com.knowledgepixels.query.AuthorityResolver.SpaceStateUnavailableException;
+import com.knowledgepixels.query.AuthorityResolver.TierInsertedTriples;
+import com.knowledgepixels.query.AuthorityResolver.TierSubjectTotals;
+import com.knowledgepixels.query.vocabulary.SpacesVocab;
+import org.eclipse.rdf4j.model.IRI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Guards on the destructive half of {@link AuthorityResolver#runFullBuild}.
+ *
+ * <p>Regression cover for the space-state wipe of 2026-08-05. RDF4J was answering
+ * reads with {@code Read timed out}. Each reader collapsed that onto its
+ * "legitimately absent" value, so:
+ * <ol>
+ *   <li>{@code getCurrentSpaceStateGraph()} returned {@code null}, and {@code tick()}
+ *       logged a trust-state flip that had not happened;</li>
+ *   <li>the resulting full build read nothing — {@code mirrored=0}, all twelve tier
+ *       counts {@code 0};</li>
+ *   <li>it published that empty graph anyway and dropped the previous one, which held
+ *       2730 triples of live space state;</li>
+ *   <li>{@code processedUpTo} was never stamped, so every later build hit the
+ *       "already current" early return and the instance could not repair itself.</li>
+ * </ol>
+ * Every state-backed query returned zero rows until an operator intervened.
+ */
+class AuthorityResolverBuildGuardTest {
+
+    private static final String HASH = "934e5df81a7cf333cc4ca1080fd4f2f6a6ba2eaa07d91c58ca4a7af0276d723a";
+    private static final long COUNTER = 2570L;
+
+    /** The graph a build for (HASH, COUNTER) targets. */
+    private static final IRI NEW_GRAPH = SpacesVocab.forSpaceState(HASH, COUNTER);
+    /** A previously published, healthy graph under a different trust hash. */
+    private static final IRI OLD_GRAPH = SpacesVocab.forSpaceState("c96bfc42db3bc5df584d992b57bc6932", COUNTER);
+
+    @BeforeEach
+    void resetSingletons() throws Exception {
+        reset(AuthorityResolver.class, "instance");
+        reset(TrustStateRegistry.class, "instance");
+    }
+
+    private static void reset(Class<?> cls, String fieldName) throws Exception {
+        Field f = cls.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(null, null);
+    }
+
+    private static TierInsertedTriples counts(int admin) {
+        TierInsertedTriples c = new TierInsertedTriples();
+        c.admin = admin;
+        return c;
+    }
+
+    /**
+     * Spy with every store-touching collaborator stubbed out, so the test exercises
+     * only runFullBuild's control flow.
+     */
+    private static AuthorityResolver buildSpy(IRI oldGraph, int mirrored, TierInsertedTriples tierCounts) {
+        AuthorityResolver ar = spy(AuthorityResolver.get());
+        doReturn(COUNTER).when(ar).getCurrentLoadCounter();
+        doReturn(oldGraph).when(ar).getCurrentSpaceStateGraph();
+        doReturn(mirrored).when(ar).mirrorTrustState(anyString(), any(IRI.class));
+        doReturn(tierCounts).when(ar).runAllTierLoops(any(IRI.class), anyLong());
+        doReturn(new TierSubjectTotals(0L, 0L, 0L)).when(ar).computeTierSubjectTotals(any(IRI.class));
+        doNothing().when(ar).writeProcessedUpTo(any(IRI.class), anyLong());
+        doNothing().when(ar).flipPointer(any(IRI.class));
+        doNothing().when(ar).dropGraph(any(IRI.class));
+        return ar;
+    }
+
+    @Test
+    void emptyBuildIsNotPublishedOverAnExistingState() {
+        // Exactly the 2026-08-05 shape: every source read failed, so the build carries
+        // no rows, while a good graph is still current.
+        AuthorityResolver ar = buildSpy(OLD_GRAPH, 0, counts(0));
+
+        ar.runFullBuild(HASH);
+
+        verify(ar, never()).flipPointer(any(IRI.class));
+        verify(ar, never()).dropGraph(OLD_GRAPH);
+        // The empty graph it just created is cleaned up instead.
+        verify(ar).dropGraph(NEW_GRAPH);
+    }
+
+    @Test
+    void emptyFirstBuildIsStillPublishedWhenThereIsNothingToLose() {
+        // No previous state: an empty result may legitimately be the truth, and
+        // refusing to publish would leave a fresh instance with no pointer at all.
+        AuthorityResolver ar = buildSpy(null, 0, counts(0));
+
+        ar.runFullBuild(HASH);
+
+        verify(ar).flipPointer(NEW_GRAPH);
+        verify(ar, never()).dropGraph(any(IRI.class));
+    }
+
+    @Test
+    void nonEmptyBuildIsPublishedAndReplacesTheOldGraph() {
+        AuthorityResolver ar = buildSpy(OLD_GRAPH, 768, counts(1839));
+
+        ar.runFullBuild(HASH);
+
+        verify(ar).writeProcessedUpTo(NEW_GRAPH, COUNTER);
+        verify(ar).flipPointer(NEW_GRAPH);
+        verify(ar).dropGraph(OLD_GRAPH);
+    }
+
+    @Test
+    void alreadyCurrentWithHealthyStampDoesNotRebuild() {
+        AuthorityResolver ar = buildSpy(NEW_GRAPH, 768, counts(1839));
+        doReturn(COUNTER).when(ar).readProcessedUpTo(NEW_GRAPH);
+
+        ar.runFullBuild(HASH);
+
+        verify(ar, never()).mirrorTrustState(anyString(), any(IRI.class));
+        verify(ar, never()).dropGraph(any(IRI.class));
+    }
+
+    @Test
+    void alreadyCurrentWithMissingStampRebuildsInPlaceAndKeepsWhatItBuilt() {
+        // The self-heal path. Pointer name matches, so the old code returned "already
+        // current" forever; the graph behind it was empty and unusable.
+        AuthorityResolver ar = buildSpy(NEW_GRAPH, 768, counts(1839));
+        doReturn(-1L).when(ar).readProcessedUpTo(NEW_GRAPH);
+
+        ar.runFullBuild(HASH);
+
+        verify(ar).mirrorTrustState(HASH, NEW_GRAPH);
+        verify(ar).flipPointer(NEW_GRAPH);
+        // Cleared once before rebuilding — and NOT again at step 5, which would
+        // delete the state we just built.
+        verify(ar, times(1)).dropGraph(NEW_GRAPH);
+    }
+
+    @Test
+    void pointerReadFailureThrowsRatherThanReportingNoPointer() {
+        try (MockedStatic<TripleStore> store = mockStatic(TripleStore.class)) {
+            TripleStore ts = mock(TripleStore.class);
+            store.when(TripleStore::get).thenReturn(ts);
+            when(ts.getRepoConnection(anyString()))
+                    .thenThrow(new RuntimeException("Read timed out"));
+
+            assertThrows(SpaceStateUnavailableException.class,
+                    () -> AuthorityResolver.get().getCurrentSpaceStateGraph(),
+                    "an unreadable pointer must not be reported as 'no pointer'");
+            assertThrows(SpaceStateUnavailableException.class,
+                    () -> AuthorityResolver.get().getCurrentLoadCounter(),
+                    "an unreadable load counter must not be reported as 0");
+            assertThrows(SpaceStateUnavailableException.class,
+                    () -> AuthorityResolver.get().readProcessedUpTo(NEW_GRAPH),
+                    "an unreadable processedUpTo must not be reported as -1");
+        }
+    }
+
+    @Test
+    void cleanOrphansBailsOutWhenThePointerCannotBeRead() {
+        // With a null pointer every npass:* graph looks like an orphan, so proceeding
+        // would clear the live one along with the leftovers.
+        AuthorityResolver ar = spy(AuthorityResolver.get());
+        doThrow(new SpaceStateUnavailableException("Read timed out", new RuntimeException()))
+                .when(ar).getCurrentSpaceStateGraph();
+
+        try (MockedStatic<TripleStore> store = mockStatic(TripleStore.class)) {
+            ar.cleanOrphans();
+            store.verify(TripleStore::get, never());
+        }
+    }
+
+    @Test
+    void tickRebuildsWhenTheCurrentGraphHasNoProcessedUpToStamp() {
+        AuthorityResolver ar = spy(AuthorityResolver.get());
+        doReturn(NEW_GRAPH).when(ar).getCurrentSpaceStateGraph();
+        doReturn(-1L).when(ar).readProcessedUpTo(NEW_GRAPH);
+        doNothing().when(ar).runFullBuild(anyString());
+
+        try (MockedStatic<TrustStateRegistry> reg = mockStatic(TrustStateRegistry.class)) {
+            TrustStateRegistry tsr = mock(TrustStateRegistry.class);
+            reg.when(TrustStateRegistry::get).thenReturn(tsr);
+            when(tsr.getCurrentHash()).thenReturn(Optional.of(HASH));
+
+            ar.tick();
+
+            verify(ar).runFullBuild(HASH);
+            verify(ar, never()).runIncrementalCycle(any(IRI.class));
+        }
+    }
+
+    @Test
+    void tickRunsTheIncrementalCycleWhenTheStateIsHealthy() {
+        AuthorityResolver ar = spy(AuthorityResolver.get());
+        doReturn(NEW_GRAPH).when(ar).getCurrentSpaceStateGraph();
+        doReturn(COUNTER).when(ar).readProcessedUpTo(NEW_GRAPH);
+        doNothing().when(ar).runIncrementalCycle(any(IRI.class));
+        doNothing().when(ar).runFullBuild(anyString());
+
+        try (MockedStatic<TrustStateRegistry> reg = mockStatic(TrustStateRegistry.class)) {
+            TrustStateRegistry tsr = mock(TrustStateRegistry.class);
+            reg.when(TrustStateRegistry::get).thenReturn(tsr);
+            when(tsr.getCurrentHash()).thenReturn(Optional.of(HASH));
+
+            ar.tick();
+
+            verify(ar).runIncrementalCycle(NEW_GRAPH);
+            verify(ar, never()).runFullBuild(eq(HASH));
+        }
+    }
+}


### PR DESCRIPTION
## What this fixes

Three things the 2026-08-05 outage demonstrably caused, all in `AuthorityResolver`, all from readers collapsing a failed read onto their "legitimately absent" value:

| reader | on read failure | means |
|---|---|---|
| `getCurrentSpaceStateGraph` | `null` | "no pointer" |
| `getCurrentLoadCounter` | `0` | "nothing loaded" |
| `readProcessedUpTo` | `-1` | "never finished" |

A degraded store was therefore indistinguishable from a fresh install:

```
05:40:30  failed to read hasCurrentSpaceState pointer: Read timed out
05:40:30  tick: trust-state flip detected (now c96bfc42…); running full build   ← no flip happened
05:59:50  dropped old space-state graph …/c96bfc42…_0     ← "_0" while the counter was 2570
06:00:44  runIncrementalCycle: missing processedUpTo …; skipping   ← every 2 s, for 25 min
```

The `…_0` graph name is unambiguous: `getCurrentLoadCounter()` returned `0` from a timed-out read, and a graph was built and dropped under a bogus name. And once `processedUpTo` was missing, `runIncrementalCycle` skipped forever while `runFullBuild` returned "already current" — the instance could not repair itself, and recovery took an operator deleting the pointer by hand.

## What this does *not* claim

**It did not empty the space state.** The shape it ended up with — sub-space rows only, no admin/maintainer/member/observer — was the correct reflection of a trust state that had collapsed in the **registry** (knowledgepixels/nanopub-registry#60, since fixed). Still unexplained separately: that build reported 2478 triples inserted and the graph later measured zero.

An earlier revision of this PR said otherwise. Corrected here, in the code comments and the test javadoc.

## Changes

1. **The three readers throw** `SpaceStateUnavailableException` on read failure, returning their absent-value only when the triple is genuinely absent. Both schedulers already wrap their ticks, so a failed read now means "do nothing this tick" rather than "act on a lie".
2. **`runFullBuild` withholds an empty build only when the emptiness cannot be true** — i.e. nothing was produced *while the trust state still has content to mirror*. That is the shape of a read failure. A genuinely empty trust state is published normally: withholding it would pin a stale space state in place, and stale trust data is over-permissive — revocations would stop propagating.
   **Note this would not have fired on 2026-08-05** (that build inserted 2478 sub-space-prefix triples). It is cover for the total-read-failure case, which the same outage came close to repeatedly.
3. **"Already current" requires `processedUpTo`**, so a half-built graph is rebuilt in place rather than declared current forever. Step 5 skips the drop in that case, since old and new are the same graph.
4. **`tick()` rebuilds** on a missing `processedUpTo` instead of leaving `runIncrementalCycle` to log "skipping" every 2 s while the service answers empty.
5. **`cleanOrphans` bails** when the pointer is unreadable (with a `null` pointer every `npass:*` graph looks like an orphan) and is now `synchronized`. It did not fire in this incident — zero log lines in four days — but it is the same trap.

## Tests

10 tests. Each guard was confirmed to fail without its fix, including both halves of the new empty-build condition: the "trust state still has content" case refuses, the "genuinely empty" case publishes. Full suite **352 green**.

## Deploying

Prevents recurrence; does not repair an instance already in the damaged state, since that predates the code. After deploy, an affected instance self-heals via changes 3/4 on the next tick.

Worth landing before the next query release, since the registry recovery makes every instance run a full space-state rebuild — which is exactly the operation these guards protect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)