### PR TITLE
perf(loader): serialise repo writes with a lock instead of SERIALIZABLE

### DIFF
--- a/src/main/java/com/knowledgepixels/query/NanopubLoader.java
+++ b/src/main/java/com/knowledgepixels/query/NanopubLoader.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.security.GeneralSecurityException;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 /**
@@ -44,6 +45,42 @@ public class NanopubLoader {
 
     private static HttpClient httpClient;
     private static final ThreadPoolExecutor loadingPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(4);
+
+    /**
+     * One write lock per repo, held for the whole read-modify-write of that repo's
+     * nanopub count / XOR checksum chain.
+     *
+     * <p>This replaces {@code IsolationLevels.SERIALIZABLE} as the mechanism protecting the
+     * chain, and it is a strictly local substitution: this process is the only writer of
+     * those triples, so in-process mutual exclusion gives exactly what the serializable
+     * transaction was buying. The chain invariant is unchanged.
+     *
+     * <p>Why bother: in RDF4J 5.3.x, {@code SailSourceBranch.derivedFromSerializable} sets a
+     * branch-level {@code serializable} sink the first time <em>any</em> transaction on that
+     * branch asks for a SERIALIZABLE-compatible level, and clears it only when the branch
+     * closes. While it is set, every dataset opened on that branch — including ordinary read
+     * queries at any isolation — is wrapped in an {@code ObservingSailDataset}, which on close
+     * runs {@code compressChanges -> prepare -> sinkObserved -> Changeset.observeAll} while
+     * holding the branch semaphore. Hashing observed {@code SimpleStatementPattern}s there is
+     * expensive ({@code LmdbIRI.hashCode} goes to a synchronized {@code ValueStore} map), so
+     * one writer can stall every reader of the repo.
+     *
+     * <p>Measured on kpxl 2026-08-05: a thread dump showed 171 threads parked on a single
+     * {@code ReentrantLock} in {@code derivedFromSerializable} for the {@code full} repo, one
+     * thread inside {@code observeAll}, and the whole servlet container unable to answer even
+     * a 404 for a nonexistent repo. Dropping to SNAPSHOT leaves {@code serializable} null, so
+     * no {@code ObservingSailDataset} is created, {@code observed} stays null and
+     * {@code sinkObserved} early-returns.
+     *
+     * <p>Keyed by repo name, so writers to different repos never contend. Calls are never
+     * nested across repos — the invalidator paths loop and call one repo at a time — so there
+     * is no lock-ordering hazard.
+     */
+    private static final ConcurrentHashMap<String, ReentrantLock> repoWriteLocks = new ConcurrentHashMap<>();
+
+    static ReentrantLock repoWriteLock(String repoName) {
+        return repoWriteLocks.computeIfAbsent(repoName, k -> new ReentrantLock());
+    }
 
     /**
      * Cached count of nanopubs ever loaded into the {@code meta} repo. Maintained
@@ -578,53 +615,62 @@ public class NanopubLoader {
         boolean success = false;
         int retries = 0;
         while (!success) {
-            RepositoryConnection conn = TripleStore.get().getRepoConnection(repoName);
-            long newCountForCache = -1;
-            String newChecksumForCache = null;
-            try (conn) {
-                // Serializable, because write skew would cause the chain of hashes to be broken.
-                // The inserts must be done serially.
-                conn.begin(IsolationLevels.SERIALIZABLE);
-                var repoStatus = fetchRepoStatus(conn, npId);
-                if (repoStatus.isLoaded) {
-                    // INFO, not DEBUG: this skip decides that a shard write is unnecessary
-                    // based on a single store read. When the backend misbehaves (issue #139:
-                    // a shard "successfully" written yet not durable), this line is the only
-                    // trace distinguishing a false skip from a lost commit.
-                    logger.info("Skipping already-loaded nanopub <{}> in repo '{}'", npId, repoName);
-                } else {
-                    String newChecksum = NanopubUtils.updateXorChecksum(npId, repoStatus.checksum);
-                    conn.remove(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, null, NPA.GRAPH);
-                    conn.remove(NPA.THIS_REPO, NPA.HAS_NANOPUB_CHECKSUM, null, NPA.GRAPH);
-                    conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, vf.createLiteral(repoStatus.count + 1), NPA.GRAPH);
-                    // @ADMIN-TRIPLE-TABLE@ REPO, npa:hasNanopubCount, NANOPUB_COUNT, npa:graph, admin, number of nanopubs loaded
-                    conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_CHECKSUM, vf.createLiteral(newChecksum), NPA.GRAPH);
-                    // @ADMIN-TRIPLE-TABLE@ REPO, npa:hasNanopubChecksum, NANOPUB_CHECKSUM, npa:graph, admin, checksum of all loaded nanopubs (order-independent XOR checksum on trusty URIs in Base64 notation)
-                    conn.add(npId, NPA.HAS_LOAD_NUMBER, vf.createLiteral(repoStatus.count), NPA.GRAPH);
-                    // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadNumber, LOAD_NUMBER, npa:graph, admin, the sequential number at which this NANOPUB was loaded
-                    conn.add(npId, NPA.HAS_LOAD_CHECKSUM, vf.createLiteral(newChecksum), NPA.GRAPH);
-                    // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadChecksum, LOAD_CHECKSUM, npa:graph, admin, the checksum of all loaded nanopubs after loading the given NANOPUB
-                    conn.add(npId, NPA.HAS_LOAD_TIMESTAMP, vf.createLiteral(new Date()), NPA.GRAPH);
-                    // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadTimestamp, LOAD_TIMESTAMP, npa:graph, admin, the time point at which this NANOPUB was loaded
-                    conn.add(statements);
-                    if ("meta".equals(repoName)) {
-                        newCountForCache = repoStatus.count + 1;
-                        newChecksumForCache = newChecksum;
+            // The count/checksum chain must not suffer write skew, so this read-modify-write
+            // is serialised — by repoWriteLock rather than by a SERIALIZABLE transaction. This
+            // process is the only writer of those triples, so the guarantee is the same; see
+            // repoWriteLocks for why the isolation level is the expensive way to buy it.
+            // Held across the whole transaction, released before any retry back-off.
+            ReentrantLock repoLock = repoWriteLock(repoName);
+            repoLock.lock();
+            try {
+                RepositoryConnection conn = TripleStore.get().getRepoConnection(repoName);
+                long newCountForCache = -1;
+                String newChecksumForCache = null;
+                try (conn) {
+                    conn.begin(IsolationLevels.SNAPSHOT);
+                    var repoStatus = fetchRepoStatus(conn, npId);
+                    if (repoStatus.isLoaded) {
+                        // INFO, not DEBUG: this skip decides that a shard write is unnecessary
+                        // based on a single store read. When the backend misbehaves (issue #139:
+                        // a shard "successfully" written yet not durable), this line is the only
+                        // trace distinguishing a false skip from a lost commit.
+                        logger.info("Skipping already-loaded nanopub <{}> in repo '{}'", npId, repoName);
+                    } else {
+                        String newChecksum = NanopubUtils.updateXorChecksum(npId, repoStatus.checksum);
+                        conn.remove(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, null, NPA.GRAPH);
+                        conn.remove(NPA.THIS_REPO, NPA.HAS_NANOPUB_CHECKSUM, null, NPA.GRAPH);
+                        conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_COUNT, vf.createLiteral(repoStatus.count + 1), NPA.GRAPH);
+                        // @ADMIN-TRIPLE-TABLE@ REPO, npa:hasNanopubCount, NANOPUB_COUNT, npa:graph, admin, number of nanopubs loaded
+                        conn.add(NPA.THIS_REPO, NPA.HAS_NANOPUB_CHECKSUM, vf.createLiteral(newChecksum), NPA.GRAPH);
+                        // @ADMIN-TRIPLE-TABLE@ REPO, npa:hasNanopubChecksum, NANOPUB_CHECKSUM, npa:graph, admin, checksum of all loaded nanopubs (order-independent XOR checksum on trusty URIs in Base64 notation)
+                        conn.add(npId, NPA.HAS_LOAD_NUMBER, vf.createLiteral(repoStatus.count), NPA.GRAPH);
+                        // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadNumber, LOAD_NUMBER, npa:graph, admin, the sequential number at which this NANOPUB was loaded
+                        conn.add(npId, NPA.HAS_LOAD_CHECKSUM, vf.createLiteral(newChecksum), NPA.GRAPH);
+                        // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadChecksum, LOAD_CHECKSUM, npa:graph, admin, the checksum of all loaded nanopubs after loading the given NANOPUB
+                        conn.add(npId, NPA.HAS_LOAD_TIMESTAMP, vf.createLiteral(new Date()), NPA.GRAPH);
+                        // @ADMIN-TRIPLE-TABLE@ NANOPUB, npa:hasLoadTimestamp, LOAD_TIMESTAMP, npa:graph, admin, the time point at which this NANOPUB was loaded
+                        conn.add(statements);
+                        if ("meta".equals(repoName)) {
+                            newCountForCache = repoStatus.count + 1;
+                            newChecksumForCache = newChecksum;
+                        }
+                    }
+                    conn.commit();
+                    if (newCountForCache >= 0) {
+                        loadedNanopubCount = newCountForCache;
+                    }
+                    if (newChecksumForCache != null) {
+                        loadedNanopubChecksum = newChecksumForCache;
+                    }
+                    success = true;
+                } catch (Exception ex) {
+                    logger.warn("Failed to load nanopub <{}> to repo '{}': {}", npId, repoName, ex.getMessage(), ex);
+                    if (conn.isActive()) {
+                        conn.rollback();
                     }
                 }
-                conn.commit();
-                if (newCountForCache >= 0) {
-                    loadedNanopubCount = newCountForCache;
-                }
-                if (newChecksumForCache != null) {
-                    loadedNanopubChecksum = newChecksumForCache;
-                }
-                success = true;
-            } catch (Exception ex) {
-                logger.warn("Failed to load nanopub <{}> to repo '{}': {}", npId, repoName, ex.getMessage(), ex);
-                if (conn.isActive()) {
-                    conn.rollback();
-                }
+            } finally {
+                repoLock.unlock();
             }
             if (!success) {
                 retries++;
@@ -662,34 +708,46 @@ public class NanopubLoader {
         boolean success = false;
         int retries = 0;
         while (!success) {
-            RepositoryConnection conn = TripleStore.get().getRepoConnection("spaces");
-            try (conn) {
-                conn.begin(IsolationLevels.SERIALIZABLE);
-                // Idempotency: skip if this nanopub is already stamped in this repo.
-                if (Utils.getObjectForPattern(conn, NPA.GRAPH, npId, NPA.HAS_LOAD_NUMBER) != null) {
-                    // INFO for the same reason as the loadNanopubToRepo skip (issue #139).
-                    logger.info("Skipping already-loaded nanopub <{}> in spaces repo", npId);
+            // Same substitution as loadNanopubToRepo: the spaces load counter is a
+            // read-modify-write, serialised by repoWriteLock instead of by the isolation
+            // level. NOTE: the spaces branch is also written by AuthorityResolver, which
+            // still uses SERIALIZABLE — so the ObservingSailDataset cost described on
+            // repoWriteLocks is not yet gone for this repo. Changing that is a separate
+            // step; this keeps the two loader paths consistent in the meantime.
+            ReentrantLock repoLock = repoWriteLock("spaces");
+            repoLock.lock();
+            try {
+                RepositoryConnection conn = TripleStore.get().getRepoConnection("spaces");
+                try (conn) {
+                    conn.begin(IsolationLevels.SNAPSHOT);
+                    // Idempotency: skip if this nanopub is already stamped in this repo.
+                    if (Utils.getObjectForPattern(conn, NPA.GRAPH, npId, NPA.HAS_LOAD_NUMBER) != null) {
+                        // INFO for the same reason as the loadNanopubToRepo skip (issue #139).
+                        logger.info("Skipping already-loaded nanopub <{}> in spaces repo", npId);
+                        conn.commit();
+                        success = true;
+                        continue;
+                    }
+                    long newCounter = fetchSpacesLoadCounter(conn) + 1;
+                    conn.remove(NPA.THIS_REPO,
+                            com.knowledgepixels.query.vocabulary.SpacesVocab.CURRENT_LOAD_COUNTER,
+                            null, NPA.GRAPH);
+                    conn.add(NPA.THIS_REPO,
+                            com.knowledgepixels.query.vocabulary.SpacesVocab.CURRENT_LOAD_COUNTER,
+                            vf.createLiteral(newCounter), NPA.GRAPH);
+                    conn.add(npId, NPA.HAS_LOAD_NUMBER, vf.createLiteral(newCounter), NPA.GRAPH);
+                    conn.add(nanopubTriples);
+                    conn.add(spaceExtraction);
                     conn.commit();
                     success = true;
-                    continue;
+                } catch (Exception ex) {
+                    logger.warn("Failed to load nanopub <{}> to spaces repo: {}", npId, ex.getMessage(), ex);
+                    if (conn.isActive()) {
+                        conn.rollback();
+                    }
                 }
-                long newCounter = fetchSpacesLoadCounter(conn) + 1;
-                conn.remove(NPA.THIS_REPO,
-                        com.knowledgepixels.query.vocabulary.SpacesVocab.CURRENT_LOAD_COUNTER,
-                        null, NPA.GRAPH);
-                conn.add(NPA.THIS_REPO,
-                        com.knowledgepixels.query.vocabulary.SpacesVocab.CURRENT_LOAD_COUNTER,
-                        vf.createLiteral(newCounter), NPA.GRAPH);
-                conn.add(npId, NPA.HAS_LOAD_NUMBER, vf.createLiteral(newCounter), NPA.GRAPH);
-                conn.add(nanopubTriples);
-                conn.add(spaceExtraction);
-                conn.commit();
-                success = true;
-            } catch (Exception ex) {
-                logger.warn("Failed to load nanopub <{}> to spaces repo: {}", npId, ex.getMessage(), ex);
-                if (conn.isActive()) {
-                    conn.rollback();
-                }
+            } finally {
+                repoLock.unlock();
             }
             if (!success) {
                 retries++;

--- a/src/test/java/com/knowledgepixels/query/NanopubLoaderRepoWriteLockTest.java
+++ b/src/test/java/com/knowledgepixels/query/NanopubLoaderRepoWriteLockTest.java
@@ -1,0 +1,184 @@
+package com.knowledgepixels.query;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.jupiter.api.Test;
+import org.nanopub.NanopubUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The guarantee {@code repoWriteLock} has to provide, now that
+ * {@code loadNanopubToRepo} no longer buys it with {@code IsolationLevels.SERIALIZABLE}.
+ *
+ * <p>The protected invariant is the one the replaced comment named: the per-repo nanopub
+ * count and order-independent XOR checksum are a read-modify-write, and concurrent writers
+ * must not interleave. Two writers both reading {@code count=N} and both writing
+ * {@code N+1} lose an increment, and the last checksum write drops the other's contribution
+ * — leaving the repo's bookkeeping understating what it holds. That bookkeeping is also the
+ * instrument used to detect backend-side loss (issue #139), so corrupting it would blind the
+ * detector as well as the data.
+ *
+ * <p>Scope, stated plainly: these tests exercise the locking mechanism and the arithmetic it
+ * protects, not {@code loadNanopubToRepo} end to end. That method drives a live RDF4J
+ * connection, and this project's unit tests cannot — see the note in
+ * {@code AuthorityResolverTest} about the sail-base / sail-memory version mix breaking
+ * SPARQL UPDATE in tests. The lost-update control below is what gives the passing case its
+ * meaning.
+ */
+class NanopubLoaderRepoWriteLockTest {
+
+    private static final SimpleValueFactory VF = SimpleValueFactory.getInstance();
+    private static final int THREADS = 8;
+    private static final int WRITES_PER_THREAD = 25;
+
+    private static final String TRUSTY_BASE = "http://purl.org/np/RA";
+    private static final String B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+    /**
+     * A distinct, well-formed trusty artifact code per (thread, i). {@code updateXorChecksum}
+     * decodes the code, so it has to be real base64url of the right length — the values
+     * themselves are arbitrary as long as they are unique.
+     */
+    private static String trustyCode(int thread, int i) {
+        // Unique by construction: the index is encoded base64url across the leading chars.
+        // Collisions would XOR-cancel and quietly weaken the checksum assertion.
+        int seed = thread * WRITES_PER_THREAD + i;
+        StringBuilder sb = new StringBuilder("A".repeat(43));
+        for (int c = 0; c < 6; c++) {
+            sb.setCharAt(c, B64.charAt((seed >> (6 * c)) & 63));
+        }
+        return sb.toString();
+    }
+
+    /** Stand-in for a repo's {@code npa:hasNanopubCount} / {@code npa:hasNanopubChecksum} pair. */
+    private static final class RepoStatus {
+        long count;
+        String checksum = NanopubUtils.INIT_CHECKSUM;
+    }
+
+    @Test
+    void sameRepoSharesOneLockAndDifferentReposDoNot() {
+        assertSame(NanopubLoader.repoWriteLock("full"), NanopubLoader.repoWriteLock("full"));
+        assertNotSame(NanopubLoader.repoWriteLock("full"), NanopubLoader.repoWriteLock("meta"),
+                "writers to different repos must not contend");
+    }
+
+    @Test
+    void lockIsReentrantSoNestedCallsOnOneThreadCannotSelfDeadlock() {
+        ReentrantLock lock = NanopubLoader.repoWriteLock("reentrancy-check");
+        lock.lock();
+        try {
+            assertTrue(lock.tryLock(), "a second acquisition on the same thread must succeed");
+            lock.unlock();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * The real assertion: under the lock, concurrent writers to one repo produce exactly the
+     * count and checksum of a serial run.
+     */
+    @Test
+    void concurrentWritersUnderTheLockKeepTheCountAndChecksumChainIntact() throws Exception {
+        RepoStatus status = runConcurrentWrites(true);
+
+        assertEquals(THREADS * WRITES_PER_THREAD, status.count,
+                "every write must be counted exactly once");
+        assertEquals(expectedChecksum(), status.checksum,
+                "the checksum must equal the XOR of every loaded nanopub");
+    }
+
+    /**
+     * Control. Without the lock the same workload loses updates — which is what makes the
+     * test above evidence rather than a restatement.
+     */
+    @Test
+    void withoutTheLockTheChainIsCorrupted() throws Exception {
+        // Interleaving is not guaranteed on any single run, so retry rather than risk a
+        // flaky control. In practice the first attempt corrupts every time.
+        boolean corrupted = false;
+        for (int attempt = 0; attempt < 20 && !corrupted; attempt++) {
+            RepoStatus status = runConcurrentWrites(false);
+            corrupted = status.count != (long) THREADS * WRITES_PER_THREAD
+                    || !expectedChecksum().equals(status.checksum);
+        }
+        assertTrue(corrupted,
+                "expected lost updates without mutual exclusion; if this never corrupts, the "
+                        + "workload is no longer contended and the sibling test proves nothing");
+    }
+
+    /** XOR is order-independent, so a correct run has one expected checksum regardless of order. */
+    private static String expectedChecksum() {
+        String checksum = NanopubUtils.INIT_CHECKSUM;
+        for (IRI np : allNanopubs()) {
+            checksum = NanopubUtils.updateXorChecksum(np, checksum);
+        }
+        return checksum;
+    }
+
+    private static List<IRI> allNanopubs() {
+        List<IRI> l = new ArrayList<>();
+        for (int t = 0; t < THREADS; t++) {
+            for (int i = 0; i < WRITES_PER_THREAD; i++) {
+                l.add(VF.createIRI(TRUSTY_BASE + trustyCode(t, i)));
+            }
+        }
+        return l;
+    }
+
+    private static RepoStatus runConcurrentWrites(boolean useLock) throws Exception {
+        RepoStatus status = new RepoStatus();
+        ReentrantLock lock = new ReentrantLock();
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<java.util.concurrent.Future<?>> futures = new ArrayList<>();
+            for (int t = 0; t < THREADS; t++) {
+                final int thread = t;
+                futures.add(pool.submit(() -> {
+                    start.await();
+                    for (int i = 0; i < WRITES_PER_THREAD; i++) {
+                        IRI np = VF.createIRI(TRUSTY_BASE + trustyCode(thread, i));
+                        if (useLock) {
+                            lock.lock();
+                        }
+                        try {
+                            // Exactly the shape of loadNanopubToRepo's transaction body:
+                            // read the current pair, derive the next one, write both back.
+                            long count = status.count;
+                            String checksum = status.checksum;
+                            Thread.yield(); // widen the window a real store would open anyway
+                            status.count = count + 1;
+                            status.checksum = NanopubUtils.updateXorChecksum(np, checksum);
+                        } finally {
+                            if (useLock) {
+                                lock.unlock();
+                            }
+                        }
+                    }
+                    return null;
+                }));
+            }
+            start.countDown();
+            for (var f : futures) {
+                f.get(60, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+        return status;
+    }
+}


### PR DESCRIPTION
Removes the cause of the RDF4J lock convoy that took the fleet down on 2026-08-05, without weakening the invariant it was protecting.

## Why SERIALIZABLE is so expensive here

The loader used `IsolationLevels.SERIALIZABLE` to protect the per-repo count / XOR-checksum chain from write skew. That guarantee is still needed — but in RDF4J 5.3.x the isolation level is a ruinously expensive way to buy it. From `SailSourceBranch`:

```java
if (serializable == null && level.isCompatibleWith(IsolationLevels.SERIALIZABLE)) {
    serializable = backingSource.sink(level);
}
SailDataset derivedFrom = derivedFromSnapshot(level);
if (serializable == null) {
    return derivedFrom;                                        // cheap
} else {
    return new ObservingSailDataset(derivedFrom, sink(level));  // observes
}
```

`serializable` is **branch state**, set the first time *any* transaction on that branch asks for a SERIALIZABLE-compatible level and cleared only when the branch closes. While it is set, **every** dataset opened on that repo — including ordinary read queries at any isolation — is an `ObservingSailDataset`. Closing one runs `compressChanges → prepare → sinkObserved → Changeset.observeAll` **while holding the branch semaphore**, and `observeAll` hashes `SimpleStatementPattern`s whose `LmdbIRI.hashCode` goes to a `synchronized` `ValueStore` map.

So one writer stalls every reader of the repo.

## What that looked like in production

A `kill -3` dump on kpxl, 2026-08-05:

- **171 threads** parked on one `ReentrantLock` in `derivedFromSerializable` for `full`
- one thread inside `Changeset.observeAll` via `ObservingSailDataset.close`
- no JVM-detected deadlock — a convoy, not a cycle
- the container could not answer even a 404 for a nonexistent repo

Externally: 504 on every endpoint for ~40 minutes, on two hosts independently.

## The change

Replace the mechanism, keep the invariant: a **per-repo `ReentrantLock`** held across the whole read-modify-write, with the transaction dropped to **SNAPSHOT**. SNAPSHOT is not SERIALIZABLE-compatible, so `serializable` stays null, no `ObservingSailDataset` is created, `observed` stays null, and `sinkObserved` early-returns.

This process is the only writer of those triples, so in-process mutual exclusion gives exactly what the serializable transaction was buying.

**Still one transaction.** Splitting the bookkeeping out of the data write would destroy the property that makes issue #139 diagnosable — count and checksum being written atomically *with* the data is what lets a vanished record be attributed to the backend rather than to us.

Locks are keyed by repo, so writers to different repos never contend, and calls are never nested across repos (the invalidator paths loop one repo at a time), so there is no lock-ordering hazard.

## Scope

Covers `loadNanopubToRepo` (`full`, `text`, `meta`, `pubkey_*`, `type_*`) and `loadToSpacesRepo` — the repos that carry the query load.

**Not covered:** the `spaces` branch is also written by `AuthorityResolver`, and `admin` by `StatusController`, both still SERIALIZABLE. Those repos keep paying the observing cost until they are addressed too. Separate changes; flagged in the code comments so the next reader isn't misled into thinking this finished the job.

## Tests

8 concurrent writers against one repo keep count and checksum **exactly equal to a serial run**, with a control showing the same workload corrupts both without the lock (retried to avoid a flaky control; in practice it corrupts on the first attempt).

Stated plainly in the test javadoc: these exercise the locking mechanism and the arithmetic it protects, **not `loadNanopubToRepo` end to end** — that drives a live RDF4J connection, which this project's unit tests cannot (see the note in `AuthorityResolverTest`). The control is what gives the passing case its meaning.

Full suite **359 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)