### PR TITLE
test(spaces): realign read-helper tests with the fail-loud build guards

### DIFF
--- a/src/test/java/com/knowledgepixels/query/AuthorityResolverPipelineTest.java
+++ b/src/test/java/com/knowledgepixels/query/AuthorityResolverPipelineTest.java
@@ -229,14 +229,16 @@ class AuthorityResolverPipelineTest {
     }
 
     @Test
-    void getCurrentLoadCounter_returnsZeroForANonNumericValue() {
-        // A corrupt counter must degrade to 0 (rebuild from scratch), not throw and
-        // wedge every subsequent tick.
+    void getCurrentLoadCounter_throwsOnANonNumericValue() {
+        // A corrupt counter must stop the build, not degrade to 0. Reading it as 0
+        // names the new graph <hash>_0, which differs from the real current graph, so
+        // the build proceeds and then drops the good one.
         try (InMemoryTripleStore store = new InMemoryTripleStore()) {
             store.update(SPACES, """
                     INSERT DATA { GRAPH <%s> { <%s> <%s> "not-a-number" } }"""
                     .formatted(NPA.GRAPH, NPA.THIS_REPO, SpacesVocab.CURRENT_LOAD_COUNTER));
-            assertEquals(0L, resolver().getCurrentLoadCounter());
+            assertThrows(AuthorityResolver.SpaceStateUnavailableException.class,
+                    () -> resolver().getCurrentLoadCounter());
         }
     }
 
@@ -774,10 +776,12 @@ class AuthorityResolverPipelineTest {
     // ---------------- degraded-store fallbacks ----------------
 
     @Test
-    void readHelpers_returnSafeDefaultsWhenTheStoreIsUnavailable() {
-        // Every one of these reads is on a scheduled tick. A store blip must produce
-        // a benign default (and a warning) rather than an exception that kills the
-        // periodic worker.
+    void bookkeepingReads_throwWhenTheStoreIsUnavailable() {
+        // These three reads decide what the next build does, and each has a sentinel
+        // that also means something legitimate: null pointer = fresh install, counter
+        // 0 = nothing loaded yet, processedUpTo -1 = graph never finished. Collapsing
+        // a failed read onto the sentinel makes a degraded store look like one of
+        // those and drives a destructive rebuild, so they must throw instead.
         try (MockedStatic<TripleStore> ts = Mockito.mockStatic(TripleStore.class)) {
             TripleStore broken = Mockito.mock(TripleStore.class);
             Mockito.when(broken.getRepoConnection(Mockito.anyString()))
@@ -787,22 +791,41 @@ class AuthorityResolverPipelineTest {
             AuthorityResolver ar = resolver();
             IRI g = SpacesVocab.forSpaceState(HASH, 1L);
 
-            assertNull(ar.getCurrentSpaceStateGraph(), "no pointer readable");
-            assertEquals(0L, ar.getCurrentLoadCounter(), "counter falls back to 0");
-            assertEquals(-1L, ar.readProcessedUpTo(g), "unknown horizon reads as -1");
+            assertThrows(AuthorityResolver.SpaceStateUnavailableException.class,
+                    () -> ar.getCurrentSpaceStateGraph(), "pointer read must not report 'no pointer'");
+            assertThrows(AuthorityResolver.SpaceStateUnavailableException.class,
+                    () -> ar.getCurrentLoadCounter(), "counter read must not report 0");
+            assertThrows(AuthorityResolver.SpaceStateUnavailableException.class,
+                    () -> ar.readProcessedUpTo(g), "horizon read must not report -1");
+        }
+    }
+
+    @Test
+    void advisoryReads_returnSafeDefaultsWhenTheStoreIsUnavailable() {
+        // These two only gate optional work — a rebuild the flag would have scheduled
+        // anyway, and a diagnostic pointer lookup. Neither can destroy state on a
+        // wrong answer, so a store blip stays a warning rather than an exception that
+        // kills the periodic worker.
+        try (MockedStatic<TripleStore> ts = Mockito.mockStatic(TripleStore.class)) {
+            TripleStore broken = Mockito.mock(TripleStore.class);
+            Mockito.when(broken.getRepoConnection(Mockito.anyString()))
+                    .thenThrow(new RuntimeException("store down"));
+            ts.when(TripleStore::get).thenReturn(broken);
+
+            AuthorityResolver ar = resolver();
+
             assertFalse(ar.readNeedsFullRebuild(), "flag defaults to false");
             assertTrue(ar.readTrustRepoCurrentHash().isEmpty());
         }
     }
 
     @Test
-    void tick_propagatesAHardStoreOutageFromTheBuildItself() {
-        // Documents current behaviour rather than prescribing it. The *read* helpers
-        // swallow failures, so a store outage makes getCurrentSpaceStateGraph report
-        // "no graph", which routes tick() into a full build — and the build's write
-        // path does not swallow, so the exception reaches the scheduler. Worth
-        // pinning: if this is ever made resilient, this test should be the one that
-        // says so.
+    void tick_abortsOnAHardStoreOutageInsteadOfRebuilding() {
+        // The outage has to stop the tick at the very first read. If it ever gets
+        // past getCurrentSpaceStateGraph, tick() reads the null pointer as "no
+        // current graph" and runs a full build against the same broken store, which
+        // publishes an empty graph and drops the live one. Doing nothing this tick
+        // and retrying on the next is always safe.
         try (MockedStatic<TripleStore> ts = Mockito.mockStatic(TripleStore.class)) {
             TripleStore broken = Mockito.mock(TripleStore.class);
             Mockito.when(broken.getRepoConnection(Mockito.anyString()))
@@ -810,7 +833,8 @@ class AuthorityResolverPipelineTest {
             ts.when(TripleStore::get).thenReturn(broken);
             TrustStateRegistry.get().setCurrentHash(HASH);
 
-            assertThrows(RuntimeException.class, () -> resolver().tick());
+            assertThrows(AuthorityResolver.SpaceStateUnavailableException.class,
+                    () -> resolver().tick());
         }
     }
 


### PR DESCRIPTION
Fixes the two failing tests on `main`.

## What broke

A semantic merge conflict between two PRs merged the same day — neither touched the other's lines, so both merged cleanly and `main` broke.

- **#159** (`fix/space-state-build-guards`, `66e8b60`) changed `AuthorityResolver`'s bookkeeping read helpers to throw `SpaceStateUnavailableException` instead of returning safe defaults.
- **#156** (`test/improve-coverage-truststate-authorityresolver`, `bb320a8`) added `AuthorityResolverPipelineTest` a day earlier, asserting exactly the swallow-and-default behaviour #159 removed.

## Why the tests move and not the code

The production behaviour is the intended one. A `null` pointer, a `0` counter and a `-1` `processedUpTo` each also describe a legitimate state — fresh install, nothing loaded yet, unfinished graph — so collapsing a failed read onto them makes a degraded store indistinguishable from a healthy one. That is the 2026-08-05 incident recorded in the `SpaceStateUnavailableException` javadoc: RDF4J answering `Read timed out`, `tick()` reading the `null` pointer as a trust-state flip that had not happened, and the resulting empty build replacing 2730 triples of live space state.

## Changes

All in `AuthorityResolverPipelineTest.java`:

- `getCurrentLoadCounter_returnsZeroForANonNumericValue` → `..._throwsOnANonNumericValue`. Read as `0`, a corrupt counter names the new graph `<hash>_0`, which differs from the real current graph — so the build proceeds and drops the good one.
- Split `readHelpers_returnSafeDefaultsWhenTheStoreIsUnavailable`, which asserted one rule over two groups that now differ:
  - `bookkeepingReads_throwWhenTheStoreIsUnavailable` — `getCurrentSpaceStateGraph`, `getCurrentLoadCounter`, `readProcessedUpTo`.
  - `advisoryReads_returnSafeDefaultsWhenTheStoreIsUnavailable` — `readNeedsFullRebuild`, `readTrustRepoCurrentHash`. These still degrade in the code, correctly: they gate optional work and cannot destroy state on a wrong answer.

## Worth a look

`tick_propagatesAHardStoreOutageFromTheBuildItself` was **passing, for the wrong reason** — it is not one of the two reported failures. It asserted a bare `RuntimeException` and its comment explained the outage reaching the scheduler via the build's write path, which was the pre-#159 routing. `tick()` now aborts at the first read and never reaches a build. Renamed to `tick_abortsOnAHardStoreOutageInsteadOfRebuilding`, assertion tightened to `SpaceStateUnavailableException`, rationale corrected. As written it would have kept passing even if the destructive rebuild path came back.

## Testing

Full suite green: 452 tests, 0 failures, 0 errors (451 before — the degraded-store test split into two). No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)