### PR TITLE
fix(loader): keep the liveness and registry-count headers honest during a resync

### DIFF
--- a/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/JellyNanopubLoader.java
@@ -56,9 +56,9 @@ public class JellyNanopubLoader {
     static final long BREAKER_PAUSE_MS = 30_000L;
 
     /**
-     * Epoch-millis of the last {@code loadUpdates} invocation that demonstrably reached
-     * the triple store — either by committing a batch, or, on an idle tick, by passing
-     * {@link #probeStoreReachable()}. Read by {@link MetricsCollector} to expose
+     * Epoch-millis of the last time the loader demonstrably reached the triple store —
+     * by committing a load counter, by completing a batch, or, on an idle tick, by
+     * passing {@link #probeStoreReachable()}. Read by {@link MetricsCollector} to expose
      * {@code registry.loader.last_successful_batch_age_seconds} and served as the
      * {@code Nanopub-Query-Loader-Last-Success-Age-Seconds} header, so an operator can
      * tell from outside whether an instance is still able to serve.
@@ -71,8 +71,21 @@ public class JellyNanopubLoader {
      * thread had died of {@code OutOfMemoryError}, so every connect timed out), which is
      * precisely the failure this signal exists to surface. A caught-up instance could
      * never fail the check, which made the check worthless exactly when it mattered.
+     * Every stamp site below therefore follows a completed round trip: a committed
+     * counter and a completed batch are both stronger proof than the ASK probe.
      *
-     * <p>On a healthy idle instance the age now oscillates between 0 and
+     * <p><strong>The initial-load paths stamp it too.</strong> They did not until
+     * 2026-08-05, and because a resync runs entirely inside {@link #loadInitial} —
+     * {@code loadUpdates} does not run again until {@code performResync} returns, which
+     * for a full re-stream is tens of minutes — the age climbed unbounded for the whole
+     * of any legitimate resync. A healthy resync was indistinguishable from a wedged one
+     * both here and in Grafana (incident 2026-08-05, query.nanodash.net: a resync stalled
+     * with the load counter pinned at -1, and the climbing age looked exactly like the
+     * resync itself). Read this together with {@code Nanopub-Query-Status}: a climbing
+     * age under {@code LOADING_INITIAL} now means a resync that has stopped making
+     * progress, not merely a long one.
+     *
+     * <p>On a healthy idle instance the age oscillates between 0 and
      * {@link #STORE_PROBE_INTERVAL_MS}, rather than sitting at 0.
      */
     static volatile long lastSuccessfulBatchAtMs = 0L;
@@ -94,6 +107,25 @@ public class JellyNanopubLoader {
      * can reset it between cases.
      */
     static long lastStoreProbeAtMs = 0L;
+
+    /**
+     * Epoch-millis of the last {@link #updateForwardingMetadata} call, i.e. of the last
+     * time the registry-derived headers we forward to clients were refreshed. Used by
+     * {@link #maybeRefreshForwardingMetadata} to rate-limit mid-load refreshes.
+     */
+    private static volatile long lastForwardingMetadataAtMs = 0L;
+
+    /**
+     * Minimum interval between opportunistic refreshes of the forwarded registry
+     * metadata during a long-running load.
+     *
+     * <p>{@link #loadUpdates} refreshes on every poll (~{@value #UPDATES_POLL_INTERVAL} ms)
+     * so this limiter never engages there; it exists for {@link #loadInitial}, which
+     * used to fetch metadata exactly once and then stream for as long as the batch
+     * took. Thirty seconds is far below the resolution anyone reads these values at
+     * while costing one HEAD request per interval.
+     */
+    private static final long METADATA_REFRESH_INTERVAL_MS = 30_000L;
 
     /**
      * Heartbeat counter for loadUpdates invocations. A summary log line is emitted
@@ -157,6 +189,13 @@ public class JellyNanopubLoader {
         }
         lastCommittedCounter = afterCounter;
         while (lastCommittedCounter < targetCounter) {
+            // Keep the forwarded registry headers moving even across a batch that
+            // fails and retries without loading anything. Rate-limited, so the first
+            // iteration (right after the fetch above) is a no-op. Note this refreshes
+            // only what we forward to clients — targetCounter stays as sampled at
+            // entry, and anything the registry gained since is picked up by
+            // loadUpdates once this initial load returns.
+            maybeRefreshForwardingMetadata();
             // Same circuit-breaker logic as loadUpdates: after BREAKER_THRESHOLD
             // consecutive failed batches, pause before retrying so a saturated RDF4J
             // (e.g. during a restart storm) can drain instead of being hammered on the
@@ -174,6 +213,11 @@ public class JellyNanopubLoader {
             try {
                 loadBatch(lastCommittedCounter, LoadingType.INITIAL);
                 consecutiveBatchFailures = 0;
+                // A completed batch wrote to RDF4J, so it satisfies the "only stamp
+                // after the store answered" rule and, like an update batch, is a
+                // stronger reachability proof than the ASK probe.
+                lastSuccessfulBatchAtMs = System.currentTimeMillis();
+                lastStoreProbeAtMs = lastSuccessfulBatchAtMs;
                 logger.info("Initial load: loaded batch up to counter {}", lastCommittedCounter);
             } catch (Exception e) {
                 consecutiveBatchFailures++;
@@ -429,6 +473,11 @@ public class JellyNanopubLoader {
                     logger.info("Loading speed: {} np/s. Counter: {}", String.format("%.2f", speed), lastCommittedCounter);
                     checkpointTime.set(currTime);
                     checkpointCounter.set(lastCommittedCounter);
+                    // A full re-stream is a single loadBatch call lasting tens of
+                    // minutes; without this the forwarded registry count would hold
+                    // its entry-time value for the whole of it, and the sync-lag
+                    // gauge derived from it would drift with it.
+                    maybeRefreshForwardingMetadata();
                 }
             });
             // Make sure to save the last committed counter at the end of the batch
@@ -459,6 +508,13 @@ public class JellyNanopubLoader {
             } else {
                 StatusController.get().setLoadingUpdates(lastCommittedCounter);
             }
+            // A committed counter is an admin-repo write that RDF4J acknowledged, so it
+            // is the finest-grained evidence of liveness there is — and the only one
+            // that ticks inside a batch rather than at its end, which is what makes a
+            // long initial load legible. Stamped after the call, never before: a failed
+            // commit is exactly how the loader wedges, and must not read as progress.
+            lastSuccessfulBatchAtMs = System.currentTimeMillis();
+            lastStoreProbeAtMs = lastSuccessfulBatchAtMs;
         } catch (Exception e) {
             throw new RuntimeException("Could not update the nanopub counter in DB", e);
         }
@@ -481,6 +537,39 @@ public class JellyNanopubLoader {
         lastCoverageAgents = metadata.coverageAgents();
         lastTestInstance = metadata.testInstance();
         lastNanopubCount = metadata.nanopubCount();
+        lastForwardingMetadataAtMs = System.currentTimeMillis();
+    }
+
+    /**
+     * Re-read the registry's metadata headers mid-load so the values forwarded to
+     * clients don't freeze for the duration of a long batch.
+     *
+     * <p>Rate-limited to one fetch per {@link #METADATA_REFRESH_INTERVAL_MS} and
+     * best-effort: on failure the previous values stay in place and the caller
+     * continues. Deliberately calls {@link #fetchRegistryMetadataInner} rather than
+     * {@link #fetchRegistryMetadata} — the latter retries {@value #MAX_RETRIES_METADATA}
+     * times with {@value #RETRY_DELAY_METADATA} ms between attempts, which against an
+     * unhealthy registry would park the nanopub stream for half a minute to refresh a
+     * header. One attempt, bounded by the client's socket timeout, is the right trade
+     * for a value that is only ever advisory.
+     *
+     * <p>Refreshes only the forwarded fields. It must not touch the load counter the
+     * caller is driving its loop from: re-targeting mid-load would let a busy registry
+     * keep {@code loadInitial} running indefinitely instead of handing over to
+     * {@code loadUpdates}.
+     */
+    private static void maybeRefreshForwardingMetadata() {
+        if (System.currentTimeMillis() - lastForwardingMetadataAtMs < METADATA_REFRESH_INTERVAL_MS) {
+            return;
+        }
+        try {
+            updateForwardingMetadata(fetchRegistryMetadataInner());
+        } catch (Exception e) {
+            // Stamp anyway so a persistently failing registry is retried on the same
+            // interval rather than on every single call.
+            lastForwardingMetadataAtMs = System.currentTimeMillis();
+            logger.info("Mid-load registry metadata refresh failed; keeping previous values: {}", e.toString());
+        }
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/query/MainVerticle.java
+++ b/src/main/java/com/knowledgepixels/query/MainVerticle.java
@@ -719,6 +719,11 @@ public class MainVerticle extends AbstractVerticle {
         // JellyNanopubLoader#lastSuccessfulBatchAtMs), so on a caught-up instance it
         // cycles 0..JellyNanopubLoader.STORE_PROBE_INTERVAL_MS rather than sitting at 0.
         // Alert thresholds must therefore exceed that interval; minutes, not seconds.
+        //
+        // Initial loads and resyncs stamp it as well, so this reads as "seconds since
+        // the loader last moved" in every state rather than only while polling for
+        // updates. Interpret it alongside Nanopub-Query-Status: a climbing age under
+        // LOADING_INITIAL is a resync that has stopped progressing, not a long one.
         long lastBatchAt = JellyNanopubLoader.lastSuccessfulBatchAtMs;
         if (lastBatchAt != 0L) {
             long ageSeconds = Math.max(0L, (System.currentTimeMillis() - lastBatchAt) / 1000L);

--- a/src/main/java/com/knowledgepixels/query/MetricsCollector.java
+++ b/src/main/java/com/knowledgepixels/query/MetricsCollector.java
@@ -65,18 +65,19 @@ public final class MetricsCollector {
                         () -> JellyNanopubLoader.consecutiveBatchFailures >= JellyNanopubLoader.BREAKER_THRESHOLD ? 1.0 : 0.0)
                 .description("1 if the loader circuit breaker is tripped (consecutive failures >= threshold), 0 otherwise")
                 .register(meterRegistry);
-        // Liveness signal that works without log access: seconds since the last
-        // non-exceptional loadUpdates return. Counts both "loaded a batch" and
-        // "caught up, nothing to do" as progress. An instance whose value climbs
-        // unbounded while peers stay low is stuck on something the other
-        // gauges don't capture.
+        // Liveness signal that works without log access: seconds since the loader last
+        // demonstrably reached the triple store — a committed load counter, a completed
+        // batch (initial or update), or a verified idle-tick probe. An instance whose
+        // value climbs unbounded while peers stay low is stuck on something the other
+        // gauges don't capture, including during an initial load or resync, which this
+        // gauge could not distinguish from a stall until those paths were stamped too.
         Gauge.builder("registry.loader.last_successful_batch_age_seconds",
                         () -> {
                             long t = JellyNanopubLoader.lastSuccessfulBatchAtMs;
                             if (t == 0L) return 0.0;    // not started yet
                             return (System.currentTimeMillis() - t) / 1000.0;
                         })
-                .description("Seconds since the last non-exceptional loadUpdates return (idle or loading)")
+                .description("Seconds since the loader last reached the store (initial load, update batch, or idle probe)")
                 .register(meterRegistry);
         // How far behind its own registry this instance is. The gauges above all
         // describe the loader's *internal* health; this one is the outcome an
@@ -85,9 +86,10 @@ public final class MetricsCollector {
         // when every instance stalls at once (incident 2026-07-31).
         //
         // Pair it with last_successful_batch_age_seconds when alerting. The registry
-        // side of the subtraction is the count forwarded by the most recent poll, so
-        // if polling itself is what broke, both counts freeze together and the lag
-        // reads a falsely reassuring 0. Neither signal covers the other's blind spot.
+        // side of the subtraction is the count from the last metadata fetch — an update
+        // poll, or a mid-load refresh during a long initial load — so if fetching itself
+        // is what broke, both counts freeze together and the lag reads a falsely
+        // reassuring 0. Neither signal covers the other's blind spot.
         Gauge.builder("registry.loader.sync_lag_nanopubs", syncLagNanopubs, AtomicLong::get)
                 .description("Nanopubs this instance is behind its registry; -1 when either count is unknown")
                 .register(meterRegistry);

--- a/src/test/java/com/knowledgepixels/query/JellyNanopubLoaderLivenessTest.java
+++ b/src/test/java/com/knowledgepixels/query/JellyNanopubLoaderLivenessTest.java
@@ -8,12 +8,18 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -133,5 +139,62 @@ class JellyNanopubLoaderLivenessTest {
 
             verify(store, times(1)).getAdminRepoConnection();
         }
+    }
+
+    /**
+     * A counter committed during an <em>initial</em> load records liveness.
+     *
+     * <p>Second half of the same problem: a resync runs entirely inside
+     * {@code loadInitial}, and {@code loadUpdates} — the only thing that used to stamp
+     * the timestamp — does not run again until it returns. The age therefore climbed for
+     * the whole of any legitimate resync, so a healthy re-stream and a wedged one looked
+     * identical from outside (incident 2026-08-05, query.nanodash.net: a resync stalled
+     * with the load counter pinned at -1).
+     */
+    @Test
+    void initialLoadCommitRecordsLiveness() throws Exception {
+        try (MockedStatic<StatusController> statusStatic = mockStatic(StatusController.class)) {
+            StatusController status = mockedStatusController(statusStatic);
+
+            resetLoaderState();
+            long before = System.currentTimeMillis();
+
+            saveCommittedCounter(JellyNanopubLoader.LoadingType.INITIAL);
+
+            verify(status).setLoadingInitial(anyLong());
+            assertTrue(JellyNanopubLoader.lastSuccessfulBatchAtMs >= before,
+                    "a counter committed during an initial load must record liveness");
+            assertEquals(JellyNanopubLoader.lastSuccessfulBatchAtMs, JellyNanopubLoader.lastStoreProbeAtMs,
+                    "an acknowledged admin-repo write also defers the next ASK probe");
+        }
+    }
+
+    /**
+     * A commit that throws must not record liveness. Failing admin-repo writes are how
+     * the loader wedges in the first place, so stamping before the call would make the
+     * stall signal report health for the duration of the stall.
+     */
+    @Test
+    void failedCommitDoesNotRecordLiveness() {
+        try (MockedStatic<StatusController> statusStatic = mockStatic(StatusController.class)) {
+            StatusController status = mockedStatusController(statusStatic);
+            doThrow(new RepositoryException("Connect to rdf4j:8080 failed: Connect timed out"))
+                    .when(status).setLoadingUpdates(anyLong());
+
+            resetLoaderState();
+
+            assertThrows(InvocationTargetException.class,
+                    () -> saveCommittedCounter(JellyNanopubLoader.LoadingType.UPDATE));
+
+            assertEquals(0L, JellyNanopubLoader.lastSuccessfulBatchAtMs,
+                    "a failed commit must leave the liveness stamp untouched");
+        }
+    }
+
+    private static void saveCommittedCounter(JellyNanopubLoader.LoadingType type) throws Exception {
+        Method m = JellyNanopubLoader.class
+                .getDeclaredMethod("saveCommittedCounter", JellyNanopubLoader.LoadingType.class);
+        m.setAccessible(true);
+        m.invoke(null, type);
     }
 }

--- a/src/test/java/com/knowledgepixels/query/JellyNanopubLoaderTest.java
+++ b/src/test/java/com/knowledgepixels/query/JellyNanopubLoaderTest.java
@@ -5,6 +5,11 @@ import com.knowledgepixels.query.JellyNanopubLoader.RegistryMetadata;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 class JellyNanopubLoaderTest {
@@ -29,5 +34,75 @@ class JellyNanopubLoaderTest {
             JellyNanopubLoader.loadInitial(5L);
         }
     }*/
+
+    /**
+     * Every metadata fetch resets the refresh clock, so the ~2 s update poll never
+     * triggers an extra HEAD request of its own.
+     */
+    @Test
+    void updateForwardingMetadataStampsTheRefreshClock() throws Exception {
+        String savedCount = JellyNanopubLoader.lastNanopubCount;
+        String savedTypes = JellyNanopubLoader.lastCoverageTypes;
+        long savedMetadataAt = getLong("lastForwardingMetadataAtMs");
+        try {
+            setLong("lastForwardingMetadataAtMs", 0L);
+            long before = System.currentTimeMillis();
+
+            Method m = JellyNanopubLoader.class
+                    .getDeclaredMethod("updateForwardingMetadata", RegistryMetadata.class);
+            m.setAccessible(true);
+            m.invoke(null, new RegistryMetadata(7L, null, "all", "viaSetting", "false", "4242", null));
+
+            assertEquals("4242", JellyNanopubLoader.lastNanopubCount);
+            assertEquals("all", JellyNanopubLoader.lastCoverageTypes);
+            assertTrue(getLong("lastForwardingMetadataAtMs") >= before,
+                    "the refresh clock must be stamped on every metadata update");
+        } finally {
+            JellyNanopubLoader.lastNanopubCount = savedCount;
+            JellyNanopubLoader.lastCoverageTypes = savedTypes;
+            setLong("lastForwardingMetadataAtMs", savedMetadataAt);
+        }
+    }
+
+    /**
+     * The mid-load refresh is rate-limited. This matters on the streaming hot path: it
+     * is called from the per-50-nanopub progress block, so an unthrottled version would
+     * issue a HEAD request several times a second for the whole of a resync.
+     */
+    @Test
+    void midLoadRefreshIsSkippedWhileTheMetadataIsFresh() throws Exception {
+        String savedCount = JellyNanopubLoader.lastNanopubCount;
+        long savedMetadataAt = getLong("lastForwardingMetadataAtMs");
+        try {
+            long freshStamp = System.currentTimeMillis();
+            setLong("lastForwardingMetadataAtMs", freshStamp);
+            JellyNanopubLoader.lastNanopubCount = "sentinel";
+
+            Method m = JellyNanopubLoader.class.getDeclaredMethod("maybeRefreshForwardingMetadata");
+            m.setAccessible(true);
+            m.invoke(null);
+
+            // Exact-match, not merely "the count is unchanged": a refresh that actually
+            // ran would re-stamp the clock even when the fetch itself failed.
+            assertEquals(freshStamp, getLong("lastForwardingMetadataAtMs"),
+                    "a fresh timestamp must short-circuit the refresh before any request");
+            assertEquals("sentinel", JellyNanopubLoader.lastNanopubCount);
+        } finally {
+            JellyNanopubLoader.lastNanopubCount = savedCount;
+            setLong("lastForwardingMetadataAtMs", savedMetadataAt);
+        }
+    }
+
+    private static long getLong(String fieldName) throws Exception {
+        Field f = JellyNanopubLoader.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        return f.getLong(null);
+    }
+
+    private static void setLong(String fieldName, long value) throws Exception {
+        Field f = JellyNanopubLoader.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.setLong(null, value);
+    }
 
 }


### PR DESCRIPTION
## The problem

`Nanopub-Query-Loader-Last-Success-Age-Seconds` and `Nanopub-Query-Registry-Nanopub-Count` were both only maintained on the `loadUpdates` path. A resync runs entirely inside `loadInitial`, and `loadUpdates` does not run again until `performResync` returns — tens of minutes for a full re-stream. So for the whole of any legitimate resync both values froze, which is precisely when an operator needs them.

Found while diagnosing query.nanodash.net on 2026-08-05. The registry there had been resynced from scratch behind a new setting nanopub; the query detected the reset correctly, entered `LOADING_INITIAL`, and then stopped — `Nanopub-Query-Load-Counter` pinned at `-1` for 45+ minutes with nothing written, while the store already held all 86678 nanopubs and every shard had the counter-0 nanopub stamped, so the re-stream should have no-opped through in minutes.

What made that hard to see is that the two headers looked exactly the same as they would during a *healthy* resync:

```
Nanopub-Query-Status: LOADING_INITIAL
Nanopub-Query-Load-Counter: -1              <- never moved
Nanopub-Query-Registry-Nanopub-Count: 75694 <- frozen at loadInitial entry; registry was at 86678
Nanopub-Query-Loader-Last-Success-Age-Seconds: 2423  <- climbs during any resync, healthy or not
```

The same ambiguity reached Grafana through `registry.loader.last_successful_batch_age_seconds`, and off-host monitors had no signal that separated the two cases.

## Liveness

Stamped wherever the loader demonstrably reached the store:

- **every committed load counter** (`saveCommittedCounter`) — the only site that ticks *inside* a batch rather than at its end, which is what makes a long initial load legible;
- **after a completed initial-load batch**, mirroring what the update path already did.

Both are acknowledged RDF4J writes, so they satisfy the invariant #158 added — the timestamp only advances after the store has answered — and both defer the next ASK probe, exactly as an update batch already does. The stamp follows the commit rather than preceding it: a failing admin-repo write is how the loader wedges, and must never read as progress. There's a test pinning that.

Net effect on the incident above: the age would have kept climbing (a true stall) while the registry count stayed live, instead of both freezing into something indistinguishable from health.

## Registry count

Refreshed opportunistically from the `loadInitial` retry loop and the per-50-nanopub progress block in `loadBatch`, rate-limited to one HEAD per 30 s off a clock that `updateForwardingMetadata` stamps — so the 2 s update poll never triggers an extra request and the limiter only engages during a long initial load.

Two deliberate constraints, both in the javadoc:

- it calls the **single-attempt** `fetchRegistryMetadataInner`, not `fetchRegistryMetadata` (10 retries x 3 s), so a sick registry cannot park the nanopub stream for half a minute to refresh an advisory header;
- it touches **only the forwarded fields**, never `targetCounter` — re-targeting mid-load would let a busy registry keep `loadInitial` running instead of handing over to `loadUpdates`.

This also repairs `registry.loader.sync_lag_nanopubs`, which divides by that count and was drifting with it.

## Tests

Full suite green: 359 tests, 0 failures. Javadoc clean (the one remaining error is the pre-existing `FeatureFlags.java:20` Mockito reference).

- `JellyNanopubLoaderLivenessTest`: an initial-load commit records liveness and defers the probe; a failing commit does not.
- `JellyNanopubLoaderTest`: the refresh clock is stamped on every metadata update; the mid-load refresh short-circuits while fresh.

Worth knowing if you extend these: `MockedStatic.when(...)` under `CALLS_REAL_METHODS` executes the real method once while recording the stub. A first attempt that stubbed `loadBatch` that way streamed live nanopubs from the configured registry into a null triple store for 15 s. The new tests drive the private statics through reflection with `StatusController` and `TripleStore` mocked out instead. The pre-existing `loadInitialWithAfterGreater` has the same latent issue on `fetchRegistryMetadata`; left alone here.

## What this does not do

It does not unstick query.nanodash.net — that instance is still `LOADING_INITIAL` / counter `-1`. This change makes a stall like it legible from outside; diagnosing the wedge itself still needs the container logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)